### PR TITLE
Fix nested paragraphs

### DIFF
--- a/packages/hir/src/hir-node.ts
+++ b/packages/hir/src/hir-node.ts
@@ -141,6 +141,11 @@ export default class HIRNode {
       }
 
       if (this.start <= node.start) {
+        if (node.start === node.end && this.end === node.end && this.rank === node.rank) {
+          this.insertSibling(node);
+          return;
+        }
+
         let childNode = node.trim(this.start, this.end);
         if (childNode) {
           this.insertChild(childNode);
@@ -201,11 +206,8 @@ export default class HIRNode {
 
   insertChild(node: HIRNode): void {
     if (!this.child) {
-      if (this.type === 'paragraph' && node.type === 'paragraph') {
-        this.insertSibling(node);
-      } else {
-        this.child = node;
-      }
+      this.child = node;
+
     } else {
       // FIXME FIXME FIXME this needs some refactoring for clarity / symmetry.
       if (node.rank < this.child.rank) {

--- a/packages/hir/src/hir-node.ts
+++ b/packages/hir/src/hir-node.ts
@@ -140,11 +140,6 @@ export default class HIRNode {
         return;
       }
 
-      if (this.type === 'paragraph' && node.type === 'paragraph') {
-        this.insertSibling(node);
-        return;
-      }
-
       if (this.start <= node.start) {
         let childNode = node.trim(this.start, this.end);
         if (childNode) {
@@ -206,7 +201,11 @@ export default class HIRNode {
 
   insertChild(node: HIRNode): void {
     if (!this.child) {
-      this.child = node;
+      if (this.type === 'paragraph' && node.type === 'paragraph') {
+        this.insertSibling(node);
+      } else {
+        this.child = node;
+      }
     } else {
       // FIXME FIXME FIXME this needs some refactoring for clarity / symmetry.
       if (node.rank < this.child.rank) {

--- a/packages/hir/src/hir.ts
+++ b/packages/hir/src/hir.ts
@@ -58,7 +58,11 @@ export default class HIR {
     atjson.annotations
       .sort((a: Annotation, b: Annotation) => {
         if (a.start === b.start) {
-          return (b.end - b.start) - (a.end - a.start);
+          if (a.type === b.type) {
+            return a.end - b.end;
+          } else {
+            return (b.end - b.start) - (a.end - a.start);
+          }
         } else {
           return a.start - b.start;
         }

--- a/packages/hir/test/hir-test.ts
+++ b/packages/hir/test/hir-test.ts
@@ -210,16 +210,26 @@ describe('@atjson/hir', function () {
 
     it('from a document with zero-length paragraphs', function () {
       let zerolength = new AtJSON({
-        content: 'Hello, world',
+        content: 'One fish\n\nTwo fish\n\n\n\nRed fish\n\nBlue fish',
         annotations: [
-          { type: 'paragraph', start: 0, end: 12 },
-          { type: 'paragraph', start: 12, end: 12 }
+          { type: 'paragraph', start: 0, end: 8 },
+          { type: 'parse-token', start: 8, end: 10 },
+          { type: 'paragraph', start: 10, end: 18 },
+          { type: 'parse-token', start: 18, end: 20 },
+          { type: 'paragraph', start: 20, end: 22 },
+          { type: 'parse-token', start: 20, end: 22 },
+          { type: 'paragraph', start: 22, end: 30 },
+          { type: 'parse-token', start: 30, end: 32 },
+          { type: 'paragraph', start: 32, end: 41 }
         ]
       });
 
       let expected = root(
-        paragraph('Hello, world'),
-        paragraph()
+        paragraph('One fish'),
+        paragraph('Two fish'),
+        paragraph(),
+        paragraph('Red fish'),
+        paragraph('Blue fish')
       );
 
       expect(new HIR(zerolength).toJSON()).toEqual(expected);


### PR DESCRIPTION
The test case written for this will fail under current conditions. In the current codebase (with the paragraph case removed), the structure of this will look like:

```json
{
  "type": "root", 
  "children": [{
    "type": "paragraph",
    "children": ["One fish"],
  }, {
    "type": "paragraph",
    "children": [
      "Two fish",
      {
        "type": "paragraph",
        "children": []
      }
    ],
  }, {
    "type": "paragraph",
    "children": ["Red fish"],
  }, {
    "type": "paragraph",
    "children": ["Blue fish"],
  }]
}
```

The naïve solution that I introduced previously will introduce the paragraph after the paragraph it was supposed to come before:


```json
{
  "type": "root", 
  "children": [{
    "type": "paragraph",
    "children": ["One fish"],
  }, {
    "type": "paragraph",
    "children": ["Two fish"],
  }, {
    "type": "paragraph",
    "children": ["Red fish"],
  }, {
    "type": "paragraph",
    "children": [],
  }, {
    "type": "paragraph",
    "children": ["Blue fish"],
  }]
}
```

This was caused because the sorting pattern put longer things before shorter things, causing the empty paragraph to be inserted *after* the `"Red fish"` annotation was inserted. I fixed this by sorting by `end` if the types match when the HIR begins inserting annotations. In addition, I handle inside of `insertChild` (this seems like a very bad place 😞 ) a paragraph insertion. If a paragraph is trying to be inserted as a child of a paragraph, it calls `insertSibling` to circumvent this.

This code isn't very ideal, but does the job. I feel like the current data structure doesn't lend itself very well to handle this use case of disallowing paragraphs in paragraphs.