### PR TITLE
Add imperative for transforming annotations on a document

### DIFF
--- a/packages/document/src/index.ts
+++ b/packages/document/src/index.ts
@@ -70,6 +70,13 @@ export default class AtJSON {
     }
   }
 
+  replaceAnnotation(annotation: Annotation, newAnnotation: Annotation): void {
+    let index = this.annotations.indexOf(annotation);
+    if (index > -1) {
+      this.annotations.splice(index, 1, newAnnotation);
+    }
+  }
+
   insertText(position: number, text: string, preserveAdjacentBoundaries: boolean = false) {
     if (position < 0 || position > this.content.length) throw new Error('Invalid position.');
 

--- a/packages/document/src/index.ts
+++ b/packages/document/src/index.ts
@@ -1,4 +1,5 @@
 import Annotation from './annotation';
+import Query, { Filter } from './query';
 
 const OBJECT_REPLACEMENT = '\uFFFC';
 
@@ -10,17 +11,56 @@ export default class AtJSON {
   contentType?: string;
   annotations: Annotation[];
 
+  private queries: Query[];
+
   constructor(options: { content: string, annotations?: Annotation[], contentType?: string } | string) {
     if (typeof options === 'string') {
       options = { content: options };
     }
     this.content = options.content;
-    this.annotations = options.annotations || [] as Annotation[];
+    this.annotations = options.annotations || [];
     this.contentType = options.contentType || 'text/plain';
   }
 
-  addAnnotations(annotations: Annotation | Annotation[]): void {
-    this.annotations = this.annotations.concat(annotations);
+  /**
+    Annotations must be explicitly allowed unless they
+    are added to the annotations array directly- this is
+    acceptable, but side-affects created by queries will
+    not be called.
+   */
+  addAnnotations(...annotations: Annotation[]): void {
+    annotations.forEach(newAnnotation => {
+      let finalizedAnnotation = this.queries.reduce((annotation, query) => {
+        return query.run(annotation);
+      }, newAnnotation);
+      if (finalizedAnnotation != null) {
+        this.annotations.push(finalizedAnnotation);
+      }
+    });
+  }
+
+  /**
+    Add imperitive queries here. These are used to dynamically
+    change annotations before they get inserted into the document,
+    making the process of reconciliation easier.
+
+    A simple example of this is transforming a document parsed from
+    an HTML document into a common format:
+
+    html.where({ type: 'h1' }).set({ type: 'heading', attributes: { level: 1 }});
+
+    When the attribute for `h1` is added to the document, it will
+    be swapped out for a `heading` with a level of 1.
+
+    Other options available are renaming variables:
+
+    html.where({ type: 'img' }).set({ 'attributes.src': 'attributes.url' });
+   */
+  where(filter: Filter): Query {
+    let query = new Query(this, filter);
+    this.queries = this.queries || [];
+    this.queries.push(query);
+    return query;
   }
 
   removeAnnotation(annotation: Annotation): Annotation | void {
@@ -31,7 +71,6 @@ export default class AtJSON {
   }
 
   insertText(position: number, text: string, preserveAdjacentBoundaries: boolean = false) {
-
     if (position < 0 || position > this.content.length) throw new Error('Invalid position.');
 
     const length = text.length;

--- a/packages/document/src/query.ts
+++ b/packages/document/src/query.ts
@@ -1,0 +1,137 @@
+import Document from '../index';
+
+interface AttributeList {
+  [key: string]: any;
+}
+
+export interface Filter {
+  [key: string]: any;
+}
+
+interface Mapping {
+  [key: string]: string;
+}
+
+interface TransformsByType {
+  [key: string]: DeferredTransform[];
+}
+
+type Transform = (annotation: Annotation, atjson: AtJSON) => Annotation;
+
+function clone(object) {
+  return JSON.parse(JSON.stringify(object));
+}
+
+function without(object: any, attributes: string[]): any {
+  let copy = {};
+  Object.keys(object).forEach((key: string) => {
+    let activeAttributes = attributes.filter(attribute => attribute.split('.')[0] === key);
+    if (activeAttributes.length === 0) {
+      copy[key] = object[key];
+    } else if (!activeAttributes.includes(key)) {
+      copy[key] = without(object[key], activeAttributes.map(attribute => attribute.split('.').slice(1).join('.')));
+    }
+  });
+  return copy;
+}
+
+function get(object: any, key: string): any {
+  if (key === '') return object;
+
+  let [path, ...rest] = key.split('.');
+  if (object) {
+    return get(object[path], rest.join('.'));
+  }
+  return null;
+}
+
+function set(object: any, key: string, value: any) {
+  if (value == null) return;
+
+  let [path, ...rest] = key.split('.');
+  if (rest.length === 0) {
+    object[path] = value;
+  } else {
+    if (object[path] == null) {
+      object[path] = {};
+    }
+    set(object[path], rest.join('.'), value);
+  }
+  return;
+}
+
+function matches(annotation: Annotation, filter: Filter) {
+  return Object.keys(filter).every(key => {
+    let value = filter[key];
+    if (typeof value === 'object') {
+      return matches(annotation[key], value);
+    }
+    return annotation[key] === value;
+  });
+}
+
+export default class Query {
+  filter: Filter;
+  private transforms: Transform[];
+
+  constructor(document: Document, filter: Filter) {
+    this.document = document;
+    this.filter = filter;
+    this.transforms = [(annotation: Annotation) => annotation];
+  }
+
+  run(newAnnotation: Annotation) {
+    if (matches(newAnnotation, this.filter)) {
+      let alteredAnnotation = this.transforms.reduce((annotation: Annotation, transform: Transform) => {
+        return transform(annotation, document);
+      }, newAnnotation);
+
+      return alteredAnnotation;
+    }
+    return newAnnotation;
+  }
+
+  done() {
+    let newAnnotations = this.document.annotations.map(annotation => this.run(annotation))
+                                                  .filter(annotation => annotation != null);
+    this.document.annotations = newAnnotations;
+  }
+
+  set(patch: any): Query {
+    this.transforms.push((annotation: Annotation) => {
+      return Object.assign(clone(annotation), clone(patch));
+    });
+    return this;
+  }
+
+  unset(...keys: string[]): Query {
+    this.transforms.push((annotation: Annotation) => {
+      return without(annotation, keys);
+    });
+    return this;
+  }
+
+  map(mapping: Mapping): Query {
+    this.transforms.push((annotation: Annotation) => {
+      let result = without(annotation, Object.keys(mapping));
+      Object.keys(mapping).forEach(key => {
+        let value = get(annotation, key);
+        set(result, mapping[key], value);
+      });
+      return result;
+    });
+    return this;
+  }
+
+  then(method: Transform): Query {
+    this.transforms.push(method);
+    return this;
+  }
+
+  remove(): Query {
+    this.transforms.push(() => {
+      return null;
+    });
+    return this;
+  }
+}

--- a/packages/document/test/query-test.ts
+++ b/packages/document/test/query-test.ts
@@ -58,6 +58,29 @@ describe('Document.where', () => {
     }]);
   });
 
+  it('set', () => {
+    let doc = new Document({
+      content: 'Hello',
+      annotations: []
+    });
+
+    doc.where({ type: 'h1' }).set({ type: 'heading', attributes: { level: 1 } }).done();
+    doc.addAnnotations({
+      type: 'h1',
+      start: 0,
+      end: 5
+    });
+    expect(doc.content).toBe('Hello');
+    expect(doc.annotations).toEqual([{
+      type: 'heading',
+      attributes: {
+        level: 1
+      },
+      start: 0,
+      end: 5
+    }]);
+  });
+
   it('unset', () => {
     let doc = new Document({
       content: '\uFFFC\uFFFC',

--- a/packages/document/test/query-test.ts
+++ b/packages/document/test/query-test.ts
@@ -163,6 +163,58 @@ describe('Document.where', () => {
     }]);
   });
 
+  it('map with function', () => {
+    let doc = new Document({
+      content: 'Conde Nast',
+      annotations: [{
+        type: 'a',
+        attributes: {
+          href: 'https://example.com'
+        },
+        start: 0,
+        end: 5
+      }]
+    });
+
+    doc.where({ type: 'a' }).map((annotation: Annotation) => {
+      return {
+        type: 'link',
+        start: annotation.start,
+        end: annotation.end,
+        attributes: {
+          url: annotation.attributes.href,
+          openInNewTab: true
+        }
+      };
+    });
+    doc.addAnnotations({
+      type: 'a',
+      attributes: {
+        href: 'https://condenast.com'
+      },
+      start: 6,
+      end: 10
+    });
+    expect(doc.content).toBe('Conde Nast');
+    expect(doc.annotations).toEqual([{
+      type: 'link',
+      attributes: {
+        url: 'https://example.com',
+        openInNewTab: true
+      },
+      start: 0,
+      end: 5
+    }, {
+      type: 'link',
+      attributes: {
+        url: 'https://condenast.com',
+        openInNewTab: true
+      },
+      start: 6,
+      end: 10
+    }]);
+  });
+
   it('remove', () => {
     let doc = new Document({
       content: 'function () {}',

--- a/packages/document/test/query-test.ts
+++ b/packages/document/test/query-test.ts
@@ -1,0 +1,162 @@
+import Document from '@atjson/document';
+
+describe('Document.where', () => {
+  it('runs queries against existing annotations', () => {
+    let doc = new Document({
+      content: 'Hello',
+      annotations: [{
+        type: 'strong',
+        start: 0,
+        end: 5
+      }, {
+        type: 'em',
+        start: 0,
+        end: 5
+      }]
+    });
+
+    doc.where({ type: 'strong' }).set({ type: 'bold' }).done();
+    doc.where({ type: 'em' }).set({ type: 'italic' }).done();
+    expect(doc.content).toBe('Hello');
+    expect(doc.annotations).toEqual([{
+      type: 'bold',
+      start: 0,
+      end: 5
+    }, {
+      type: 'italic',
+      start: 0,
+      end: 5
+    }]);
+  });
+
+  it('runs queries against new annotations', () => {
+    let doc = new Document({
+      content: 'Hello',
+      annotations: []
+    });
+
+    doc.where({ type: 'strong' }).set({ type: 'bold' }).done();
+    doc.where({ type: 'em' }).set({ type: 'italic' }).done();
+    doc.addAnnotations({
+      type: 'strong',
+      start: 0,
+      end: 5
+    }, {
+      type: 'em',
+      start: 0,
+      end: 5
+    });
+    expect(doc.content).toBe('Hello');
+    expect(doc.annotations).toEqual([{
+      type: 'bold',
+      start: 0,
+      end: 5
+    }, {
+      type: 'italic',
+      start: 0,
+      end: 5
+    }]);
+  });
+
+  it('unset', () => {
+    let doc = new Document({
+      content: '\uFFFC\uFFFC',
+      annotations: [{
+        type: 'embed',
+        attributes: {
+          type: 'instagram',
+          url: 'https://www.instagram.com/p/BeW0pqZDUuK/'
+        },
+        start: 0,
+        end: 1
+      }]
+    });
+
+    doc.where({ type: 'embed', attributes: { type: 'instagram' } }).set({ type: 'instagram' }).unset('attributes.type').done();
+    doc.addAnnotations({
+      type: 'embed',
+      attributes: {
+        type: 'instagram',
+        url: 'https://www.instagram.com/p/BdyySYBDvpm/'
+      },
+      start: 1,
+      end: 2
+    });
+    expect(doc.content).toBe('\uFFFC\uFFFC');
+    expect(doc.annotations).toEqual([{
+      type: 'instagram',
+      attributes: {
+        url: 'https://www.instagram.com/p/BeW0pqZDUuK/'
+      },
+      start: 0,
+      end: 1
+    }, {
+      type: 'instagram',
+      attributes: {
+        url: 'https://www.instagram.com/p/BdyySYBDvpm/'
+      },
+      start: 1,
+      end: 2
+    }]);
+  });
+
+  it('map', () => {
+    let doc = new Document({
+      content: 'Conde Nast',
+      annotations: [{
+        type: 'a',
+        attributes: {
+          href: 'https://example.com'
+        },
+        start: 0,
+        end: 5
+      }]
+    });
+
+    doc.where({ type: 'a' }).set({ type: 'link' }).map({ 'attributes.href': 'attributes.url' }).done();
+    doc.addAnnotations({
+      type: 'a',
+      attributes: {
+        href: 'https://condenast.com'
+      },
+      start: 6,
+      end: 10
+    });
+    expect(doc.content).toBe('Conde Nast');
+    expect(doc.annotations).toEqual([{
+      type: 'link',
+      attributes: {
+        url: 'https://example.com'
+      },
+      start: 0,
+      end: 5
+    }, {
+      type: 'link',
+      attributes: {
+        url: 'https://condenast.com'
+      },
+      start: 6,
+      end: 10
+    }]);
+  });
+
+  it('remove', () => {
+    let doc = new Document({
+      content: 'function () {}',
+      annotations: [{
+        type: 'code',
+        start: 0,
+        end: 14
+      }]
+    });
+
+    doc.where({ type: 'code' }).remove().done();
+    doc.addAnnotations({
+      type: 'code',
+      start: 0,
+      end: 14
+    });
+    expect(doc.content).toBe('function () {}');
+    expect(doc.annotations).toEqual([]);
+  });
+});

--- a/packages/document/test/query-test.ts
+++ b/packages/document/test/query-test.ts
@@ -136,7 +136,7 @@ describe('Document.where', () => {
       }]
     });
 
-    doc.where({ type: 'a' }).set({ type: 'link' }).map({ 'attributes.href': 'attributes.url' });
+    doc.where({ type: 'a' }).set({ type: 'link' }).map({ attributes: { href: 'url' } });
     doc.addAnnotations({
       type: 'a',
       attributes: {

--- a/packages/document/test/query-test.ts
+++ b/packages/document/test/query-test.ts
@@ -15,8 +15,8 @@ describe('Document.where', () => {
       }]
     });
 
-    doc.where({ type: 'strong' }).set({ type: 'bold' }).done();
-    doc.where({ type: 'em' }).set({ type: 'italic' }).done();
+    doc.where({ type: 'strong' }).set({ type: 'bold' });
+    doc.where({ type: 'em' }).set({ type: 'italic' });
     expect(doc.content).toBe('Hello');
     expect(doc.annotations).toEqual([{
       type: 'bold',
@@ -35,8 +35,8 @@ describe('Document.where', () => {
       annotations: []
     });
 
-    doc.where({ type: 'strong' }).set({ type: 'bold' }).done();
-    doc.where({ type: 'em' }).set({ type: 'italic' }).done();
+    doc.where({ type: 'strong' }).set({ type: 'bold' });
+    doc.where({ type: 'em' }).set({ type: 'italic' });
     doc.addAnnotations({
       type: 'strong',
       start: 0,
@@ -64,7 +64,7 @@ describe('Document.where', () => {
       annotations: []
     });
 
-    doc.where({ type: 'h1' }).set({ type: 'heading', attributes: { level: 1 } }).done();
+    doc.where({ type: 'h1' }).set({ type: 'heading', attributes: { level: 1 } });
     doc.addAnnotations({
       type: 'h1',
       start: 0,
@@ -95,7 +95,7 @@ describe('Document.where', () => {
       }]
     });
 
-    doc.where({ type: 'embed', attributes: { type: 'instagram' } }).set({ type: 'instagram' }).unset('attributes.type').done();
+    doc.where({ type: 'embed', attributes: { type: 'instagram' } }).set({ type: 'instagram' }).unset('attributes.type');
     doc.addAnnotations({
       type: 'embed',
       attributes: {
@@ -136,7 +136,7 @@ describe('Document.where', () => {
       }]
     });
 
-    doc.where({ type: 'a' }).set({ type: 'link' }).map({ 'attributes.href': 'attributes.url' }).done();
+    doc.where({ type: 'a' }).set({ type: 'link' }).map({ 'attributes.href': 'attributes.url' });
     doc.addAnnotations({
       type: 'a',
       attributes: {
@@ -173,7 +173,7 @@ describe('Document.where', () => {
       }]
     });
 
-    doc.where({ type: 'code' }).remove().done();
+    doc.where({ type: 'code' }).remove();
     doc.addAnnotations({
       type: 'code',
       start: 0,


### PR DESCRIPTION
This adds an imperative API for documents that allows us to change historical and future annotations added to the document.

I've designed this to make code for sources easier to use. My thoughts on this are that this api will remove the need for a canonical format, allowing for simple transformations between types of annotations.

A common example of this is using the HTML source. We'd like to map HTML elements to annotations that the commonmark renderer can understand. Using this API, we'd be able to update headings for rendering:

```js
import HTMLSource from '@atjson/source-html';
let document = new HTMLSource('<h1>Hello</h1>').toAtJSON();

document.where({ type: 'h1' }).set({ type: 'heading', attributes: { level: 1 }).done();
```

Note: I'd like to remove the `done` at the end of the query, but I'm not sure how to know when a developer has finished chaining here. I had a suggestion that chaining is the issue, and this could be solved making the DSL not chainable. Suggestions on how that looks would be very welcome.