### PR TITLE
Document Schema

### DIFF
--- a/packages/document/src/annotation.ts
+++ b/packages/document/src/annotation.ts
@@ -1,5 +1,6 @@
 export default interface Annotation {
   type: string;
+  display?: Display;
   start: number;
   end: number;
 

--- a/packages/document/src/index.ts
+++ b/packages/document/src/index.ts
@@ -1,6 +1,6 @@
 import Annotation from './annotation';
-import Schema from './schema';
 import Query, { Filter, flatten } from './query';
+import Schema from './schema';
 
 const OBJECT_REPLACEMENT = '\uFFFC';
 

--- a/packages/document/src/schema.ts
+++ b/packages/document/src/schema.ts
@@ -1,7 +1,7 @@
-type Type = "paragraph" | "object" | "inline" | "block";
+type Display = 'paragraph' | 'object' | 'inline' | 'block';
 
 export default interface Schema {
   [key: string]: {
-    type: Type;
+    display: Type;
   };
 }

--- a/packages/hir/src/hir-node.ts
+++ b/packages/hir/src/hir-node.ts
@@ -35,8 +35,12 @@ export default class HIRNode {
     this.rank = RANK.inline;
     this.schema = schema || {};
 
+    // Overrides on annotations are used first
+    if (node.display) {
+      this.rank = RANK[node.display];
+
     // Handle built-in types first
-    if (node.type === 'text' && typeof node.text === 'string') {
+    } else if (node.type === 'text' && typeof node.text === 'string') {
       this.rank = RANK.text;
       this.text = node.text;
     } else if (node.type === 'parse-token') {
@@ -44,7 +48,7 @@ export default class HIRNode {
     } else if (node.type === 'root') {
       this.rank = RANK.root;
     } else if (this.schema[this.type]) {
-      this.rank = RANK[this.schema[this.type].type];
+      this.rank = RANK[this.schema[this.type].display];
     }
   }
 

--- a/packages/hir/src/hir.ts
+++ b/packages/hir/src/hir.ts
@@ -28,7 +28,7 @@ export default class HIR {
     document.annotations
       .filter(a => a.start === a.end)
       .forEach(a => {
-         document.insertText(a.start, "\uFFFC");
+         document.insertText(a.start, '\uFFFC');
          a.start--;
       });
     document.where({ type: 'parse-element' }).remove();

--- a/packages/hir/test/hir-test.ts
+++ b/packages/hir/test/hir-test.ts
@@ -1,98 +1,35 @@
 import Document, { Annotation } from '@atjson/document';
 import { HIR } from '@atjson/hir';
 import schema from './schema';
+import { bold, document, italic, li, ol, paragraph, ul } from './utils';
 
-type node = {
-  type: string;
-  attributes: any;
-  children: node[];
-} | string;
-
-// HIR test helpers for quickly generating JSON for
-// the JSON output
-function root(...children: node[]) {
-  return {
-    type: 'root',
-    attributes: undefined,
-    children
-  };
-}
-
-function bold(...children: node[]) {
-  return {
-    type: 'bold',
-    attributes: undefined,
-    children
-  };
-}
-
-function italic(...children: node[]) {
-  return {
-    type: 'italic',
-    attributes: undefined,
-    children
-  };
-}
-
-function ol(...children: node[]) {
-  return {
-    type: 'ordered-list',
-    attributes: undefined,
-    children
-  };
-}
-
-function ul(...children: node[]) {
-  return {
-    type: 'unordered-list',
-    attributes: undefined,
-    children
-  };
-}
-
-function li(...children: node[]) {
-  return {
-    type: 'list-item',
-    attributes: undefined,
-    children
-  };
-}
-
-function paragraph(...children: node[]) {
-  return {
-    type: 'paragraph',
-    attributes: undefined,
-    children
-  };
-}
-
-describe('@atjson/hir', function () {
+describe('@atjson/hir', () => {
 
   /**
    * FIXME I don't know how to test types. This just throws in compile time,
    * but we should test that invalid objects are in fact caught by the compiler. ???
    *
-  it('rejects invalid documents', function () {
+  it('rejects invalid documents', () => {
     let invalidDoc = { blah: 'x' };
     expect(() => new HIR(invalidDoc)).toThrow();
   });
    */
 
-  it('accepts atjson-shaped object', function () {
+  it('accepts atjson-shaped object', () => {
     let validDoc = new Document({
       content: 'test\ndocument\n\nnew paragraph',
       annotations: [],
       schema
     });
 
-    let expected = root('test\ndocument\n\nnew paragraph');
+    let expected = document('test\ndocument\n\nnew paragraph');
     expect(new HIR(validDoc)).toBeDefined();
     expect(new HIR(validDoc).toJSON()).toEqual(expected);
   });
 
-  describe('constructs a valid hierarchy', function () {
+  describe('constructs a valid hierarchy', () => {
 
-    it('from a document without nesting', function () {
+    it('from a document without nesting', () => {
       let noNesting = new Document({
         content: 'A string with a bold and an italic annotation',
         annotations: [
@@ -103,7 +40,7 @@ describe('@atjson/hir', function () {
       });
 
       let hir = new HIR(noNesting).toJSON();
-      let expected = root(
+      let expected = document(
         'A string with a ',
         bold('bold'),
         ' and an ',
@@ -114,7 +51,7 @@ describe('@atjson/hir', function () {
       expect(hir).toEqual(expected);
     });
 
-    it('from a document with nesting', function () {
+    it('from a document with nesting', () => {
       let nested = new Document({
         content: 'I have a list:\n\nFirst item plus bold text\n\n' +
                  'Second item plus italic text\n\nItem 2a\n\nItem 2b\n\nAfter all the lists',
@@ -131,7 +68,7 @@ describe('@atjson/hir', function () {
         schema
       });
 
-      let expected = root(
+      let expected = document(
         'I have a list:\n\n',
         ol(
           li('First item plus ', bold('bold'), ' text\n\n'),
@@ -148,7 +85,7 @@ describe('@atjson/hir', function () {
       expect(new HIR(nested).toJSON()).toEqual(expected);
     });
 
-    it('from a document with overlapping annotations at the same level', function () {
+    it('from a document with overlapping annotations at the same level', () => {
       let overlapping = new Document({
         content: 'Some text that is both bold and italic plus something after.',
         annotations: [
@@ -158,7 +95,7 @@ describe('@atjson/hir', function () {
         schema
       });
 
-      let expected = root(
+      let expected = document(
         'Some text that is both ',
         bold('bold ', italic('and')),
         italic(' italic'),
@@ -168,7 +105,7 @@ describe('@atjson/hir', function () {
       expect(new HIR(overlapping).toJSON()).toEqual(expected);
     });
 
-    it('from a document with overlapping annotations across heirarchical levels', function () {
+    it('from a document with overlapping annotations across heirarchical levels', () => {
       let spanning = new Document({
         content: 'A paragraph with some bold\n\ntext that continues into the next.',
         annotations: [
@@ -179,7 +116,7 @@ describe('@atjson/hir', function () {
         schema
       });
 
-      let expected = root(
+      let expected = document(
         paragraph(
           'A paragraph with some ',
           bold('bold\n\n'),
@@ -193,7 +130,7 @@ describe('@atjson/hir', function () {
       expect(new HIR(spanning).toJSON()).toEqual(expected);
     });
 
-    it('from a zero-length document with annotations', function () {
+    it('from a zero-length document with annotations', () => {
       let zerolength = new Document({
         content: '',
         annotations: [
@@ -203,12 +140,12 @@ describe('@atjson/hir', function () {
         schema
       });
 
-      let expected = root( paragraph( bold() ) );
+      let expected = document( paragraph( bold() ) );
 
       expect(new HIR(zerolength).toJSON()).toEqual(expected);
     });
 
-    it('from a document with zero-length paragraphs', function () {
+    it('from a document with zero-length paragraphs', () => {
       let zerolength = new Document({
         content: 'One fish\n\nTwo fish\n\n\n\nRed fish\n\nBlue fish',
         annotations: [
@@ -225,7 +162,7 @@ describe('@atjson/hir', function () {
         schema
       });
 
-      let expected = root(
+      let expected = document(
         paragraph('One fish'),
         paragraph('Two fish'),
         paragraph(),
@@ -236,7 +173,7 @@ describe('@atjson/hir', function () {
       expect(new HIR(zerolength).toJSON()).toEqual(expected);
     });
 
-    it('from a document with a point annotation', function () {
+    it('from a document with a point annotation', () => {
       let zerolength = new Document({
         content: 'One fish\n\nTwo fish\n\n\n\nRed fish\n\nBlue fish',
         annotations: [
@@ -254,7 +191,7 @@ describe('@atjson/hir', function () {
         schema
       });
 
-      let expected = root(
+      let expected = document(
         paragraph('One fish'),
         paragraph('Two fish'),
           paragraph(

--- a/packages/hir/test/schema.ts
+++ b/packages/hir/test/schema.ts
@@ -1,23 +1,23 @@
 export default {
   'ordered-list': {
-    type: 'block'
+    display: 'block'
   },
   'unordered-list': {
-    type: 'block'
+    display: 'block'
   },
   'list-item': {
-    type: 'block'
+    display: 'block'
   },
   'paragraph': {
-    type: 'paragraph'
+    display: 'paragraph'
   },
   'bold': {
-    type: 'inline'
+    display: 'inline'
   },
   'italic': {
-    type: 'inline'
+    display: 'inline'
   },
   'image': {
-    type: 'object'
+    display: 'object'
   }
 };

--- a/packages/hir/test/utils.ts
+++ b/packages/hir/test/utils.ts
@@ -1,0 +1,28 @@
+type node = {
+  type: string;
+  attributes: any;
+  children: node[];
+} | string;
+
+// HIR test helpers for quickly generating JSON for
+// the JSON output
+function node(type: string) {
+  return (...children: node[]) => {
+    return {
+      type,
+      attributes: undefined,
+      children
+    };
+  };
+}
+
+let bold = node('bold');
+let document = node('root');
+let image = node('image');
+let italic = node('italic');
+let li = node('list-item');
+let ol = node('ordered-list');
+let paragraph = node('paragraph');
+let ul = node('unordered-list');
+
+export { bold, document, image, italic, li, node, ol, paragraph, ul };

--- a/packages/renderer-commonmark/test/schema.ts
+++ b/packages/renderer-commonmark/test/schema.ts
@@ -1,44 +1,44 @@
 export default {
   'link': {
-    type: 'inline'
+    display: 'inline'
   },
   'paragraph': {
-    type: 'paragraph'
+    display: 'paragraph'
   },
   'heading': {
-    type: 'block'
+    display: 'block'
   },
   'list-item': {
-    type: 'block'
+    display: 'block'
   },
   'ordered-list': {
-    type: 'block'
+    display: 'block'
   },
   'unordered-list': {
-    type: 'block'
+    display: 'block'
   },
   'bold': {
-    type: 'inline'
+    display: 'inline'
   },
   'italic': {
-    type: 'inline'
+    display: 'inline'
   },
   'code-block': {
-    type: 'block'
+    display: 'block'
   },
   'code': {
-    type: 'inline'
+    display: 'inline'
   },
   'blockquote': {
-    type: 'block'
+    display: 'block'
   },
   'horizontal-rule': {
-    type: 'object'
+    display: 'object'
   },
   'line-break': {
-    type: 'object'
+    display: 'object'
   },
   'image': {
-    type: 'object'
+    display: 'object'
   }
 };

--- a/packages/schema/index.ts
+++ b/packages/schema/index.ts
@@ -22,6 +22,7 @@ export default {
     type: 'block',
     attributes: [
       'type',
+      'level',
       'startsAt'
     ]
   },
@@ -41,6 +42,7 @@ export default {
     type: 'object',
     attributes: [
       'url',
+      'title',
       'description'
     ]
   }

--- a/packages/schema/index.ts
+++ b/packages/schema/index.ts
@@ -1,0 +1,47 @@
+export default {
+  'link': {
+    type: 'inline',
+    attributes: [
+      'destination',
+      'title'
+    ]
+  },
+  'paragraph': {
+    type: 'paragraph'
+  },
+  'heading': {
+    type: 'block',
+    attributes: [
+      'level'
+    ]
+  },
+  'item': {
+    type: 'block'
+  },
+  'list': {
+    type: 'block',
+    attributes: [
+      'type',
+      'startsAt'
+    ]
+  },
+  'bold': {
+    type: 'inline'
+  },
+  'italic': {
+    type: 'inline'
+  },
+  'quotation': {
+    type: 'block'
+  },
+  'line-break': {
+    type: 'object'
+  },
+  'image': {
+    type: 'object',
+    attributes: [
+      'destination',
+      'description'
+    ]
+  }
+};

--- a/packages/schema/index.ts
+++ b/packages/schema/index.ts
@@ -1,45 +1,45 @@
 export default {
   'link': {
-    type: 'inline',
+    display: 'inline',
     attributes: [
       'url',
       'title'
     ]
   },
   'paragraph': {
-    type: 'paragraph'
+    display: 'paragraph'
   },
   'heading': {
-    type: 'block',
+    display: 'block',
     attributes: [
       'level'
     ]
   },
   'item': {
-    type: 'block'
+    display: 'block'
   },
   'list': {
-    type: 'block',
+    display: 'block',
     attributes: [
-      'type',
+      'display',
       'level',
       'startsAt'
     ]
   },
   'bold': {
-    type: 'inline'
+    display: 'inline'
   },
   'italic': {
-    type: 'inline'
+    display: 'inline'
   },
   'quotation': {
-    type: 'block'
+    display: 'block'
   },
   'line-break': {
-    type: 'object'
+    display: 'object'
   },
   'image': {
-    type: 'object',
+    display: 'object',
     attributes: [
       'url',
       'title',

--- a/packages/schema/index.ts
+++ b/packages/schema/index.ts
@@ -21,7 +21,7 @@ export default {
   'list': {
     display: 'block',
     attributes: [
-      'display',
+      'type',
       'level',
       'startsAt'
     ]

--- a/packages/schema/index.ts
+++ b/packages/schema/index.ts
@@ -2,7 +2,7 @@ export default {
   'link': {
     type: 'inline',
     attributes: [
-      'destination',
+      'url',
       'title'
     ]
   },
@@ -40,7 +40,7 @@ export default {
   'image': {
     type: 'object',
     attributes: [
-      'destination',
+      'url',
       'description'
     ]
   }

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@atjson/schema",
+  "version": "0.6.5",
+  "description": "The common schema used to render AtJSON documents",
+  "main": "dist/commonjs/index.js",
+  "module": "dist/modules/index.js",
+  "types": "dist/commonjs/index.d.ts",
+  "scripts": {
+    "prepublish": "npm run build",
+    "build": "rm -rf dist; tsc -p . & tsc -p . --module ESNext --outDir dist/modules/ --target ES2017; exit 0",
+    "test": "../../node_modules/jest/bin/jest.js packages/$(basename $PWD) --config=../../package.json"
+  },
+  "license": "Apache-2.0",
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/source-html/src/index.ts
+++ b/packages/source-html/src/index.ts
@@ -21,13 +21,16 @@ function isText(node: Node) {
   return node.nodeName === '#text';
 }
 
-type Attributes = { [key: string]: string };
+interface Attributes {
+  [key: string]: string;
+}
+
 type Attribute = parse5.AST.Default.Attribute;
 
 function getAttributes(node: Node): Attributes {
-  let attrs: Attributes = (node.attrs || []).reduce((attrs: Attributes, attr: Attribute) => {
-    attrs[attr.name] = attr.value;
-    return attrs;
+  let attrs: Attributes = (node.attrs || []).reduce((attributes: Attributes, attr: Attribute) => {
+    attributes[attr.name] = attr.value;
+    return attributes;
   }, {});
 
   if (node.tagName === 'a' && attrs.href) {
@@ -77,7 +80,7 @@ class Parser {
     });
   }
 
-  convertTag(node: Node, which: "startTag" | "endTag"): number {
+  convertTag(node: Node, which: 'startTag' | 'endTag'): number {
     let { startOffset: start, endOffset: end } = node.__location[which];
     this.annotations.push({
       type: 'parse-token',

--- a/packages/source-html/src/schema.ts
+++ b/packages/source-html/src/schema.ts
@@ -1,35 +1,35 @@
 export default {
   a: {
-    type: 'inline'
+    display: 'inline'
   },
   blockquote: {
-    type: 'block'
+    display: 'block'
   },
   br: {
-    type: 'object'
+    display: 'object'
   },
   em: {
-    type: 'inline'
+    display: 'inline'
   },
   hr: {
-    type: 'object'
+    display: 'object'
   },
   img: {
-    type: 'object'
+    display: 'object'
   },
   li: {
-    type: 'block'
+    display: 'block'
   },
   ol: {
-    type: 'block'
+    display: 'block'
   },
   p: {
-    type: 'paragraph'
+    display: 'paragraph'
   },
   strong: {
-    type: 'inline'
+    display: 'inline'
   },
   ul: {
-    type: 'block'
+    display: 'block'
   }
 };


### PR DESCRIPTION
This is the core document schema for an AtJSON document. We're using this as the base specification for what annotations are available from a simple document.