### PR TITLE
Update travis badge for travis-ci.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# AtJSON [![Build Status](https://travis-ci.com/CondeNast-Copilot/atjson.svg?token=EyGr19LqBpbDaJHnY815&branch=latest)](https://travis-ci.com/CondeNast-Copilot/atjson)
+# AtJSON [![Build Status](https://travis-ci.org/CondeNast-Copilot/atjson.svg?branch=latest)](https://travis-ci.org/CondeNast-Copilot/atjson)
 
 AtJSON is a collection of repositories that together make up a fully-realized content format.
 


### PR DESCRIPTION
I believe the original travis hooks may have broken when making the repo public. I've updated this repo to use travis-ci.org