### PR TITLE
Make base CommonmarkSource extensible.

### DIFF
--- a/packages/source-commonmark/src/index.ts
+++ b/packages/source-commonmark/src/index.ts
@@ -191,14 +191,26 @@ export class Parser {
 
 export default class extends Document {
   constructor(markdown: string) {
-    let md = MarkdownIt('commonmark');
-    let parser = new Parser(md.parse(markdown, { linkify: false }), {});
     super({
-      content: parser.content,
+      content: '',
       contentType: 'text/commonmark',
-      annotations: parser.annotations,
+      annotations: [],
       schema: markdownSchema
     });
+
+    let md = this.constructor.markdownParser();
+    let parser = new Parser(md.parse(markdown, { linkify: false }), this.constructor.contentHandlers());
+
+    this.content = parser.content;
+    this.annotations = parser.annotations;
+  }
+
+  static markdownParser() {
+    return MarkdownIt('commonmark');
+  }
+
+  static contentHandlers() {
+    return {};
   }
 
   toCommonSchema() {


### PR DESCRIPTION
This is to support derived Commonmark parsers (eg copilot-atjson/source-them) being a little bit DRYer and to keep implementations a bit more opinionated. Currently, in order to swap out the parser (i.e., from base MarkdownIt to our cfm parser), it requires re-implementing the constructor.

It's a bit unfortunate that `super()` needs to be called before `this` is available in the constructor, but I don't see an easy way around that (without moving the parse step to a separate method, of course).