### PR TITLE
Google Docs (paste) Source, WIP

### DIFF
--- a/packages/source-gdocs-paste/LICENSE
+++ b/packages/source-gdocs-paste/LICENSE
@@ -1,0 +1,13 @@
+Copyright 2017 Condé Nast
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/packages/source-gdocs-paste/README.md
+++ b/packages/source-gdocs-paste/README.md
@@ -2,5 +2,5 @@
 
 Create AtJSON documents from Google Docs annotation paste buffers.
 
-See [content-documentation.md] for more information about the structure of the
+See [Content Documentation](content-documentation.md) for more information about the structure of the
 Google Docs paste buffers.

--- a/packages/source-gdocs-paste/README.md
+++ b/packages/source-gdocs-paste/README.md
@@ -1,3 +1,6 @@
 # @atjson/source-gdocs-paste
 
 Create AtJSON documents from Google Docs annotation paste buffers.
+
+See [content-documentation.md] for more information about the structure of the
+Google Docs paste buffers.

--- a/packages/source-gdocs-paste/README.md
+++ b/packages/source-gdocs-paste/README.md
@@ -1,0 +1,3 @@
+# @atjson/source-gdocs-paste
+
+Create AtJSON documents from Google Docs annotation paste buffers.

--- a/packages/source-gdocs-paste/content-documentation.md
+++ b/packages/source-gdocs-paste/content-documentation.md
@@ -1,0 +1,98 @@
+This is a rough sketch of the google docs paste format, which is accessible
+via a paste event with a `application/x-vnd.google-docs-document-slice-clip+wrapped`
+content type.
+
+The first-level object returned by the paste is mostly ignorable (?) metadata.
+We're interested in the `data.resolved` subpath.
+
+At `data.resolved`, there are a number of sub-objects that describe the
+document. They are listed here in relative order of relevance to conversion to
+AtJSON documents.
+
+# `dsl_spacers`: Body Text
+
+`dsl_spacers` is the body text in raw form. This includes newlines, and is
+largely analagous to AtJSON's `content` field. As far as I can tell, there are
+no differences, except for the omission of object replacement characters
+(Google Docs uses '*' instead).
+
+# `dsl_styleslices`: Styles Applied to Text
+
+`dsl_styleslices` describes a number of facets of styling that can be applied
+to text. Each "style slice" is a list where each element corresponds to a
+character offset in the document.
+
+```
+dsl_styleslices [
+  { stsl_type: "...", stsl_styles: [] }
+]
+```
+
+Our interest in these is limited for the time being to a few of the `stsl_type`s,
+specifically `horizontal_rule`, `link`, `list`, `paragraph`, and `text`. The
+format of these is described below:
+
+## `paragraph` style
+
+The paragraph style is aligned to the last character before the newline, and
+applies (? - needs verification) to the text seen _since_ the previous paragraph.
+
+Paragraph styles set on a character level are either `null` or an object with the following properties:
+
+`ps_hd`: `integer` between `0` and `6`, `100`, `101` (others?)
+  `0`: Normal paragraph
+  `1-6`: Headings level 1-6
+  `100`: Title
+  `101`: Subtitle
+`ps_hdid`: 'string' - Heading ID (unknown use)
+
+### Unimplemented
+
+`ps_al`: `float` - Horizontal alignment
+`ps_ls`: `integer` - Line spacing,
+`ps_awao` `boolean` - unknown
+`ps_sa`: `float` - Space before
+`ps_sb`: `float` - Space after
+`ps_ifl`: `float` - Indent first line
+`ps_il`: `float` - Indent line
+
+### Unknown
+
+`ps_sd`, `ps_bbtw`, `ps_bb`, `ps_bl`, `ps_br`, `ps_bt`, `ps_ir`, `ps_klt`,
+`ps_kwn`, `ps_ltr`, `ps_sm`, `ps_rd`, `ps_shd` 
+
+## `text` style
+
+The text style for a given character (per index in `stsl_styles` array) is
+either `null` (no _change_ to previous style) or an object with the following
+properties set:
+
+`ts_bd`: `boolean` - Bold
+`ts_it`: `boolean` - Italic
+`ts_st`: `boolean` - Strikethrough
+`ts_un`: `boolean` - Underline
+`ts_va`: `enum` (`nor`, `sup`, `sub`) - Vertical align: Superscript/Subscript/Normal
+`ts_sc`: `boolean` - Smallcaps
+
+### Unimplemented
+
+`ts_fs`: `integer` - Font size
+`ts_ff`: `string` - Font family
+`ts_tw`: `integer` - Text weight
+`ts_bgc2`: `object` - Background color
+`ts_fgc2`: `object` - Foreground color
+
+## `link` style
+
+Links are styled as non-overlapping ranges with entriesin the `stsl_styles`
+array either `null` or an object with the `links_link` attribute set.
+
+`links_link` can be one of `null` (no link) or an object with the following
+attributes:
+
+`link_type`: `integer` (unknown)
+`ulnk_url`: `string` Destination URL of link.
+
+## `list` style
+
+## `horizontal_rule` style

--- a/packages/source-gdocs-paste/package.json
+++ b/packages/source-gdocs-paste/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@atjson/source-gdocs-paste",
+  "version": "0.6.4",
+  "description": "Create AtJSON documents from Google Docs (KIX) paste buffers",
+  "main": "dist/commonjs/index.js",
+  "module": "dist/modules/index.js",
+  "types": "dist/commonjs/index.d.ts",
+  "scripts": {
+    "prepublish": "npm run build",
+    "build": "rm -rf dist; tsc -p . & tsc -p . --module ESNext --outDir dist/modules/ --target ES2017; exit 0",
+    "test": "../../node_modules/jest/bin/jest.js packages/$(basename $PWD) --config=../../package.json"
+  },
+  "license": "Apache-2.0",
+  "publishConfig": {
+    "access": "public"
+  },
+  "devDependencies": {
+    "@atjson/hir": "^0.5.17",
+    "@atjson/renderer-hir": "^0.5.20",
+    "typescript": "^2.6.2"
+  },
+  "dependencies": {
+    "@atjson/document": "^0.5.12"
+  }
+}

--- a/packages/source-gdocs-paste/package.json
+++ b/packages/source-gdocs-paste/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atjson/source-gdocs-paste",
-  "version": "0.6.4",
+  "version": "0.7.4",
   "description": "Create AtJSON documents from Google Docs (KIX) paste buffers",
   "main": "dist/commonjs/index.js",
   "module": "dist/modules/index.js",
@@ -15,11 +15,9 @@
     "access": "public"
   },
   "devDependencies": {
-    "@atjson/hir": "^0.5.17",
-    "@atjson/renderer-hir": "^0.5.20",
     "typescript": "^2.6.2"
   },
   "dependencies": {
-    "@atjson/document": "^0.5.12"
+    "@atjson/document": "0.7.2"
   }
 }

--- a/packages/source-gdocs-paste/src/index.ts
+++ b/packages/source-gdocs-paste/src/index.ts
@@ -1,0 +1,124 @@
+import { Annotation } from '@atjson/document';
+
+export default class Parser {
+
+  gdocsSource: string;
+
+  constructor(gdocsSource: string) {
+    this.gdocsSource = gdocsSource;
+  }
+
+  getContent(): string {
+    return this.gdocsSource.resolved.dsl_spacers;
+  }
+
+  getAnnotations(): Annotation[] {
+    let transforms = {
+      'text': this._extractTextStyles,
+      'paragraph': this._extractParagraphStyles,
+      'list': this._extractListStyles
+    }
+
+    let annotations = this.gdocsSource.resolved.dsl_styleslices.map(styleSlice => {
+      if (transforms[styleSlice.stsl_type]) {
+        return transforms[styleSlice.stsl_type](styleSlice.stsl_styles, this.gdocsSource.resolved.dsl_entitymap);
+      }
+    });
+
+    return [].concat.apply([], annotations).filter(a => a !== undefined);
+  }
+
+  _extractTextStyles(styles): Annotation[] {
+
+    let state = {}
+    let annotations = [];
+
+    for (let i = 0; i < styles.length; i++) {
+      let style = styles[i];
+      
+      if (style === null) continue;
+
+      for (let styleType of ['ts_bd', 'ts_it', 'ts_un']) {
+        if (style[styleType] === true && !state[styleType]) {
+          state[styleType] = { type: styleType, start: i };
+        } else if (style[styleType] === false && style[styleType + '_i'] === false && state[styleType]) {
+          state[styleType].end = i;
+          annotations.push(state[styleType]);
+          delete state[styleType];
+        }
+      }
+
+    }
+
+    return annotations;
+  }
+
+  _extractParagraphStyles(styles): Annotation[] {
+
+    let lastParagraphStart = 0;
+    let annotations = [];
+
+    for (let i = 0; i < styles.length; i++) {
+      let style = styles[i];
+
+      if (style === null) continue;
+
+      if (style['ps_hd'] !== 0) {
+        annotations.push({
+          type: 'ps_hd',
+          level: style['ps_hd'],
+          start: lastParagraphStart,
+          end: i
+        });
+      }
+
+      lastParagraphStart = i + 1;
+    }
+
+    return annotations;
+  }
+
+  _extractListStyles(lists, entities): Annotation[] {
+
+    let lastParagraphStart = 0;
+    let listAnnotations = {};
+    let annotations = [];
+
+    for (let i = 0; i < lists.length; i++) {
+      let list = lists[i];
+      
+      if (list === null) continue;
+      if (list['ls_id'] === null) {
+        lastParagraphStart = i + 1;
+        continue;
+      }
+
+      if (!listAnnotations[list['ls_id']]) {
+        listAnnotations[list['ls_id']] = {
+          type: 'list',
+          ls_id: list['ls_id'],
+          start: lastParagraphStart,
+          end: i
+        }
+      } else {
+        listAnnotations[list['ls_id']].end = i;
+      }
+
+      annotations.push({
+        type: 'list-item',
+        ls_nest: list['ls_nest'],
+        ls_id: list['ls_id'],
+        start: lastParagraphStart,
+        end: i
+      });
+
+      lastParagraphStart = i + 1;
+    }
+
+    for (var list in listAnnotations) {
+      annotations.push(listAnnotations[list]);
+    }
+
+    return annotations;
+  }
+}

--- a/packages/source-gdocs-paste/src/index.ts
+++ b/packages/source-gdocs-paste/src/index.ts
@@ -1,5 +1,9 @@
 import { Annotation } from '@atjson/document';
 
+import extractTextStyles from './text-styles';
+import extractParagraphStyles from './paragraph-styles';
+import extractListStyles from './list-styles';
+
 export default class Parser {
 
   gdocsSource: string;
@@ -14,9 +18,9 @@ export default class Parser {
 
   getAnnotations(): Annotation[] {
     let transforms = {
-      'text': this._extractTextStyles,
-      'paragraph': this._extractParagraphStyles,
-      'list': this._extractListStyles
+      'text': extractTextStyles,
+      'paragraph': extractParagraphStyles,
+      'list': extractListStyles
     }
 
     let annotations = this.gdocsSource.resolved.dsl_styleslices.map(styleSlice => {
@@ -28,97 +32,4 @@ export default class Parser {
     return [].concat.apply([], annotations).filter(a => a !== undefined);
   }
 
-  _extractTextStyles(styles): Annotation[] {
-
-    let state = {}
-    let annotations = [];
-
-    for (let i = 0; i < styles.length; i++) {
-      let style = styles[i];
-      
-      if (style === null) continue;
-
-      for (let styleType of ['ts_bd', 'ts_it', 'ts_un']) {
-        if (style[styleType] === true && !state[styleType]) {
-          state[styleType] = { type: styleType, start: i };
-        } else if (style[styleType] === false && style[styleType + '_i'] === false && state[styleType]) {
-          state[styleType].end = i;
-          annotations.push(state[styleType]);
-          delete state[styleType];
-        }
-      }
-
-    }
-
-    return annotations;
-  }
-
-  _extractParagraphStyles(styles): Annotation[] {
-
-    let lastParagraphStart = 0;
-    let annotations = [];
-
-    for (let i = 0; i < styles.length; i++) {
-      let style = styles[i];
-
-      if (style === null) continue;
-
-      if (style['ps_hd'] !== 0) {
-        annotations.push({
-          type: 'ps_hd',
-          level: style['ps_hd'],
-          start: lastParagraphStart,
-          end: i
-        });
-      }
-
-      lastParagraphStart = i + 1;
-    }
-
-    return annotations;
-  }
-
-  _extractListStyles(lists, entities): Annotation[] {
-
-    let lastParagraphStart = 0;
-    let listAnnotations = {};
-    let annotations = [];
-
-    for (let i = 0; i < lists.length; i++) {
-      let list = lists[i];
-      
-      if (list === null) continue;
-      if (list['ls_id'] === null) {
-        lastParagraphStart = i + 1;
-        continue;
-      }
-
-      if (!listAnnotations[list['ls_id']]) {
-        listAnnotations[list['ls_id']] = {
-          type: 'list',
-          ls_id: list['ls_id'],
-          start: lastParagraphStart,
-          end: i
-        }
-      } else {
-        listAnnotations[list['ls_id']].end = i;
-      }
-
-      annotations.push({
-        type: 'list-item',
-        ls_nest: list['ls_nest'],
-        ls_id: list['ls_id'],
-        start: lastParagraphStart,
-        end: i
-      });
-
-      lastParagraphStart = i + 1;
-    }
-
-    for (var list in listAnnotations) {
-      annotations.push(listAnnotations[list]);
-    }
-
-    return annotations;
-  }
 }

--- a/packages/source-gdocs-paste/src/list-styles.ts
+++ b/packages/source-gdocs-paste/src/list-styles.ts
@@ -1,0 +1,45 @@
+import { Annotation } from '@atjson/document';
+
+export default function extractListStyles(lists): Annotation[] {
+
+  let lastParagraphStart = 0;
+  let listAnnotations = {};
+  let annotations = [];
+
+  for (let i = 0; i < lists.length; i++) {
+    let list = lists[i];
+    
+    if (list === null) continue;
+    if (list['ls_id'] === null) {
+      lastParagraphStart = i + 1;
+      continue;
+    }
+
+    if (!listAnnotations[list['ls_id']]) {
+      listAnnotations[list['ls_id']] = {
+        type: 'list',
+        ls_id: list['ls_id'],
+        start: lastParagraphStart,
+        end: i
+      }
+    } else {
+      listAnnotations[list['ls_id']].end = i;
+    }
+
+    annotations.push({
+      type: 'list-item',
+      ls_nest: list['ls_nest'],
+      ls_id: list['ls_id'],
+      start: lastParagraphStart,
+      end: i
+    });
+
+    lastParagraphStart = i + 1;
+  }
+
+  for (var list in listAnnotations) {
+    annotations.push(listAnnotations[list]);
+  }
+
+  return annotations;
+}

--- a/packages/source-gdocs-paste/src/paragraph-styles.ts
+++ b/packages/source-gdocs-paste/src/paragraph-styles.ts
@@ -1,0 +1,25 @@
+import { Annotation } from '@atjson/document';
+
+export default function extractParagraphStyles(styles): Annotation[] {
+  let lastParagraphStart = 0;
+  let annotations = [];
+
+  for (let i = 0; i < styles.length; i++) {
+    let style = styles[i];
+
+    if (style === null) continue;
+
+    if (style['ps_hd'] !== 0) {
+      annotations.push({
+        type: 'ps_hd',
+        level: style['ps_hd'],
+        start: lastParagraphStart,
+        end: i
+      });
+    }
+
+    lastParagraphStart = i + 1;
+  }
+
+  return annotations;
+}

--- a/packages/source-gdocs-paste/src/paragraph-styles.ts
+++ b/packages/source-gdocs-paste/src/paragraph-styles.ts
@@ -1,5 +1,36 @@
 import { Annotation } from '@atjson/document';
 
+/*
+ * Import paragraph styles.
+ *
+ * from gdoc.dsl_styleslices[stsl_Type='paragraph']
+ *
+ * Paragraph style attributes are:
+ *
+ *   ps_al: unknown
+ *   ps_awao: unknown
+ *   ps_bb: unknown
+ *   ps_bbtw: unknown
+ *   ps_bl: unknown
+ *   ps_br: unknown
+ *   ps_bt: unknown
+ *   ps_hd: header (integer, 0 = none, 1+ = header level)
+ *   ps_hdid: header id (?)
+ *   ps_ifl: unknown
+ *   ps_il: unknown
+ *   ps_ir: unknown
+ *   ps_klt: unknown
+ *   ps_kwn: unknown
+ *   ps_ls: unknown
+ *   ps_ltr: unknown
+ *   ps_rd: unknown
+ *   ps_sa: unknown
+ *   ps_sb: unknown
+ *   ps_sd: unknown
+ *   ps_shd: unknown
+ *   ps_sm: unknown
+ *
+ */
 export default function extractParagraphStyles(styles): Annotation[] {
   let lastParagraphStart = 0;
   let annotations = [];

--- a/packages/source-gdocs-paste/src/text-styles.ts
+++ b/packages/source-gdocs-paste/src/text-styles.ts
@@ -1,0 +1,25 @@
+import { Annotation } from '@atjson/document';
+
+export default function extractTextStyles(styles): Annotation[] {
+  let state = {}
+  let annotations = [];
+
+  for (let i = 0; i < styles.length; i++) {
+    let style = styles[i];
+    
+    if (style === null) continue;
+
+    for (let styleType of ['ts_bd', 'ts_it', 'ts_un']) {
+      if (style[styleType] === true && !state[styleType]) {
+        state[styleType] = { type: styleType, start: i };
+      } else if (style[styleType] === false && style[styleType + '_i'] === false && state[styleType]) {
+        state[styleType].end = i;
+        annotations.push(state[styleType]);
+        delete state[styleType];
+      }
+    }
+
+  }
+
+  return annotations;
+}

--- a/packages/source-gdocs-paste/test/__snapshots__/atjson-source-gdocs-paste-test.ts.snap
+++ b/packages/source-gdocs-paste/test/__snapshots__/atjson-source-gdocs-paste-test.ts.snap
@@ -1,0 +1,27 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`@atjson/source-gdocs-paste relatively complex document correctly sets the content 1`] = `
+"This is a simple test.
+*
+Here is some text
+
+Here’s a numbered list
+And another item
+
+Here is a poem
+  With some text ahead
+    Four spaces this time and a suggestion
+Now no spaces
+Here’s a line with some different line spacing (1.5)
+And here’s a double spaced line
+Heading 1
+Heading 2
+Title
+Subtitle
+UPPER CASE
+Title Case is fun
+This is superscript!
+This is subscript
+abdsfdf
+"
+`;

--- a/packages/source-gdocs-paste/test/atjson-source-gdocs-paste-test.ts
+++ b/packages/source-gdocs-paste/test/atjson-source-gdocs-paste-test.ts
@@ -1,0 +1,108 @@
+import Document from '@atjson/document';
+import { HIR } from '@atjson/hir';
+import KIXSource from '@atjson/source-gdocs-paste';
+import * as fs from 'fs';
+import * as path from 'path';
+
+describe('@atjson/source-gdocs-paste', () => {
+  describe('relatively complex document', () => {
+    var atjson;
+
+    beforeAll(() => {
+      // https://docs.google.com/document/d/1xP_M2SchJt81ZuivsO7oix8Q_fCx4PENKJFJR5npFNM/edit
+      let fixturePath = path.join(__dirname, 'fixtures', 'complex.json');
+      atjson = JSON.parse(fs.readFileSync(fixturePath));
+    });
+
+    it('has some json', () =>  {
+      expect(atjson).toHaveProperty('resolved')
+    });
+
+    it('does not throw an error when instantiating with KIXSource', () => {
+      expect(new KIXSource(atjson)).toBeTruthy();
+    });
+
+    it('correctly sets the content');
+
+    it('extracts bold', () => {
+      let gdocs = new KIXSource(atjson);
+      let annotations = gdocs.getAnnotations().filter(a => a.type === 'ts_bd');
+      expect(annotations.length).toEqual(2);
+
+      let a0 = annotations[0];
+      let a1 = annotations[1];
+      expect(gdocs.getContent().substring(a0.start, a0.end)).toEqual('simple te');
+      expect(gdocs.getContent().substring(a1.start, a1.end)).toEqual('re is so');
+    });
+
+    it('extracts italic', () => {
+      let gdocs = new KIXSource(atjson);
+      let annotations = gdocs.getAnnotations().filter(a => a.type === 'ts_it');
+      expect(annotations.length).toEqual(2);
+
+      let a0 = annotations[0];
+      let a1 = annotations[1];
+      expect(gdocs.getContent().substring(a0.start, a0.end)).toEqual('simple ');
+      expect(gdocs.getContent().substring(a1.start, a1.end)).toEqual('some ');
+    });
+
+    it('extracts headings', () => {
+      let gdocs = new KIXSource(atjson);
+      let annotations = gdocs.getAnnotations().filter(a => a.type === 'ps_hd').sort((a,b) => a.start - b.start);
+      expect(annotations.length).toEqual(4);
+
+      let a0 = annotations[0];
+      let a1 = annotations[1];
+      let a2 = annotations[2];
+      let a3 = annotations[3];
+
+      expect(gdocs.getContent().substring(a0.start, a0.end)).toEqual('Heading 1');
+      expect(a0.level).toEqual(1);
+
+      expect(gdocs.getContent().substring(a1.start, a1.end)).toEqual('Heading 2');
+      expect(a1.level).toEqual(2);
+
+      expect(gdocs.getContent().substring(a2.start, a2.end)).toEqual('Title');
+      expect(a2.level).toEqual(100);
+
+      expect(gdocs.getContent().substring(a3.start, a3.end)).toEqual('Subtitle');
+      expect(a3.level).toEqual(101);
+
+    });
+
+    it('extracts lists', () => {
+      let gdocs = new KIXSource(atjson);
+      let annotations = gdocs.getAnnotations().filter(a => a.type === 'list');
+      expect(annotations.length).toEqual(1);
+
+      let a0 = annotations[0];
+      
+      expect(gdocs.getContent().substring(a0.start, a0.end)).toEqual('Here’s a numbered list\nAnd another item');
+      expect(a0.ls_id).toEqual('kix.r139o3ivf8cd');
+    });
+
+    it('extracts list items', () => {
+      let gdocs = new KIXSource(atjson);
+      let annotations = gdocs.getAnnotations().filter(a => a.type === 'list-item');
+      expect(annotations.length).toEqual(2);
+
+      let a0 = annotations[0];
+      let a1 = annotations[1];
+
+      expect(gdocs.getContent().substring(a0.start, a0.end)).toEqual('Here’s a numbered list');
+      expect(a0.ls_id).toEqual('kix.r139o3ivf8cd');
+      expect(a0.ls_nest).toEqual(0);
+
+      expect(gdocs.getContent().substring(a1.start, a1.end)).toEqual('And another item');
+      expect(a1.ls_id).toEqual('kix.r139o3ivf8cd');
+      expect(a1.ls_nest).toEqual(0);
+    });
+
+    it('extracts images');
+
+    it('extracts subscript');
+
+    it('extracts superscript');
+
+  });
+});

--- a/packages/source-gdocs-paste/test/atjson-source-gdocs-paste-test.ts
+++ b/packages/source-gdocs-paste/test/atjson-source-gdocs-paste-test.ts
@@ -33,8 +33,7 @@ describe('@atjson/source-gdocs-paste', () => {
       let annotations = gdocs.getAnnotations().filter(a => a.type === 'ts_bd');
       expect(annotations.length).toEqual(2);
 
-      let a0 = annotations[0];
-      let a1 = annotations[1];
+      let [a0, a1] = annotations;
       expect(gdocs.getContent().substring(a0.start, a0.end)).toEqual('simple te');
       expect(gdocs.getContent().substring(a1.start, a1.end)).toEqual('re is so');
     });
@@ -44,8 +43,7 @@ describe('@atjson/source-gdocs-paste', () => {
       let annotations = gdocs.getAnnotations().filter(a => a.type === 'ts_it');
       expect(annotations.length).toEqual(2);
 
-      let a0 = annotations[0];
-      let a1 = annotations[1];
+      let [a0, a1] = annotations;
       expect(gdocs.getContent().substring(a0.start, a0.end)).toEqual('simple ');
       expect(gdocs.getContent().substring(a1.start, a1.end)).toEqual('some ');
     });
@@ -55,10 +53,7 @@ describe('@atjson/source-gdocs-paste', () => {
       let annotations = gdocs.getAnnotations().filter(a => a.type === 'ps_hd').sort((a,b) => a.start - b.start);
       expect(annotations.length).toEqual(4);
 
-      let a0 = annotations[0];
-      let a1 = annotations[1];
-      let a2 = annotations[2];
-      let a3 = annotations[3];
+      let [a0, a1, a2, a3] = annotations;
 
       expect(gdocs.getContent().substring(a0.start, a0.end)).toEqual('Heading 1');
       expect(a0.level).toEqual(1);
@@ -90,8 +85,7 @@ describe('@atjson/source-gdocs-paste', () => {
       let annotations = gdocs.getAnnotations().filter(a => a.type === 'list-item');
       expect(annotations.length).toEqual(2);
 
-      let a0 = annotations[0];
-      let a1 = annotations[1];
+      let [a0, a1] = annotations;
 
       expect(gdocs.getContent().substring(a0.start, a0.end)).toEqual('Here’s a numbered list');
       expect(a0.ls_id).toEqual('kix.r139o3ivf8cd');

--- a/packages/source-gdocs-paste/test/atjson-source-gdocs-paste-test.ts
+++ b/packages/source-gdocs-paste/test/atjson-source-gdocs-paste-test.ts
@@ -19,7 +19,7 @@ describe('@atjson/source-gdocs-paste', () => {
     });
 
     it('does not throw an error when instantiating with KIXSource', () => {
-      expect(new KIXSource(atjson)).toBeTruthy();
+      expect(new KIXSource(atjson)).toBeDefined();
     });
 
     it('correctly sets the content');

--- a/packages/source-gdocs-paste/test/atjson-source-gdocs-paste-test.ts
+++ b/packages/source-gdocs-paste/test/atjson-source-gdocs-paste-test.ts
@@ -22,7 +22,11 @@ describe('@atjson/source-gdocs-paste', () => {
       expect(new KIXSource(atjson)).toBeDefined();
     });
 
-    it('correctly sets the content');
+    it('correctly sets the content', () => {
+      let gdocs = new KIXSource(atjson);
+      expect(gdocs.getContent().length).toEqual(384);
+      expect(gdocs.getContent()).toMatchSnapshot();
+    });
 
     it('extracts bold', () => {
       let gdocs = new KIXSource(atjson);

--- a/packages/source-gdocs-paste/test/fixtures/complex.json
+++ b/packages/source-gdocs-paste/test/fixtures/complex.json
@@ -1,0 +1,3717 @@
+{
+  "resolved": {
+    "dsl_spacers": "This is a simple test.\n*\nHere is some text\n\nHere’s a numbered list\nAnd another item\n\nHere is a poem\n  With some text ahead\n    Four spaces this time and a suggestion\nNow no spaces\nHere’s a line with some different line spacing (1.5)\nAnd here’s a double spaced line\nHeading 1\nHeading 2\nTitle\nSubtitle\nUPPER CASE\nTitle Case is fun\nThis is superscript!\nThis is subscript\n\u001a\u001f\u001f\u001f\u0019a\u001db\u001bdsfdf\u001e\n",
+    "dsl_styleslices": [
+      {
+        "stsl_type": "autogen",
+        "stsl_styles": []
+      },
+      {
+        "stsl_type": "cell",
+        "stsl_styles": []
+      },
+      {
+        "stsl_type": "column_sector",
+        "stsl_trailing": {
+          "css_cols": {
+            "cv": {
+              "op": "set",
+              "opValue": []
+            }
+          },
+          "css_lb": false,
+          "css_ltr": true
+        },
+        "stsl_trailingType": "column_sector",
+        "stsl_styles": []
+      },
+      {
+        "stsl_type": "comment",
+        "stsl_styles": [
+          {
+            "cs_cids": {
+              "cv": {
+                "op": "set",
+                "opValue": []
+              }
+            }
+          },
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          {
+            "cs_cids": {
+              "cv": {
+                "op": "set",
+                "opValue": [
+                  "kix.s4vhxl7sswk5"
+                ]
+              }
+            }
+          },
+          null,
+          null,
+          null,
+          null,
+          null,
+          {
+            "cs_cids": {
+              "cv": {
+                "op": "set",
+                "opValue": []
+              }
+            }
+          }
+        ]
+      },
+      {
+        "stsl_type": "date_time",
+        "stsl_styles": []
+      },
+      {
+        "stsl_type": "document",
+        "stsl_leading": {
+          "ds_b": {
+            "bg_c": null
+          },
+          "ds_fi": null,
+          "ds_hi": null,
+          "ds_epfi": null,
+          "ds_ephi": null,
+          "ds_uephf": false,
+          "ds_fpfi": null,
+          "ds_fphi": null,
+          "ds_ufphf": false,
+          "ds_pnsi": 1,
+          "ds_mb": 72,
+          "ds_ml": 72,
+          "ds_mr": 72,
+          "ds_mt": 72,
+          "ds_ph": 792,
+          "ds_pw": 612,
+          "ds_rtd": "",
+          "ds_mh": 36,
+          "ds_mf": 36,
+          "ds_ulhfl": true
+        },
+        "stsl_leadingType": "document",
+        "stsl_styles": []
+      },
+      {
+        "stsl_type": "equation",
+        "stsl_trailing": {
+          "eqs_p": "$"
+        },
+        "stsl_trailingType": "equation",
+        "stsl_styles": [
+          null, null, null, null, null, null, null, null, null, null, null,
+          null, null, null, null, null, null, null, null, null, null, null,
+          null, null, null, null, null, null, null, null, null, null, null,
+          null, null, null, null, null, null, null, null, null, null, null,
+          null, null, null, null, null, null, null, null, null, null, null,
+          null, null, null, null, null, null, null, null, null, null, null,
+          null, null, null, null, null, null, null, null, null, null, null,
+          null, null, null, null, null, null, null, null, null, null, null,
+          null, null, null, null, null, null, null, null, null, null, null,
+          null, null, null, null, null, null, null, null, null, null, null,
+          null, null, null, null, null, null, null, null, null, null, null,
+          null, null, null, null, null, null, null, null, null, null, null,
+          null, null, null, null, null, null, null, null, null, null, null,
+          null, null, null, null, null, null, null, null, null, null, null,
+          null, null, null, null, null, null, null, null, null, null, null,
+          null, null, null, null, null, null, null, null, null, null, null,
+          null, null, null, null, null, null, null, null, null, null, null,
+          null, null, null, null, null, null, null, null, null, null, null,
+          null, null, null, null, null, null, null, null, null, null, null,
+          null, null, null, null, null, null, null, null, null, null, null,
+          null, null, null, null, null, null, null, null, null, null, null,
+          null, null, null, null, null, null, null, null, null, null, null,
+          null, null, null, null, null, null, null, null, null, null, null,
+          null, null, null, null, null, null, null, null, null, null, null,
+          null, null, null, null, null, null, null, null, null, null, null,
+          null, null, null, null, null, null, null, null, null, null, null,
+          null, null, null, null, null, null, null, null, null, null, null,
+          null, null, null, null, null, null, null, null, null, null, null,
+          null, null, null, null, null, null, null, null, null, null, null,
+          null, null, null, null, null, null, null, null, null, null, null,
+          null, null, null, null, null, null, null, null, null, null, null,
+          null, null, null, null, null, null, null, null, null, null, null,
+          null, null, null, null, null, null, null, null, null, null, null,
+          null, null, null, null, null,
+          {
+            "eqs_p": "$"
+          }
+        ]
+      },
+      {
+        "stsl_type": "equation_function",
+        "stsl_trailing": {
+          "eqfs_c": "\\intab"
+        },
+        "stsl_trailingType": "equation_function",
+        "stsl_styles": [
+          null, null, null, null, null, null, null, null, null, null, null,
+          null, null, null, null, null, null, null, null, null, null, null,
+          null, null, null, null, null, null, null, null, null, null, null,
+          null, null, null, null, null, null, null, null, null, null, null,
+          null, null, null, null, null, null, null, null, null, null, null,
+          null, null, null, null, null, null, null, null, null, null, null,
+          null, null, null, null, null, null, null, null, null, null, null,
+          null, null, null, null, null, null, null, null, null, null, null,
+          null, null, null, null, null, null, null, null, null, null, null,
+          null, null, null, null, null, null, null, null, null, null, null,
+          null, null, null, null, null, null, null, null, null, null, null,
+          null, null, null, null, null, null, null, null, null, null, null,
+          null, null, null, null, null, null, null, null, null, null, null,
+          null, null, null, null, null, null, null, null, null, null, null,
+          null, null, null, null, null, null, null, null, null, null, null,
+          null, null, null, null, null, null, null, null, null, null, null,
+          null, null, null, null, null, null, null, null, null, null, null,
+          null, null, null, null, null, null, null, null, null, null, null,
+          null, null, null, null, null, null, null, null, null, null, null,
+          null, null, null, null, null, null, null, null, null, null, null,
+          null, null, null, null, null, null, null, null, null, null, null,
+          null, null, null, null, null, null, null, null, null, null, null,
+          null, null, null, null, null, null, null, null, null, null, null,
+          null, null, null, null, null, null, null, null, null, null, null,
+          null, null, null, null, null, null, null, null, null, null, null,
+          null, null, null, null, null, null, null, null, null, null, null,
+          null, null, null, null, null, null, null, null, null, null, null,
+          null, null, null, null, null, null, null, null, null, null, null,
+          null, null, null, null, null, null, null, null, null, null, null,
+          null, null, null, null, null, null, null, null, null, null, null,
+          null, null, null, null, null, null, null, null, null, null, null,
+          null, null, null, null, null, null, null, null, null, null, null,
+          null, null, null, null, null, null, null, null, null, null, null,
+          null, null, null, null, null, null,
+          {
+            "eqfs_c": "\\beta"
+          },
+          {
+            "eqfs_c": "\\times"
+          },
+          {
+            "eqfs_c": "\\alpha"
+          },
+          {
+            "eqfs_c": "\\intab"
+          }
+        ]
+      },
+      {
+        "stsl_type": "footnote",
+        "stsl_styles": []
+      },
+      {
+        "stsl_type": "headings",
+        "stsl_styles": []
+      },
+      {
+        "stsl_type": "horizontal_rule",
+        "stsl_styles": []
+      },
+      {
+        "stsl_type": "import_warnings",
+        "stsl_styles": [
+          {
+            "iws_iwids": {
+              "cv": {
+                "op": "set",
+                "opValue": []
+              }
+            }
+          }
+        ]
+      },
+      {
+        "stsl_type": "language",
+        "stsl_trailing": {
+          "lgs_l": "en"
+        },
+        "stsl_trailingType": "language",
+        "stsl_styles": []
+      },
+      {
+        "stsl_type": "link",
+        "stsl_styles": [
+          {
+            "lnks_link": null
+          },
+          null, null, null, null, null, null, null, null, null, null, null,
+          null, null, null, null, null, null, null, null, null, null, null,
+          null, null, null, null, null, null, null, null, null, null, null,
+          null, null, null, null, null, null, null, null, null, null, null,
+          null, null, null, null, null, null, null, null, null, null, null,
+          null, null, null, null, null, null, null, null, null, null, null,
+          null, null, null, null, null, null, null, null, null, null, null,
+          null, null, null, null, null, null, null, null, null, null, null,
+          {
+            "lnks_link": {
+              "lnk_type": 0,
+              "ulnk_url": "https://www.google.com/"
+            }
+          },
+          null, null, null,
+          {
+            "lnks_link": null
+          }
+        ]
+      },
+      {
+        "stsl_type": "list",
+        "stsl_styles": [
+          null, null, null, null, null, null, null, null, null, null, null, null,
+          null, null, null, null, null, null, null, null, null, null,
+          {
+            "ls_nest": 0,
+            "ls_id": null,
+            "ls_ts": {
+              "ts_bd": false,
+              "ts_fs": 11,
+              "ts_ff": "Arial",
+              "ts_it": false,
+              "ts_sc": false,
+              "ts_st": false,
+              "ts_tw": 400,
+              "ts_un": false,
+              "ts_va": "nor",
+              "ts_bgc2": {
+                "clr_type": 0,
+                "hclr_color": null
+              },
+              "ts_fgc2": {
+                "clr_type": 0,
+                "hclr_color": "#000000"
+              },
+              "ts_bd_i": false,
+              "ts_fs_i": false,
+              "ts_ff_i": false,
+              "ts_it_i": false,
+              "ts_sc_i": false,
+              "ts_st_i": false,
+              "ts_un_i": false,
+              "ts_va_i": false,
+              "ts_bgc2_i": false,
+              "ts_fgc2_i": false
+            }
+          },
+          null,
+          {
+            "ls_nest": 0,
+            "ls_id": null,
+            "ls_ts": {
+              "ts_bd": false,
+              "ts_fs": 11,
+              "ts_ff": "Arial",
+              "ts_it": false,
+              "ts_sc": false,
+              "ts_st": false,
+              "ts_tw": 400,
+              "ts_un": false,
+              "ts_va": "nor",
+              "ts_bgc2": {
+                "clr_type": 0,
+                "hclr_color": null
+              },
+              "ts_fgc2": {
+                "clr_type": 0,
+                "hclr_color": "#000000"
+              },
+              "ts_bd_i": false,
+              "ts_fs_i": false,
+              "ts_ff_i": false,
+              "ts_it_i": false,
+              "ts_sc_i": false,
+              "ts_st_i": false,
+              "ts_un_i": false,
+              "ts_va_i": false,
+              "ts_bgc2_i": false,
+              "ts_fgc2_i": false
+            }
+          },
+          null, null, null, null, null, null, null, null, null, null, null,
+          null, null, null, null, null, null,
+          {
+            "ls_nest": 0,
+            "ls_id": null,
+            "ls_ts": {
+              "ts_bd": false,
+              "ts_fs": 11,
+              "ts_ff": "Arial",
+              "ts_it": false,
+              "ts_sc": false,
+              "ts_st": false,
+              "ts_tw": 400,
+              "ts_un": false,
+              "ts_va": "nor",
+              "ts_bgc2": {
+                "clr_type": 0,
+                "hclr_color": null
+              },
+              "ts_fgc2": {
+                "clr_type": 0,
+                "hclr_color": "#000000"
+              },
+              "ts_bd_i": false,
+              "ts_fs_i": false,
+              "ts_ff_i": false,
+              "ts_it_i": false,
+              "ts_sc_i": false,
+              "ts_st_i": false,
+              "ts_un_i": false,
+              "ts_va_i": false,
+              "ts_bgc2_i": false,
+              "ts_fgc2_i": false
+            }
+          },
+          {
+            "ls_nest": 0,
+            "ls_id": null,
+            "ls_ts": {
+              "ts_bd": false,
+              "ts_fs": 11,
+              "ts_ff": "Arial",
+              "ts_it": false,
+              "ts_sc": false,
+              "ts_st": false,
+              "ts_tw": 400,
+              "ts_un": false,
+              "ts_va": "nor",
+              "ts_bgc2": {
+                "clr_type": 0,
+                "hclr_color": null
+              },
+              "ts_fgc2": {
+                "clr_type": 0,
+                "hclr_color": "#000000"
+              },
+              "ts_bd_i": false,
+              "ts_fs_i": false,
+              "ts_ff_i": false,
+              "ts_it_i": false,
+              "ts_sc_i": false,
+              "ts_st_i": false,
+              "ts_un_i": false,
+              "ts_va_i": false,
+              "ts_bgc2_i": false,
+              "ts_fgc2_i": false
+            }
+          },
+          null, null, null, null, null, null, null, null, null, null, null,
+          null, null, null, null, null, null, null, null, null, null, null,
+          {
+            "ls_nest": 0,
+            "ls_id": "kix.r139o3ivf8cd",
+            "ls_ts": {
+              "ts_bd": false,
+              "ts_fs": 11,
+              "ts_ff": "Arial",
+              "ts_it": false,
+              "ts_sc": false,
+              "ts_st": false,
+              "ts_tw": 400,
+              "ts_un": false,
+              "ts_va": "nor",
+              "ts_bgc2": {
+                "clr_type": 0,
+                "hclr_color": null
+              },
+              "ts_fgc2": {
+                "clr_type": 0,
+                "hclr_color": "#000000"
+              },
+              "ts_bd_i": false,
+              "ts_fs_i": false,
+              "ts_ff_i": false,
+              "ts_it_i": false,
+              "ts_sc_i": false,
+              "ts_st_i": false,
+              "ts_un_i": false,
+              "ts_va_i": false,
+              "ts_bgc2_i": false,
+              "ts_fgc2_i": false
+            }
+          },
+          null, null, null, null, null, null, null, null, null, null, null,
+          null, null, null, null, null,
+          {
+            "ls_nest": 0,
+            "ls_id": "kix.r139o3ivf8cd",
+            "ls_ts": {
+              "ts_bd": false,
+              "ts_fs": 11,
+              "ts_ff": "Arial",
+              "ts_it": false,
+              "ts_sc": false,
+              "ts_st": false,
+              "ts_tw": 400,
+              "ts_un": false,
+              "ts_va": "nor",
+              "ts_bgc2": {
+                "clr_type": 0,
+                "hclr_color": null
+              },
+              "ts_fgc2": {
+                "clr_type": 0,
+                "hclr_color": "#000000"
+              },
+              "ts_bd_i": false,
+              "ts_fs_i": false,
+              "ts_ff_i": false,
+              "ts_it_i": false,
+              "ts_sc_i": false,
+              "ts_st_i": false,
+              "ts_un_i": false,
+              "ts_va_i": false,
+              "ts_bgc2_i": false,
+              "ts_fgc2_i": false
+            }
+          },
+          {
+            "ls_nest": 0,
+            "ls_id": null,
+            "ls_ts": {
+              "ts_bd": false,
+              "ts_fs": 11,
+              "ts_ff": "Arial",
+              "ts_it": false,
+              "ts_sc": false,
+              "ts_st": false,
+              "ts_tw": 400,
+              "ts_un": false,
+              "ts_va": "nor",
+              "ts_bgc2": {
+                "clr_type": 0,
+                "hclr_color": null
+              },
+              "ts_fgc2": {
+                "clr_type": 0,
+                "hclr_color": "#000000"
+              },
+              "ts_bd_i": false,
+              "ts_fs_i": false,
+              "ts_ff_i": false,
+              "ts_it_i": false,
+              "ts_sc_i": false,
+              "ts_st_i": false,
+              "ts_un_i": false,
+              "ts_va_i": false,
+              "ts_bgc2_i": false,
+              "ts_fgc2_i": false
+            }
+          },
+          null, null, null, null, null, null, null, null, null,
+          null, null, null, null, null,
+          {
+            "ls_nest": 0,
+            "ls_id": null,
+            "ls_ts": {
+              "ts_bd": false,
+              "ts_fs": 11,
+              "ts_ff": "Arial",
+              "ts_it": false,
+              "ts_sc": false,
+              "ts_st": false,
+              "ts_tw": 400,
+              "ts_un": false,
+              "ts_va": "nor",
+              "ts_bgc2": {
+                "clr_type": 0,
+                "hclr_color": null
+              },
+              "ts_fgc2": {
+                "clr_type": 0,
+                "hclr_color": "#000000"
+              },
+              "ts_bd_i": false,
+              "ts_fs_i": false,
+              "ts_ff_i": false,
+              "ts_it_i": false,
+              "ts_sc_i": false,
+              "ts_st_i": false,
+              "ts_un_i": false,
+              "ts_va_i": false,
+              "ts_bgc2_i": false,
+              "ts_fgc2_i": false
+            }
+          },
+          null, null, null, null, null, null, null, null, null, null, null,
+          null, null, null, null, null, null, null, null, null, null, null,
+          {
+            "ls_nest": 0,
+            "ls_id": null,
+            "ls_ts": {
+              "ts_bd": false,
+              "ts_fs": 11,
+              "ts_ff": "Arial",
+              "ts_it": false,
+              "ts_sc": false,
+              "ts_st": false,
+              "ts_tw": 400,
+              "ts_un": false,
+              "ts_va": "nor",
+              "ts_bgc2": {
+                "clr_type": 0,
+                "hclr_color": null
+              },
+              "ts_fgc2": {
+                "clr_type": 0,
+                "hclr_color": "#000000"
+              },
+              "ts_bd_i": false,
+              "ts_fs_i": false,
+              "ts_ff_i": false,
+              "ts_it_i": false,
+              "ts_sc_i": false,
+              "ts_st_i": false,
+              "ts_un_i": false,
+              "ts_va_i": false,
+              "ts_bgc2_i": false,
+              "ts_fgc2_i": false
+            }
+          },
+          null, null, null, null, null, null, null, null, null, null, null,
+          null, null, null, null, null, null, null, null, null, null, null,
+          null, null, null, null, null, null, null, null, null, null, null,
+          null, null, null, null, null, null, null, null, null,
+          {
+            "ls_nest": 0,
+            "ls_id": null,
+            "ls_ts": {
+              "ts_bd": false,
+              "ts_fs": 11,
+              "ts_ff": "Arial",
+              "ts_it": false,
+              "ts_sc": false,
+              "ts_st": false,
+              "ts_tw": 400,
+              "ts_un": false,
+              "ts_va": "nor",
+              "ts_bgc2": {
+                "clr_type": 0,
+                "hclr_color": null
+              },
+              "ts_fgc2": {
+                "clr_type": 0,
+                "hclr_color": "#000000"
+              },
+              "ts_bd_i": false,
+              "ts_fs_i": false,
+              "ts_ff_i": false,
+              "ts_it_i": false,
+              "ts_sc_i": false,
+              "ts_st_i": false,
+              "ts_un_i": false,
+              "ts_va_i": false,
+              "ts_bgc2_i": false,
+              "ts_fgc2_i": false
+            }
+          },
+          null, null, null, null, null, null, null, null, null, null, null,
+          null, null,
+          {
+            "ls_nest": 0,
+            "ls_id": null,
+            "ls_ts": {
+              "ts_bd": false,
+              "ts_fs": 11,
+              "ts_ff": "Arial",
+              "ts_it": false,
+              "ts_sc": false,
+              "ts_st": false,
+              "ts_tw": 400,
+              "ts_un": false,
+              "ts_va": "nor",
+              "ts_bgc2": {
+                "clr_type": 0,
+                "hclr_color": null
+              },
+              "ts_fgc2": {
+                "clr_type": 0,
+                "hclr_color": "#000000"
+              },
+              "ts_bd_i": false,
+              "ts_fs_i": false,
+              "ts_ff_i": false,
+              "ts_it_i": false,
+              "ts_sc_i": false,
+              "ts_st_i": false,
+              "ts_un_i": false,
+              "ts_va_i": false,
+              "ts_bgc2_i": false,
+              "ts_fgc2_i": false
+            }
+          },
+          null, null, null, null, null, null, null, null, null, null, null,
+          null, null, null, null, null, null, null, null, null, null, null,
+          null, null, null, null, null, null, null, null, null, null, null,
+          null, null, null, null, null, null, null, null, null, null, null,
+          null, null, null, null, null, null, null, null,
+          {
+            "ls_nest": 0,
+            "ls_id": null,
+            "ls_ts": {
+              "ts_bd": false,
+              "ts_fs": 11,
+              "ts_ff": "Arial",
+              "ts_it": false,
+              "ts_sc": false,
+              "ts_st": false,
+              "ts_tw": 400,
+              "ts_un": false,
+              "ts_va": "nor",
+              "ts_bgc2": {
+                "clr_type": 0,
+                "hclr_color": null
+              },
+              "ts_fgc2": {
+                "clr_type": 0,
+                "hclr_color": "#000000"
+              },
+              "ts_bd_i": false,
+              "ts_fs_i": false,
+              "ts_ff_i": false,
+              "ts_it_i": false,
+              "ts_sc_i": false,
+              "ts_st_i": false,
+              "ts_un_i": false,
+              "ts_va_i": false,
+              "ts_bgc2_i": false,
+              "ts_fgc2_i": false
+            }
+          },
+          null, null, null, null, null, null, null, null, null, null, null,
+          null, null, null, null, null, null, null, null, null, null, null,
+          null, null, null, null, null, null, null, null, null,
+          {
+            "ls_nest": 0,
+            "ls_id": null,
+            "ls_ts": {
+              "ts_bd": false,
+              "ts_fs": 11,
+              "ts_ff": "Arial",
+              "ts_it": false,
+              "ts_sc": false,
+              "ts_st": false,
+              "ts_tw": 400,
+              "ts_un": false,
+              "ts_va": "nor",
+              "ts_bgc2": {
+                "clr_type": 0,
+                "hclr_color": null
+              },
+              "ts_fgc2": {
+                "clr_type": 0,
+                "hclr_color": "#000000"
+              },
+              "ts_bd_i": false,
+              "ts_fs_i": false,
+              "ts_ff_i": false,
+              "ts_it_i": false,
+              "ts_sc_i": false,
+              "ts_st_i": false,
+              "ts_un_i": false,
+              "ts_va_i": false,
+              "ts_bgc2_i": false,
+              "ts_fgc2_i": false
+            }
+          },
+          null, null, null, null, null, null, null, null, null,
+          {
+            "ls_nest": 0,
+            "ls_id": null,
+            "ls_ts": {
+              "ts_bd": false,
+              "ts_fs": 11,
+              "ts_ff": "Arial",
+              "ts_it": false,
+              "ts_sc": false,
+              "ts_st": false,
+              "ts_tw": 400,
+              "ts_un": false,
+              "ts_va": "nor",
+              "ts_bgc2": {
+                "clr_type": 0,
+                "hclr_color": null
+              },
+              "ts_fgc2": {
+                "clr_type": 0,
+                "hclr_color": "#000000"
+              },
+              "ts_bd_i": false,
+              "ts_fs_i": false,
+              "ts_ff_i": false,
+              "ts_it_i": false,
+              "ts_sc_i": false,
+              "ts_st_i": false,
+              "ts_un_i": false,
+              "ts_va_i": false,
+              "ts_bgc2_i": false,
+              "ts_fgc2_i": false
+            }
+          },
+          null, null, null, null, null, null, null, null, null,
+          {
+            "ls_nest": 0,
+            "ls_id": null,
+            "ls_ts": {
+              "ts_bd": false,
+              "ts_fs": 11,
+              "ts_ff": "Arial",
+              "ts_it": false,
+              "ts_sc": false,
+              "ts_st": false,
+              "ts_tw": 400,
+              "ts_un": false,
+              "ts_va": "nor",
+              "ts_bgc2": {
+                "clr_type": 0,
+                "hclr_color": null
+              },
+              "ts_fgc2": {
+                "clr_type": 0,
+                "hclr_color": "#000000"
+              },
+              "ts_bd_i": false,
+              "ts_fs_i": false,
+              "ts_ff_i": false,
+              "ts_it_i": false,
+              "ts_sc_i": false,
+              "ts_st_i": false,
+              "ts_un_i": false,
+              "ts_va_i": false,
+              "ts_bgc2_i": false,
+              "ts_fgc2_i": false
+            }
+          },
+          null, null, null, null, null,
+          {
+            "ls_nest": 0,
+            "ls_id": null,
+            "ls_ts": {
+              "ts_bd": false,
+              "ts_fs": 11,
+              "ts_ff": "Arial",
+              "ts_it": false,
+              "ts_sc": false,
+              "ts_st": false,
+              "ts_tw": 400,
+              "ts_un": false,
+              "ts_va": "nor",
+              "ts_bgc2": {
+                "clr_type": 0,
+                "hclr_color": null
+              },
+              "ts_fgc2": {
+                "clr_type": 0,
+                "hclr_color": "#000000"
+              },
+              "ts_bd_i": false,
+              "ts_fs_i": false,
+              "ts_ff_i": false,
+              "ts_it_i": false,
+              "ts_sc_i": false,
+              "ts_st_i": false,
+              "ts_un_i": false,
+              "ts_va_i": false,
+              "ts_bgc2_i": false,
+              "ts_fgc2_i": false
+            }
+          },
+          null, null, null, null, null, null, null, null,
+          {
+            "ls_nest": 0,
+            "ls_id": null,
+            "ls_ts": {
+              "ts_bd": false,
+              "ts_fs": 11,
+              "ts_ff": "Arial",
+              "ts_it": false,
+              "ts_sc": false,
+              "ts_st": false,
+              "ts_tw": 400,
+              "ts_un": false,
+              "ts_va": "nor",
+              "ts_bgc2": {
+                "clr_type": 0,
+                "hclr_color": null
+              },
+              "ts_fgc2": {
+                "clr_type": 0,
+                "hclr_color": "#000000"
+              },
+              "ts_bd_i": false,
+              "ts_fs_i": false,
+              "ts_ff_i": false,
+              "ts_it_i": false,
+              "ts_sc_i": false,
+              "ts_st_i": false,
+              "ts_un_i": false,
+              "ts_va_i": false,
+              "ts_bgc2_i": false,
+              "ts_fgc2_i": false
+            }
+          },
+          null, null, null, null, null, null, null, null, null, null,
+          {
+            "ls_nest": 0,
+            "ls_id": null,
+            "ls_ts": {
+              "ts_bd": false,
+              "ts_fs": 11,
+              "ts_ff": "Arial",
+              "ts_it": false,
+              "ts_sc": false,
+              "ts_st": false,
+              "ts_tw": 400,
+              "ts_un": false,
+              "ts_va": "nor",
+              "ts_bgc2": {
+                "clr_type": 0,
+                "hclr_color": null
+              },
+              "ts_fgc2": {
+                "clr_type": 0,
+                "hclr_color": "#000000"
+              },
+              "ts_bd_i": false,
+              "ts_fs_i": false,
+              "ts_ff_i": false,
+              "ts_it_i": false,
+              "ts_sc_i": false,
+              "ts_st_i": false,
+              "ts_un_i": false,
+              "ts_va_i": false,
+              "ts_bgc2_i": false,
+              "ts_fgc2_i": false
+            }
+          },
+          null, null, null, null, null, null, null, null, null, null, null,
+          null, null, null, null, null, null,
+          {
+            "ls_nest": 0,
+            "ls_id": null,
+            "ls_ts": {
+              "ts_bd": false,
+              "ts_fs": 11,
+              "ts_ff": "Arial",
+              "ts_it": false,
+              "ts_sc": false,
+              "ts_st": false,
+              "ts_tw": 400,
+              "ts_un": false,
+              "ts_va": "nor",
+              "ts_bgc2": {
+                "clr_type": 0,
+                "hclr_color": null
+              },
+              "ts_fgc2": {
+                "clr_type": 0,
+                "hclr_color": "#000000"
+              },
+              "ts_bd_i": false,
+              "ts_fs_i": false,
+              "ts_ff_i": false,
+              "ts_it_i": false,
+              "ts_sc_i": false,
+              "ts_st_i": false,
+              "ts_un_i": false,
+              "ts_va_i": false,
+              "ts_bgc2_i": false,
+              "ts_fgc2_i": false
+            }
+          },
+          null, null, null, null, null, null, null, null, null, null, null,
+          null, null, null, null, null, null, null, null, null,
+          {
+            "ls_nest": 0,
+            "ls_id": null,
+            "ls_ts": {
+              "ts_bd": false,
+              "ts_fs": 11,
+              "ts_ff": "Arial",
+              "ts_it": false,
+              "ts_sc": false,
+              "ts_st": false,
+              "ts_tw": 400,
+              "ts_un": false,
+              "ts_va": "nor",
+              "ts_bgc2": {
+                "clr_type": 0,
+                "hclr_color": null
+              },
+              "ts_fgc2": {
+                "clr_type": 0,
+                "hclr_color": "#000000"
+              },
+              "ts_bd_i": false,
+              "ts_fs_i": false,
+              "ts_ff_i": false,
+              "ts_it_i": false,
+              "ts_sc_i": false,
+              "ts_st_i": false,
+              "ts_un_i": false,
+              "ts_va_i": false,
+              "ts_bgc2_i": false,
+              "ts_fgc2_i": false
+            }
+          },
+          null, null, null, null, null, null, null, null, null, null, null,
+          null, null, null, null, null, null,
+          {
+            "ls_nest": 0,
+            "ls_id": null,
+            "ls_ts": {
+              "ts_bd": false,
+              "ts_fs": 11,
+              "ts_ff": "Arial",
+              "ts_it": false,
+              "ts_sc": false,
+              "ts_st": false,
+              "ts_tw": 400,
+              "ts_un": false,
+              "ts_va": "nor",
+              "ts_bgc2": {
+                "clr_type": 0,
+                "hclr_color": null
+              },
+              "ts_fgc2": {
+                "clr_type": 0,
+                "hclr_color": "#000000"
+              },
+              "ts_bd_i": false,
+              "ts_fs_i": false,
+              "ts_ff_i": false,
+              "ts_it_i": false,
+              "ts_sc_i": false,
+              "ts_st_i": false,
+              "ts_un_i": false,
+              "ts_va_i": false,
+              "ts_bgc2_i": false,
+              "ts_fgc2_i": false
+            }
+          },
+          null, null, null, null, null, null, null, null, null, null, null,
+          null, null, null, null,
+          {
+            "ls_nest": 0,
+            "ls_id": null,
+            "ls_ts": {
+              "ts_bd": false,
+              "ts_fs": 11,
+              "ts_ff": "Arial",
+              "ts_it": false,
+              "ts_sc": false,
+              "ts_st": false,
+              "ts_tw": 400,
+              "ts_un": false,
+              "ts_va": "nor",
+              "ts_bgc2": {
+                "clr_type": 0,
+                "hclr_color": null
+              },
+              "ts_fgc2": {
+                "clr_type": 0,
+                "hclr_color": "#000000"
+              },
+              "ts_bd_i": false,
+              "ts_fs_i": false,
+              "ts_ff_i": false,
+              "ts_it_i": false,
+              "ts_sc_i": false,
+              "ts_st_i": false,
+              "ts_un_i": false,
+              "ts_va_i": false,
+              "ts_bgc2_i": false,
+              "ts_fgc2_i": false
+            }
+          }
+        ]
+      },
+      {
+        "stsl_type": "named_range",
+        "stsl_styles": [
+          {
+            "nrs_ei": {
+              "cv": {
+                "op": "set",
+                "opValue": []
+              }
+            }
+          }
+        ]
+      },
+      {
+        "stsl_type": "paragraph",
+        "stsl_styles": [
+          null, null, null, null, null, null, null, null, null, null, null,
+          null, null, null, null, null, null, null, null, null, null, null,
+          {
+            "ps_al": 0,
+            "ps_awao": true,
+            "ps_sd": null,
+            "ps_bbtw": null,
+            "ps_bb": null,
+            "ps_bl": null,
+            "ps_br": null,
+            "ps_bt": null,
+            "ps_hd": 0,
+            "ps_hdid": "",
+            "ps_ifl": 0,
+            "ps_il": 0,
+            "ps_ir": 0,
+            "ps_klt": false,
+            "ps_kwn": false,
+            "ps_ltr": true,
+            "ps_ls": 1.15,
+            "ps_sm": 1,
+            "ps_sa": 0,
+            "ps_sb": 0,
+            "ps_al_i": false,
+            "ps_awao_i": false,
+            "ps_sd_i": false,
+            "ps_bbtw_i": false,
+            "ps_bb_i": false,
+            "ps_bl_i": false,
+            "ps_br_i": false,
+            "ps_bt_i": false,
+            "ps_ifl_i": false,
+            "ps_il_i": false,
+            "ps_ir_i": false,
+            "ps_klt_i": false,
+            "ps_kwn_i": false,
+            "ps_ls_i": false,
+            "ps_rd": "",
+            "ps_sm_i": false,
+            "ps_sa_i": false,
+            "ps_sb_i": false,
+            "ps_shd": false,
+            "ps_ts": {
+              "cv": {
+                "op": "set",
+                "opValue": []
+              }
+            }
+          },
+          null,
+          {
+            "ps_al": 0,
+            "ps_awao": true,
+            "ps_sd": null,
+            "ps_bbtw": null,
+            "ps_bb": null,
+            "ps_bl": null,
+            "ps_br": null,
+            "ps_bt": null,
+            "ps_hd": 0,
+            "ps_hdid": "",
+            "ps_ifl": 0,
+            "ps_il": 0,
+            "ps_ir": 0,
+            "ps_klt": false,
+            "ps_kwn": false,
+            "ps_ltr": true,
+            "ps_ls": 1.15,
+            "ps_sm": 1,
+            "ps_sa": 0,
+            "ps_sb": 0,
+            "ps_al_i": false,
+            "ps_awao_i": false,
+            "ps_sd_i": false,
+            "ps_bbtw_i": false,
+            "ps_bb_i": false,
+            "ps_bl_i": false,
+            "ps_br_i": false,
+            "ps_bt_i": false,
+            "ps_ifl_i": false,
+            "ps_il_i": false,
+            "ps_ir_i": false,
+            "ps_klt_i": false,
+            "ps_kwn_i": false,
+            "ps_ls_i": false,
+            "ps_rd": "",
+            "ps_sm_i": false,
+            "ps_sa_i": false,
+            "ps_sb_i": false,
+            "ps_shd": false,
+            "ps_ts": {
+              "cv": {
+                "op": "set",
+                "opValue": []
+              }
+            }
+          },
+          null, null, null, null, null, null, null, null, null, null, null,
+          null, null, null, null, null, null,
+          {
+            "ps_al": 0,
+            "ps_awao": true,
+            "ps_sd": null,
+            "ps_bbtw": null,
+            "ps_bb": null,
+            "ps_bl": null,
+            "ps_br": null,
+            "ps_bt": null,
+            "ps_hd": 0,
+            "ps_hdid": "",
+            "ps_ifl": 0,
+            "ps_il": 0,
+            "ps_ir": 0,
+            "ps_klt": false,
+            "ps_kwn": false,
+            "ps_ltr": true,
+            "ps_ls": 1.15,
+            "ps_sm": 1,
+            "ps_sa": 0,
+            "ps_sb": 0,
+            "ps_al_i": false,
+            "ps_awao_i": false,
+            "ps_sd_i": false,
+            "ps_bbtw_i": false,
+            "ps_bb_i": false,
+            "ps_bl_i": false,
+            "ps_br_i": false,
+            "ps_bt_i": false,
+            "ps_ifl_i": false,
+            "ps_il_i": false,
+            "ps_ir_i": false,
+            "ps_klt_i": false,
+            "ps_kwn_i": false,
+            "ps_ls_i": false,
+            "ps_rd": "",
+            "ps_sm_i": false,
+            "ps_sa_i": false,
+            "ps_sb_i": false,
+            "ps_shd": false,
+            "ps_ts": {
+              "cv": {
+                "op": "set",
+                "opValue": []
+              }
+            }
+          },
+          {
+            "ps_al": 0,
+            "ps_awao": true,
+            "ps_sd": null,
+            "ps_bbtw": null,
+            "ps_bb": null,
+            "ps_bl": null,
+            "ps_br": null,
+            "ps_bt": null,
+            "ps_hd": 0,
+            "ps_hdid": "",
+            "ps_ifl": 0,
+            "ps_il": 0,
+            "ps_ir": 0,
+            "ps_klt": false,
+            "ps_kwn": false,
+            "ps_ltr": true,
+            "ps_ls": 1.15,
+            "ps_sm": 1,
+            "ps_sa": 0,
+            "ps_sb": 0,
+            "ps_al_i": false,
+            "ps_awao_i": false,
+            "ps_sd_i": false,
+            "ps_bbtw_i": false,
+            "ps_bb_i": false,
+            "ps_bl_i": false,
+            "ps_br_i": false,
+            "ps_bt_i": false,
+            "ps_ifl_i": false,
+            "ps_il_i": false,
+            "ps_ir_i": false,
+            "ps_klt_i": false,
+            "ps_kwn_i": false,
+            "ps_ls_i": false,
+            "ps_rd": "",
+            "ps_sm_i": false,
+            "ps_sa_i": false,
+            "ps_sb_i": false,
+            "ps_shd": false,
+            "ps_ts": {
+              "cv": {
+                "op": "set",
+                "opValue": []
+              }
+            }
+          },
+          null, null, null, null, null, null, null, null, null, null, null,
+          null, null, null, null, null, null, null, null, null, null, null,
+          {
+            "ps_al": 0,
+            "ps_awao": true,
+            "ps_sd": null,
+            "ps_bbtw": null,
+            "ps_bb": null,
+            "ps_bl": null,
+            "ps_br": null,
+            "ps_bt": null,
+            "ps_hd": 0,
+            "ps_hdid": "",
+            "ps_ifl": 18,
+            "ps_il": 36,
+            "ps_ir": 0,
+            "ps_klt": false,
+            "ps_kwn": false,
+            "ps_ltr": true,
+            "ps_ls": 1.15,
+            "ps_sm": 0,
+            "ps_sa": 0,
+            "ps_sb": 0,
+            "ps_al_i": false,
+            "ps_awao_i": false,
+            "ps_sd_i": false,
+            "ps_bbtw_i": false,
+            "ps_bb_i": false,
+            "ps_bl_i": false,
+            "ps_br_i": false,
+            "ps_bt_i": false,
+            "ps_ifl_i": false,
+            "ps_il_i": false,
+            "ps_ir_i": false,
+            "ps_klt_i": false,
+            "ps_kwn_i": false,
+            "ps_ls_i": false,
+            "ps_rd": "",
+            "ps_sm_i": false,
+            "ps_sa_i": false,
+            "ps_sb_i": false,
+            "ps_shd": false,
+            "ps_ts": {
+              "cv": {
+                "op": "set",
+                "opValue": []
+              }
+            }
+          },
+          null, null, null, null, null, null, null, null, null, null, null,
+          null, null, null, null, null,
+          {
+            "ps_al": 0,
+            "ps_awao": true,
+            "ps_sd": null,
+            "ps_bbtw": null,
+            "ps_bb": null,
+            "ps_bl": null,
+            "ps_br": null,
+            "ps_bt": null,
+            "ps_hd": 0,
+            "ps_hdid": "",
+            "ps_ifl": 18,
+            "ps_il": 36,
+            "ps_ir": 0,
+            "ps_klt": false,
+            "ps_kwn": false,
+            "ps_ltr": true,
+            "ps_ls": 1.15,
+            "ps_sm": 0,
+            "ps_sa": 0,
+            "ps_sb": 0,
+            "ps_al_i": false,
+            "ps_awao_i": false,
+            "ps_sd_i": false,
+            "ps_bbtw_i": false,
+            "ps_bb_i": false,
+            "ps_bl_i": false,
+            "ps_br_i": false,
+            "ps_bt_i": false,
+            "ps_ifl_i": false,
+            "ps_il_i": false,
+            "ps_ir_i": false,
+            "ps_klt_i": false,
+            "ps_kwn_i": false,
+            "ps_ls_i": false,
+            "ps_rd": "",
+            "ps_sm_i": false,
+            "ps_sa_i": false,
+            "ps_sb_i": false,
+            "ps_shd": false,
+            "ps_ts": {
+              "cv": {
+                "op": "set",
+                "opValue": []
+              }
+            }
+          },
+          {
+            "ps_al": 0,
+            "ps_awao": true,
+            "ps_sd": null,
+            "ps_bbtw": null,
+            "ps_bb": null,
+            "ps_bl": null,
+            "ps_br": null,
+            "ps_bt": null,
+            "ps_hd": 0,
+            "ps_hdid": "",
+            "ps_ifl": 0,
+            "ps_il": 0,
+            "ps_ir": 0,
+            "ps_klt": false,
+            "ps_kwn": false,
+            "ps_ltr": true,
+            "ps_ls": 1.15,
+            "ps_sm": 1,
+            "ps_sa": 0,
+            "ps_sb": 0,
+            "ps_al_i": false,
+            "ps_awao_i": false,
+            "ps_sd_i": false,
+            "ps_bbtw_i": false,
+            "ps_bb_i": false,
+            "ps_bl_i": false,
+            "ps_br_i": false,
+            "ps_bt_i": false,
+            "ps_ifl_i": false,
+            "ps_il_i": false,
+            "ps_ir_i": false,
+            "ps_klt_i": false,
+            "ps_kwn_i": false,
+            "ps_ls_i": false,
+            "ps_rd": "",
+            "ps_sm_i": false,
+            "ps_sa_i": false,
+            "ps_sb_i": false,
+            "ps_shd": false,
+            "ps_ts": {
+              "cv": {
+                "op": "set",
+                "opValue": []
+              }
+            }
+          },
+          null, null, null, null, null, null, null, null, null, null, null,
+          null, null, null,
+          {
+            "ps_al": 0,
+            "ps_awao": true,
+            "ps_sd": null,
+            "ps_bbtw": null,
+            "ps_bb": null,
+            "ps_bl": null,
+            "ps_br": null,
+            "ps_bt": null,
+            "ps_hd": 0,
+            "ps_hdid": "",
+            "ps_ifl": 0,
+            "ps_il": 0,
+            "ps_ir": 0,
+            "ps_klt": false,
+            "ps_kwn": false,
+            "ps_ltr": true,
+            "ps_ls": 1.15,
+            "ps_sm": 1,
+            "ps_sa": 0,
+            "ps_sb": 0,
+            "ps_al_i": false,
+            "ps_awao_i": false,
+            "ps_sd_i": false,
+            "ps_bbtw_i": false,
+            "ps_bb_i": false,
+            "ps_bl_i": false,
+            "ps_br_i": false,
+            "ps_bt_i": false,
+            "ps_ifl_i": false,
+            "ps_il_i": false,
+            "ps_ir_i": false,
+            "ps_klt_i": false,
+            "ps_kwn_i": false,
+            "ps_ls_i": false,
+            "ps_rd": "",
+            "ps_sm_i": false,
+            "ps_sa_i": false,
+            "ps_sb_i": false,
+            "ps_shd": false,
+            "ps_ts": {
+              "cv": {
+                "op": "set",
+                "opValue": []
+              }
+            }
+          },
+          null, null, null, null, null, null, null, null, null, null, null,
+          null, null, null, null, null, null, null, null, null, null, null,
+          {
+            "ps_al": 0,
+            "ps_awao": true,
+            "ps_sd": null,
+            "ps_bbtw": null,
+            "ps_bb": null,
+            "ps_bl": null,
+            "ps_br": null,
+            "ps_bt": null,
+            "ps_hd": 0,
+            "ps_hdid": "",
+            "ps_ifl": 0,
+            "ps_il": 0,
+            "ps_ir": 0,
+            "ps_klt": false,
+            "ps_kwn": false,
+            "ps_ltr": true,
+            "ps_ls": 1.15,
+            "ps_sm": 1,
+            "ps_sa": 0,
+            "ps_sb": 0,
+            "ps_al_i": false,
+            "ps_awao_i": false,
+            "ps_sd_i": false,
+            "ps_bbtw_i": false,
+            "ps_bb_i": false,
+            "ps_bl_i": false,
+            "ps_br_i": false,
+            "ps_bt_i": false,
+            "ps_ifl_i": false,
+            "ps_il_i": false,
+            "ps_ir_i": false,
+            "ps_klt_i": false,
+            "ps_kwn_i": false,
+            "ps_ls_i": false,
+            "ps_rd": "",
+            "ps_sm_i": false,
+            "ps_sa_i": false,
+            "ps_sb_i": false,
+            "ps_shd": false,
+            "ps_ts": {
+              "cv": {
+                "op": "set",
+                "opValue": []
+              }
+            }
+          },
+          null, null, null, null, null, null, null, null, null, null, null,
+          null, null, null, null, null, null, null, null, null, null, null,
+          null, null, null, null, null, null, null, null, null, null, null,
+          null, null, null, null, null, null, null, null, null,
+          {
+            "ps_al": 0,
+            "ps_awao": true,
+            "ps_sd": null,
+            "ps_bbtw": null,
+            "ps_bb": null,
+            "ps_bl": null,
+            "ps_br": null,
+            "ps_bt": null,
+            "ps_hd": 0,
+            "ps_hdid": "",
+            "ps_ifl": 0,
+            "ps_il": 0,
+            "ps_ir": 0,
+            "ps_klt": false,
+            "ps_kwn": false,
+            "ps_ltr": true,
+            "ps_ls": 1.15,
+            "ps_sm": 1,
+            "ps_sa": 0,
+            "ps_sb": 0,
+            "ps_al_i": false,
+            "ps_awao_i": false,
+            "ps_sd_i": false,
+            "ps_bbtw_i": false,
+            "ps_bb_i": false,
+            "ps_bl_i": false,
+            "ps_br_i": false,
+            "ps_bt_i": false,
+            "ps_ifl_i": false,
+            "ps_il_i": false,
+            "ps_ir_i": false,
+            "ps_klt_i": false,
+            "ps_kwn_i": false,
+            "ps_ls_i": false,
+            "ps_rd": "",
+            "ps_sm_i": false,
+            "ps_sa_i": false,
+            "ps_sb_i": false,
+            "ps_shd": false,
+            "ps_ts": {
+              "cv": {
+                "op": "set",
+                "opValue": []
+              }
+            }
+          },
+          null, null, null, null, null, null, null, null, null, null, null,
+          null, null,
+          {
+            "ps_al": 0,
+            "ps_awao": true,
+            "ps_sd": null,
+            "ps_bbtw": null,
+            "ps_bb": null,
+            "ps_bl": null,
+            "ps_br": null,
+            "ps_bt": null,
+            "ps_hd": 0,
+            "ps_hdid": "",
+            "ps_ifl": 0,
+            "ps_il": 0,
+            "ps_ir": 0,
+            "ps_klt": false,
+            "ps_kwn": false,
+            "ps_ltr": true,
+            "ps_ls": 1.15,
+            "ps_sm": 1,
+            "ps_sa": 0,
+            "ps_sb": 0,
+            "ps_al_i": false,
+            "ps_awao_i": false,
+            "ps_sd_i": false,
+            "ps_bbtw_i": false,
+            "ps_bb_i": false,
+            "ps_bl_i": false,
+            "ps_br_i": false,
+            "ps_bt_i": false,
+            "ps_ifl_i": false,
+            "ps_il_i": false,
+            "ps_ir_i": false,
+            "ps_klt_i": false,
+            "ps_kwn_i": false,
+            "ps_ls_i": false,
+            "ps_rd": "",
+            "ps_sm_i": false,
+            "ps_sa_i": false,
+            "ps_sb_i": false,
+            "ps_shd": false,
+            "ps_ts": {
+              "cv": {
+                "op": "set",
+                "opValue": []
+              }
+            }
+          },
+          null, null, null, null, null, null, null, null, null, null, null,
+          null, null, null, null, null, null, null, null, null, null, null,
+          null, null, null, null, null, null, null, null, null, null, null,
+          null, null, null, null, null, null, null, null, null, null, null,
+          null, null, null, null, null, null, null, null,
+          {
+            "ps_al": 0,
+            "ps_awao": true,
+            "ps_sd": null,
+            "ps_bbtw": null,
+            "ps_bb": null,
+            "ps_bl": null,
+            "ps_br": null,
+            "ps_bt": null,
+            "ps_hd": 0,
+            "ps_hdid": "",
+            "ps_ifl": 0,
+            "ps_il": 0,
+            "ps_ir": 0,
+            "ps_klt": false,
+            "ps_kwn": false,
+            "ps_ltr": true,
+            "ps_ls": 1.5,
+            "ps_sm": 1,
+            "ps_sa": 0,
+            "ps_sb": 0,
+            "ps_al_i": false,
+            "ps_awao_i": false,
+            "ps_sd_i": false,
+            "ps_bbtw_i": false,
+            "ps_bb_i": false,
+            "ps_bl_i": false,
+            "ps_br_i": false,
+            "ps_bt_i": false,
+            "ps_ifl_i": false,
+            "ps_il_i": false,
+            "ps_ir_i": false,
+            "ps_klt_i": false,
+            "ps_kwn_i": false,
+            "ps_ls_i": false,
+            "ps_rd": "",
+            "ps_sm_i": false,
+            "ps_sa_i": false,
+            "ps_sb_i": false,
+            "ps_shd": false,
+            "ps_ts": {
+              "cv": {
+                "op": "set",
+                "opValue": []
+              }
+            }
+          },
+          null, null, null, null, null, null, null, null, null, null, null,
+          null, null, null, null, null, null, null, null, null, null, null,
+          null, null, null, null, null, null, null, null, null,
+          {
+            "ps_al": 0,
+            "ps_awao": true,
+            "ps_sd": null,
+            "ps_bbtw": null,
+            "ps_bb": null,
+            "ps_bl": null,
+            "ps_br": null,
+            "ps_bt": null,
+            "ps_hd": 0,
+            "ps_hdid": "",
+            "ps_ifl": 0,
+            "ps_il": 0,
+            "ps_ir": 0,
+            "ps_klt": false,
+            "ps_kwn": false,
+            "ps_ltr": true,
+            "ps_ls": 2,
+            "ps_sm": 1,
+            "ps_sa": 0,
+            "ps_sb": 0,
+            "ps_al_i": false,
+            "ps_awao_i": false,
+            "ps_sd_i": false,
+            "ps_bbtw_i": false,
+            "ps_bb_i": false,
+            "ps_bl_i": false,
+            "ps_br_i": false,
+            "ps_bt_i": false,
+            "ps_ifl_i": false,
+            "ps_il_i": false,
+            "ps_ir_i": false,
+            "ps_klt_i": false,
+            "ps_kwn_i": false,
+            "ps_ls_i": false,
+            "ps_rd": "",
+            "ps_sm_i": false,
+            "ps_sa_i": false,
+            "ps_sb_i": false,
+            "ps_shd": false,
+            "ps_ts": {
+              "cv": {
+                "op": "set",
+                "opValue": []
+              }
+            }
+          },
+          null, null, null, null, null, null, null, null, null,
+          {
+            "ps_al": 0,
+            "ps_awao": true,
+            "ps_sd": null,
+            "ps_bbtw": null,
+            "ps_bb": null,
+            "ps_bl": null,
+            "ps_br": null,
+            "ps_bt": null,
+            "ps_hd": 1,
+            "ps_hdid": "h.g21n6rb4zqed",
+            "ps_ifl": 0,
+            "ps_il": 0,
+            "ps_ir": 0,
+            "ps_klt": true,
+            "ps_kwn": true,
+            "ps_ltr": true,
+            "ps_ls": 2,
+            "ps_sm": 1,
+            "ps_sa": 6,
+            "ps_sb": 20,
+            "ps_al_i": false,
+            "ps_awao_i": false,
+            "ps_sd_i": false,
+            "ps_bbtw_i": false,
+            "ps_bb_i": false,
+            "ps_bl_i": false,
+            "ps_br_i": false,
+            "ps_bt_i": false,
+            "ps_ifl_i": false,
+            "ps_il_i": false,
+            "ps_ir_i": false,
+            "ps_klt_i": false,
+            "ps_kwn_i": false,
+            "ps_ls_i": false,
+            "ps_rd": "",
+            "ps_sm_i": false,
+            "ps_sa_i": false,
+            "ps_sb_i": false,
+            "ps_shd": false,
+            "ps_ts": {
+              "cv": {
+                "op": "set",
+                "opValue": []
+              }
+            }
+          },
+          null, null, null, null, null, null, null, null, null,
+          {
+            "ps_al": 0,
+            "ps_awao": true,
+            "ps_sd": null,
+            "ps_bbtw": null,
+            "ps_bb": null,
+            "ps_bl": null,
+            "ps_br": null,
+            "ps_bt": null,
+            "ps_hd": 2,
+            "ps_hdid": "h.krq4m2981po1",
+            "ps_ifl": 0,
+            "ps_il": 0,
+            "ps_ir": 0,
+            "ps_klt": true,
+            "ps_kwn": true,
+            "ps_ltr": true,
+            "ps_ls": 1.15,
+            "ps_sm": 1,
+            "ps_sa": 6,
+            "ps_sb": 18,
+            "ps_al_i": false,
+            "ps_awao_i": false,
+            "ps_sd_i": false,
+            "ps_bbtw_i": false,
+            "ps_bb_i": false,
+            "ps_bl_i": false,
+            "ps_br_i": false,
+            "ps_bt_i": false,
+            "ps_ifl_i": false,
+            "ps_il_i": false,
+            "ps_ir_i": false,
+            "ps_klt_i": false,
+            "ps_kwn_i": false,
+            "ps_ls_i": false,
+            "ps_rd": "",
+            "ps_sm_i": false,
+            "ps_sa_i": false,
+            "ps_sb_i": false,
+            "ps_shd": false,
+            "ps_ts": {
+              "cv": {
+                "op": "set",
+                "opValue": []
+              }
+            }
+          },
+          null, null, null, null, null,
+          {
+            "ps_al": 0,
+            "ps_awao": true,
+            "ps_sd": null,
+            "ps_bbtw": null,
+            "ps_bb": null,
+            "ps_bl": null,
+            "ps_br": null,
+            "ps_bt": null,
+            "ps_hd": 100,
+            "ps_hdid": "h.8vtolgr7aqve",
+            "ps_ifl": 0,
+            "ps_il": 0,
+            "ps_ir": 0,
+            "ps_klt": true,
+            "ps_kwn": true,
+            "ps_ltr": true,
+            "ps_ls": 1.15,
+            "ps_sm": 1,
+            "ps_sa": 3,
+            "ps_sb": 0,
+            "ps_al_i": false,
+            "ps_awao_i": false,
+            "ps_sd_i": false,
+            "ps_bbtw_i": false,
+            "ps_bb_i": false,
+            "ps_bl_i": false,
+            "ps_br_i": false,
+            "ps_bt_i": false,
+            "ps_ifl_i": false,
+            "ps_il_i": false,
+            "ps_ir_i": false,
+            "ps_klt_i": false,
+            "ps_kwn_i": false,
+            "ps_ls_i": false,
+            "ps_rd": "",
+            "ps_sm_i": false,
+            "ps_sa_i": false,
+            "ps_sb_i": false,
+            "ps_shd": false,
+            "ps_ts": {
+              "cv": {
+                "op": "set",
+                "opValue": []
+              }
+            }
+          },
+          null, null, null, null, null, null, null, null,
+          {
+            "ps_al": 0,
+            "ps_awao": true,
+            "ps_sd": null,
+            "ps_bbtw": null,
+            "ps_bb": null,
+            "ps_bl": null,
+            "ps_br": null,
+            "ps_bt": null,
+            "ps_hd": 101,
+            "ps_hdid": "h.8e5zrml20l2k",
+            "ps_ifl": 0,
+            "ps_il": 0,
+            "ps_ir": 0,
+            "ps_klt": true,
+            "ps_kwn": true,
+            "ps_ltr": true,
+            "ps_ls": 1.15,
+            "ps_sm": 1,
+            "ps_sa": 16,
+            "ps_sb": 0,
+            "ps_al_i": false,
+            "ps_awao_i": false,
+            "ps_sd_i": false,
+            "ps_bbtw_i": false,
+            "ps_bb_i": false,
+            "ps_bl_i": false,
+            "ps_br_i": false,
+            "ps_bt_i": false,
+            "ps_ifl_i": false,
+            "ps_il_i": false,
+            "ps_ir_i": false,
+            "ps_klt_i": false,
+            "ps_kwn_i": false,
+            "ps_ls_i": false,
+            "ps_rd": "",
+            "ps_sm_i": false,
+            "ps_sa_i": false,
+            "ps_sb_i": false,
+            "ps_shd": false,
+            "ps_ts": {
+              "cv": {
+                "op": "set",
+                "opValue": []
+              }
+            }
+          },
+          null, null, null, null, null, null, null, null, null, null,
+          {
+            "ps_al": 0,
+            "ps_awao": true,
+            "ps_sd": null,
+            "ps_bbtw": null,
+            "ps_bb": null,
+            "ps_bl": null,
+            "ps_br": null,
+            "ps_bt": null,
+            "ps_hd": 0,
+            "ps_hdid": "",
+            "ps_ifl": 0,
+            "ps_il": 0,
+            "ps_ir": 0,
+            "ps_klt": false,
+            "ps_kwn": false,
+            "ps_ltr": true,
+            "ps_ls": 1.15,
+            "ps_sm": 1,
+            "ps_sa": 0,
+            "ps_sb": 0,
+            "ps_al_i": false,
+            "ps_awao_i": false,
+            "ps_sd_i": false,
+            "ps_bbtw_i": false,
+            "ps_bb_i": false,
+            "ps_bl_i": false,
+            "ps_br_i": false,
+            "ps_bt_i": false,
+            "ps_ifl_i": false,
+            "ps_il_i": false,
+            "ps_ir_i": false,
+            "ps_klt_i": false,
+            "ps_kwn_i": false,
+            "ps_ls_i": false,
+            "ps_rd": "",
+            "ps_sm_i": false,
+            "ps_sa_i": false,
+            "ps_sb_i": false,
+            "ps_shd": false,
+            "ps_ts": {
+              "cv": {
+                "op": "set",
+                "opValue": []
+              }
+            }
+          },
+          null, null, null, null, null, null, null, null, null, null, null,
+          null, null, null, null, null, null,
+          {
+            "ps_al": 0,
+            "ps_awao": true,
+            "ps_sd": null,
+            "ps_bbtw": null,
+            "ps_bb": null,
+            "ps_bl": null,
+            "ps_br": null,
+            "ps_bt": null,
+            "ps_hd": 0,
+            "ps_hdid": "",
+            "ps_ifl": 0,
+            "ps_il": 0,
+            "ps_ir": 0,
+            "ps_klt": false,
+            "ps_kwn": false,
+            "ps_ltr": true,
+            "ps_ls": 1.15,
+            "ps_sm": 1,
+            "ps_sa": 0,
+            "ps_sb": 0,
+            "ps_al_i": false,
+            "ps_awao_i": false,
+            "ps_sd_i": false,
+            "ps_bbtw_i": false,
+            "ps_bb_i": false,
+            "ps_bl_i": false,
+            "ps_br_i": false,
+            "ps_bt_i": false,
+            "ps_ifl_i": false,
+            "ps_il_i": false,
+            "ps_ir_i": false,
+            "ps_klt_i": false,
+            "ps_kwn_i": false,
+            "ps_ls_i": false,
+            "ps_rd": "",
+            "ps_sm_i": false,
+            "ps_sa_i": false,
+            "ps_sb_i": false,
+            "ps_shd": false,
+            "ps_ts": {
+              "cv": {
+                "op": "set",
+                "opValue": []
+              }
+            }
+          },
+          null, null, null, null, null, null, null, null, null, null, null,
+          null, null, null, null, null, null, null, null, null,
+          {
+            "ps_al": 0,
+            "ps_awao": true,
+            "ps_sd": null,
+            "ps_bbtw": null,
+            "ps_bb": null,
+            "ps_bl": null,
+            "ps_br": null,
+            "ps_bt": null,
+            "ps_hd": 0,
+            "ps_hdid": "",
+            "ps_ifl": 0,
+            "ps_il": 0,
+            "ps_ir": 0,
+            "ps_klt": false,
+            "ps_kwn": false,
+            "ps_ltr": true,
+            "ps_ls": 1.15,
+            "ps_sm": 1,
+            "ps_sa": 0,
+            "ps_sb": 0,
+            "ps_al_i": false,
+            "ps_awao_i": false,
+            "ps_sd_i": false,
+            "ps_bbtw_i": false,
+            "ps_bb_i": false,
+            "ps_bl_i": false,
+            "ps_br_i": false,
+            "ps_bt_i": false,
+            "ps_ifl_i": false,
+            "ps_il_i": false,
+            "ps_ir_i": false,
+            "ps_klt_i": false,
+            "ps_kwn_i": false,
+            "ps_ls_i": false,
+            "ps_rd": "",
+            "ps_sm_i": false,
+            "ps_sa_i": false,
+            "ps_sb_i": false,
+            "ps_shd": false,
+            "ps_ts": {
+              "cv": {
+                "op": "set",
+                "opValue": []
+              }
+            }
+          },
+          null, null, null, null, null, null, null, null, null, null, null,
+          null, null, null, null, null, null,
+          {
+            "ps_al": 0,
+            "ps_awao": true,
+            "ps_sd": null,
+            "ps_bbtw": null,
+            "ps_bb": null,
+            "ps_bl": null,
+            "ps_br": null,
+            "ps_bt": null,
+            "ps_hd": 0,
+            "ps_hdid": "",
+            "ps_ifl": 0,
+            "ps_il": 0,
+            "ps_ir": 0,
+            "ps_klt": false,
+            "ps_kwn": false,
+            "ps_ltr": true,
+            "ps_ls": 1.15,
+            "ps_sm": 1,
+            "ps_sa": 0,
+            "ps_sb": 0,
+            "ps_al_i": false,
+            "ps_awao_i": false,
+            "ps_sd_i": false,
+            "ps_bbtw_i": false,
+            "ps_bb_i": false,
+            "ps_bl_i": false,
+            "ps_br_i": false,
+            "ps_bt_i": false,
+            "ps_ifl_i": false,
+            "ps_il_i": false,
+            "ps_ir_i": false,
+            "ps_klt_i": false,
+            "ps_kwn_i": false,
+            "ps_ls_i": false,
+            "ps_rd": "",
+            "ps_sm_i": false,
+            "ps_sa_i": false,
+            "ps_sb_i": false,
+            "ps_shd": false,
+            "ps_ts": {
+              "cv": {
+                "op": "set",
+                "opValue": []
+              }
+            }
+          },
+          null, null, null, null, null, null, null, null, null, null, null,
+          null, null, null, null,
+          {
+            "ps_al": 0,
+            "ps_awao": true,
+            "ps_sd": null,
+            "ps_bbtw": null,
+            "ps_bb": null,
+            "ps_bl": null,
+            "ps_br": null,
+            "ps_bt": null,
+            "ps_hd": 0,
+            "ps_hdid": "",
+            "ps_ifl": 0,
+            "ps_il": 0,
+            "ps_ir": 0,
+            "ps_klt": false,
+            "ps_kwn": false,
+            "ps_ltr": true,
+            "ps_ls": 1.15,
+            "ps_sm": 1,
+            "ps_sa": 0,
+            "ps_sb": 0,
+            "ps_al_i": false,
+            "ps_awao_i": false,
+            "ps_sd_i": false,
+            "ps_bbtw_i": false,
+            "ps_bb_i": false,
+            "ps_bl_i": false,
+            "ps_br_i": false,
+            "ps_bt_i": false,
+            "ps_ifl_i": false,
+            "ps_il_i": false,
+            "ps_ir_i": false,
+            "ps_klt_i": false,
+            "ps_kwn_i": false,
+            "ps_ls_i": false,
+            "ps_rd": "",
+            "ps_sm_i": false,
+            "ps_sa_i": false,
+            "ps_sb_i": false,
+            "ps_shd": false,
+            "ps_ts": {
+              "cv": {
+                "op": "set",
+                "opValue": []
+              }
+            }
+          }
+        ]
+      },
+      {
+        "stsl_type": "row",
+        "stsl_styles": []
+      },
+      {
+        "stsl_type": "suppress_feature",
+        "stsl_styles": [
+          {
+            "sfs_sst": false
+          }
+        ]
+      },
+      {
+        "stsl_type": "tbl",
+        "stsl_styles": []
+      },
+      {
+        "stsl_type": "text",
+        "stsl_styles": [
+          {
+            "ts_bd": false,
+            "ts_fs": 11,
+            "ts_ff": "Arial",
+            "ts_it": false,
+            "ts_sc": false,
+            "ts_st": false,
+            "ts_tw": 400,
+            "ts_un": false,
+            "ts_va": "nor",
+            "ts_bgc2": {
+              "clr_type": 0,
+              "hclr_color": null
+            },
+            "ts_fgc2": {
+              "clr_type": 0,
+              "hclr_color": "#000000"
+            },
+            "ts_bd_i": false,
+            "ts_fs_i": false,
+            "ts_ff_i": false,
+            "ts_it_i": false,
+            "ts_sc_i": false,
+            "ts_st_i": false,
+            "ts_un_i": false,
+            "ts_va_i": false,
+            "ts_bgc2_i": false,
+            "ts_fgc2_i": false
+          },
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          {
+            "ts_bd": true,
+            "ts_fs": 11,
+            "ts_ff": "Arial",
+            "ts_it": true,
+            "ts_sc": false,
+            "ts_st": false,
+            "ts_tw": 400,
+            "ts_un": true,
+            "ts_va": "nor",
+            "ts_bgc2": {
+              "clr_type": 0,
+              "hclr_color": null
+            },
+            "ts_fgc2": {
+              "clr_type": 0,
+              "hclr_color": "#000000"
+            },
+            "ts_bd_i": false,
+            "ts_fs_i": false,
+            "ts_ff_i": false,
+            "ts_it_i": false,
+            "ts_sc_i": false,
+            "ts_st_i": false,
+            "ts_un_i": false,
+            "ts_va_i": false,
+            "ts_bgc2_i": false,
+            "ts_fgc2_i": false
+          },
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          {
+            "ts_bd": true,
+            "ts_fs": 11,
+            "ts_ff": "Arial",
+            "ts_it": false,
+            "ts_sc": false,
+            "ts_st": false,
+            "ts_tw": 400,
+            "ts_un": false,
+            "ts_va": "nor",
+            "ts_bgc2": {
+              "clr_type": 0,
+              "hclr_color": null
+            },
+            "ts_fgc2": {
+              "clr_type": 0,
+              "hclr_color": "#000000"
+            },
+            "ts_bd_i": false,
+            "ts_fs_i": false,
+            "ts_ff_i": false,
+            "ts_it_i": false,
+            "ts_sc_i": false,
+            "ts_st_i": false,
+            "ts_un_i": false,
+            "ts_va_i": false,
+            "ts_bgc2_i": false,
+            "ts_fgc2_i": false
+          },
+          null,
+          {
+            "ts_bd": false,
+            "ts_fs": 11,
+            "ts_ff": "Arial",
+            "ts_it": false,
+            "ts_sc": false,
+            "ts_st": false,
+            "ts_tw": 400,
+            "ts_un": false,
+            "ts_va": "nor",
+            "ts_bgc2": {
+              "clr_type": 0,
+              "hclr_color": null
+            },
+            "ts_fgc2": {
+              "clr_type": 0,
+              "hclr_color": "#000000"
+            },
+            "ts_bd_i": false,
+            "ts_fs_i": false,
+            "ts_ff_i": false,
+            "ts_it_i": false,
+            "ts_sc_i": false,
+            "ts_st_i": false,
+            "ts_un_i": false,
+            "ts_va_i": false,
+            "ts_bgc2_i": false,
+            "ts_fgc2_i": false
+          },
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          {
+            "ts_bd": true,
+            "ts_fs": 11,
+            "ts_ff": "Arial",
+            "ts_it": false,
+            "ts_sc": false,
+            "ts_st": false,
+            "ts_tw": 400,
+            "ts_un": false,
+            "ts_va": "nor",
+            "ts_bgc2": {
+              "clr_type": 0,
+              "hclr_color": null
+            },
+            "ts_fgc2": {
+              "clr_type": 0,
+              "hclr_color": "#000000"
+            },
+            "ts_bd_i": false,
+            "ts_fs_i": false,
+            "ts_ff_i": false,
+            "ts_it_i": false,
+            "ts_sc_i": false,
+            "ts_st_i": false,
+            "ts_un_i": false,
+            "ts_va_i": false,
+            "ts_bgc2_i": false,
+            "ts_fgc2_i": false
+          },
+          null,
+          null,
+          null,
+          null,
+          null,
+          {
+            "ts_bd": true,
+            "ts_fs": 11,
+            "ts_ff": "Arial",
+            "ts_it": true,
+            "ts_sc": false,
+            "ts_st": false,
+            "ts_tw": 400,
+            "ts_un": false,
+            "ts_va": "nor",
+            "ts_bgc2": {
+              "clr_type": 0,
+              "hclr_color": null
+            },
+            "ts_fgc2": {
+              "clr_type": 0,
+              "hclr_color": "#000000"
+            },
+            "ts_bd_i": false,
+            "ts_fs_i": false,
+            "ts_ff_i": false,
+            "ts_it_i": false,
+            "ts_sc_i": false,
+            "ts_st_i": false,
+            "ts_un_i": false,
+            "ts_va_i": false,
+            "ts_bgc2_i": false,
+            "ts_fgc2_i": false
+          },
+          null,
+          {
+            "ts_bd": false,
+            "ts_fs": 11,
+            "ts_ff": "Arial",
+            "ts_it": true,
+            "ts_sc": false,
+            "ts_st": false,
+            "ts_tw": 400,
+            "ts_un": false,
+            "ts_va": "nor",
+            "ts_bgc2": {
+              "clr_type": 0,
+              "hclr_color": null
+            },
+            "ts_fgc2": {
+              "clr_type": 0,
+              "hclr_color": "#000000"
+            },
+            "ts_bd_i": false,
+            "ts_fs_i": false,
+            "ts_ff_i": false,
+            "ts_it_i": false,
+            "ts_sc_i": false,
+            "ts_st_i": false,
+            "ts_un_i": false,
+            "ts_va_i": false,
+            "ts_bgc2_i": false,
+            "ts_fgc2_i": false
+          },
+          null,
+          null,
+          {
+            "ts_bd": false,
+            "ts_fs": 11,
+            "ts_ff": "Arial",
+            "ts_it": false,
+            "ts_sc": false,
+            "ts_st": false,
+            "ts_tw": 400,
+            "ts_un": false,
+            "ts_va": "nor",
+            "ts_bgc2": {
+              "clr_type": 0,
+              "hclr_color": null
+            },
+            "ts_fgc2": {
+              "clr_type": 0,
+              "hclr_color": "#000000"
+            },
+            "ts_bd_i": false,
+            "ts_fs_i": false,
+            "ts_ff_i": false,
+            "ts_it_i": false,
+            "ts_sc_i": false,
+            "ts_st_i": false,
+            "ts_un_i": false,
+            "ts_va_i": false,
+            "ts_bgc2_i": false,
+            "ts_fgc2_i": false
+          },
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          {
+            "ts_bd": false,
+            "ts_fs": 11,
+            "ts_ff": "Arial",
+            "ts_it": false,
+            "ts_sc": false,
+            "ts_st": false,
+            "ts_tw": 400,
+            "ts_un": false,
+            "ts_va": "nor",
+            "ts_bgc2": {
+              "clr_type": 0,
+              "hclr_color": null
+            },
+            "ts_fgc2": {
+              "clr_type": 0,
+              "hclr_color": "#ff0000"
+            },
+            "ts_bd_i": false,
+            "ts_fs_i": false,
+            "ts_ff_i": false,
+            "ts_it_i": false,
+            "ts_sc_i": false,
+            "ts_st_i": false,
+            "ts_un_i": false,
+            "ts_va_i": false,
+            "ts_bgc2_i": false,
+            "ts_fgc2_i": false
+          },
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          {
+            "ts_bd": false,
+            "ts_fs": 11,
+            "ts_ff": "Arial",
+            "ts_it": false,
+            "ts_sc": false,
+            "ts_st": false,
+            "ts_tw": 400,
+            "ts_un": false,
+            "ts_va": "nor",
+            "ts_bgc2": {
+              "clr_type": 0,
+              "hclr_color": null
+            },
+            "ts_fgc2": {
+              "clr_type": 0,
+              "hclr_color": "#000000"
+            },
+            "ts_bd_i": false,
+            "ts_fs_i": false,
+            "ts_ff_i": false,
+            "ts_it_i": false,
+            "ts_sc_i": false,
+            "ts_st_i": false,
+            "ts_un_i": false,
+            "ts_va_i": false,
+            "ts_bgc2_i": false,
+            "ts_fgc2_i": false
+          },
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          {
+            "ts_bd": false,
+            "ts_fs": 11,
+            "ts_ff": "Arial",
+            "ts_it": false,
+            "ts_sc": false,
+            "ts_st": false,
+            "ts_tw": 400,
+            "ts_un": false,
+            "ts_va": "nor",
+            "ts_bgc2": {
+              "clr_type": 0,
+              "hclr_color": "#ffff00"
+            },
+            "ts_fgc2": {
+              "clr_type": 0,
+              "hclr_color": "#000000"
+            },
+            "ts_bd_i": false,
+            "ts_fs_i": false,
+            "ts_ff_i": false,
+            "ts_it_i": false,
+            "ts_sc_i": false,
+            "ts_st_i": false,
+            "ts_un_i": false,
+            "ts_va_i": false,
+            "ts_bgc2_i": false,
+            "ts_fgc2_i": false
+          },
+          null,
+          null,
+          null,
+          null,
+          {
+            "ts_bd": false,
+            "ts_fs": 11,
+            "ts_ff": "Arial",
+            "ts_it": false,
+            "ts_sc": false,
+            "ts_st": false,
+            "ts_tw": 400,
+            "ts_un": false,
+            "ts_va": "nor",
+            "ts_bgc2": {
+              "clr_type": 0,
+              "hclr_color": null
+            },
+            "ts_fgc2": {
+              "clr_type": 0,
+              "hclr_color": "#000000"
+            },
+            "ts_bd_i": false,
+            "ts_fs_i": false,
+            "ts_ff_i": false,
+            "ts_it_i": false,
+            "ts_sc_i": false,
+            "ts_st_i": false,
+            "ts_un_i": false,
+            "ts_va_i": false,
+            "ts_bgc2_i": false,
+            "ts_fgc2_i": false
+          },
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          {
+            "ts_bd": false,
+            "ts_fs": 11,
+            "ts_ff": "Arial",
+            "ts_it": false,
+            "ts_sc": false,
+            "ts_st": false,
+            "ts_tw": 400,
+            "ts_un": true,
+            "ts_va": "nor",
+            "ts_bgc2": {
+              "clr_type": 0,
+              "hclr_color": null
+            },
+            "ts_fgc2": {
+              "clr_type": 0,
+              "hclr_color": "#1155cc"
+            },
+            "ts_bd_i": false,
+            "ts_fs_i": false,
+            "ts_ff_i": false,
+            "ts_it_i": false,
+            "ts_sc_i": false,
+            "ts_st_i": false,
+            "ts_un_i": false,
+            "ts_va_i": false,
+            "ts_bgc2_i": false,
+            "ts_fgc2_i": false
+          },
+          null,
+          null,
+          null,
+          {
+            "ts_bd": false,
+            "ts_fs": 11,
+            "ts_ff": "Arial",
+            "ts_it": false,
+            "ts_sc": false,
+            "ts_st": false,
+            "ts_tw": 400,
+            "ts_un": false,
+            "ts_va": "nor",
+            "ts_bgc2": {
+              "clr_type": 0,
+              "hclr_color": null
+            },
+            "ts_fgc2": {
+              "clr_type": 0,
+              "hclr_color": "#000000"
+            },
+            "ts_bd_i": false,
+            "ts_fs_i": false,
+            "ts_ff_i": false,
+            "ts_it_i": false,
+            "ts_sc_i": false,
+            "ts_st_i": false,
+            "ts_un_i": false,
+            "ts_va_i": false,
+            "ts_bgc2_i": false,
+            "ts_fgc2_i": false
+          },
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          {
+            "ts_bd": false,
+            "ts_fs": 20,
+            "ts_ff": "Arial",
+            "ts_it": false,
+            "ts_sc": false,
+            "ts_st": false,
+            "ts_tw": 400,
+            "ts_un": false,
+            "ts_va": "nor",
+            "ts_bgc2": {
+              "clr_type": 0,
+              "hclr_color": null
+            },
+            "ts_fgc2": {
+              "clr_type": 0,
+              "hclr_color": "#000000"
+            },
+            "ts_bd_i": false,
+            "ts_fs_i": false,
+            "ts_ff_i": false,
+            "ts_it_i": false,
+            "ts_sc_i": false,
+            "ts_st_i": false,
+            "ts_un_i": false,
+            "ts_va_i": false,
+            "ts_bgc2_i": false,
+            "ts_fgc2_i": false
+          },
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          {
+            "ts_bd": false,
+            "ts_fs": 16,
+            "ts_ff": "Arial",
+            "ts_it": false,
+            "ts_sc": false,
+            "ts_st": false,
+            "ts_tw": 400,
+            "ts_un": false,
+            "ts_va": "nor",
+            "ts_bgc2": {
+              "clr_type": 0,
+              "hclr_color": null
+            },
+            "ts_fgc2": {
+              "clr_type": 0,
+              "hclr_color": "#000000"
+            },
+            "ts_bd_i": false,
+            "ts_fs_i": false,
+            "ts_ff_i": false,
+            "ts_it_i": false,
+            "ts_sc_i": false,
+            "ts_st_i": false,
+            "ts_un_i": false,
+            "ts_va_i": false,
+            "ts_bgc2_i": false,
+            "ts_fgc2_i": false
+          },
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          {
+            "ts_bd": false,
+            "ts_fs": 26,
+            "ts_ff": "Arial",
+            "ts_it": false,
+            "ts_sc": false,
+            "ts_st": false,
+            "ts_tw": 400,
+            "ts_un": false,
+            "ts_va": "nor",
+            "ts_bgc2": {
+              "clr_type": 0,
+              "hclr_color": null
+            },
+            "ts_fgc2": {
+              "clr_type": 0,
+              "hclr_color": "#000000"
+            },
+            "ts_bd_i": false,
+            "ts_fs_i": false,
+            "ts_ff_i": false,
+            "ts_it_i": false,
+            "ts_sc_i": false,
+            "ts_st_i": false,
+            "ts_un_i": false,
+            "ts_va_i": false,
+            "ts_bgc2_i": false,
+            "ts_fgc2_i": false
+          },
+          null,
+          null,
+          null,
+          null,
+          null,
+          {
+            "ts_bd": false,
+            "ts_fs": 15,
+            "ts_ff": "Arial",
+            "ts_it": false,
+            "ts_sc": false,
+            "ts_st": false,
+            "ts_tw": 400,
+            "ts_un": false,
+            "ts_va": "nor",
+            "ts_bgc2": {
+              "clr_type": 0,
+              "hclr_color": null
+            },
+            "ts_fgc2": {
+              "clr_type": 0,
+              "hclr_color": "#666666"
+            },
+            "ts_bd_i": false,
+            "ts_fs_i": false,
+            "ts_ff_i": false,
+            "ts_it_i": false,
+            "ts_sc_i": false,
+            "ts_st_i": false,
+            "ts_un_i": false,
+            "ts_va_i": false,
+            "ts_bgc2_i": false,
+            "ts_fgc2_i": false
+          },
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          {
+            "ts_bd": false,
+            "ts_fs": 11,
+            "ts_ff": "Arial",
+            "ts_it": false,
+            "ts_sc": false,
+            "ts_st": false,
+            "ts_tw": 400,
+            "ts_un": false,
+            "ts_va": "nor",
+            "ts_bgc2": {
+              "clr_type": 0,
+              "hclr_color": null
+            },
+            "ts_fgc2": {
+              "clr_type": 0,
+              "hclr_color": "#000000"
+            },
+            "ts_bd_i": false,
+            "ts_fs_i": false,
+            "ts_ff_i": false,
+            "ts_it_i": false,
+            "ts_sc_i": false,
+            "ts_st_i": false,
+            "ts_un_i": false,
+            "ts_va_i": false,
+            "ts_bgc2_i": false,
+            "ts_fgc2_i": false
+          },
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          {
+            "ts_bd": false,
+            "ts_fs": 11,
+            "ts_ff": "Arial",
+            "ts_it": false,
+            "ts_sc": false,
+            "ts_st": false,
+            "ts_tw": 400,
+            "ts_un": false,
+            "ts_va": "sup",
+            "ts_bgc2": {
+              "clr_type": 0,
+              "hclr_color": null
+            },
+            "ts_fgc2": {
+              "clr_type": 0,
+              "hclr_color": "#000000"
+            },
+            "ts_bd_i": false,
+            "ts_fs_i": false,
+            "ts_ff_i": false,
+            "ts_it_i": false,
+            "ts_sc_i": false,
+            "ts_st_i": false,
+            "ts_un_i": false,
+            "ts_va_i": false,
+            "ts_bgc2_i": false,
+            "ts_fgc2_i": false
+          },
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          {
+            "ts_bd": false,
+            "ts_fs": 11,
+            "ts_ff": "Arial",
+            "ts_it": false,
+            "ts_sc": false,
+            "ts_st": false,
+            "ts_tw": 400,
+            "ts_un": false,
+            "ts_va": "sub",
+            "ts_bgc2": {
+              "clr_type": 0,
+              "hclr_color": null
+            },
+            "ts_fgc2": {
+              "clr_type": 0,
+              "hclr_color": "#000000"
+            },
+            "ts_bd_i": false,
+            "ts_fs_i": false,
+            "ts_ff_i": false,
+            "ts_it_i": false,
+            "ts_sc_i": false,
+            "ts_st_i": false,
+            "ts_un_i": false,
+            "ts_va_i": false,
+            "ts_bgc2_i": false,
+            "ts_fgc2_i": false
+          }
+        ]
+      }
+    ],
+    "dsl_metastyleslices": [
+      {
+        "stsl_type": "composing_decoration",
+        "stsl_styles": [
+          {
+            "cd_u": false,
+            "cd_bgc": {
+              "clr_type": 0,
+              "hclr_color": null
+            }
+          }
+        ]
+      },
+      {
+        "stsl_type": "composing_region",
+        "stsl_styles": [
+          {
+            "cr_c": false
+          }
+        ]
+      },
+      {
+        "stsl_type": "draft_comment",
+        "stsl_styles": [
+          {
+            "dcs_cids": {
+              "cv": {
+                "op": "set",
+                "opValue": []
+              }
+            }
+          }
+        ]
+      },
+      {
+        "stsl_type": "ignore_word",
+        "stsl_styles": [
+          {
+            "iwos_i": false
+          }
+        ]
+      },
+      {
+        "stsl_type": "revision_diff",
+        "stsl_styles": [
+          {
+            "revdiff_dt": 0,
+            "revdiff_a": "",
+            "revdiff_aid": ""
+          }
+        ]
+      },
+      {
+        "stsl_type": "smart_todo",
+        "stsl_styles": [
+          {
+            "sts_cid": null,
+            "sts_ot": null,
+            "sts_ac": null,
+            "sts_hi": {
+              "cv": {
+                "op": "set",
+                "opValue": []
+              }
+            },
+            "sts_pa": {
+              "cv": {
+                "op": "set",
+                "opValue": []
+              }
+            },
+            "sts_dm": {
+              "cv": {
+                "op": "set",
+                "opValue": []
+              }
+            }
+          }
+        ]
+      },
+      {
+        "stsl_type": "spellcheck",
+        "stsl_styles": [
+          {
+            "sc_ow": null,
+            "sc_sl": null,
+            "sc_sugg": {
+              "cv": {
+                "op": "set",
+                "opValue": []
+              }
+            },
+            "sc_sm": {
+              "cv": {
+                "op": "set",
+                "opValue": []
+              }
+            }
+          }
+        ]
+      },
+      {
+        "stsl_type": "voice_corrections",
+        "stsl_styles": [
+          {
+            "vcs_c": {
+              "cv": {
+                "op": "set",
+                "opValue": []
+              }
+            }
+          }
+        ]
+      },
+      {
+        "stsl_type": "voice_dotted_span",
+        "stsl_styles": [
+          {
+            "vdss_p": null
+          }
+        ]
+      }
+    ],
+    "dsl_suggestedinsertions": {
+      "sgsl_sugg": [
+        [],
+        null, null, null, null, null, null, null, null, null, null, null,
+        null, null, null, null, null, null, null, null, null, null, null,
+        null, null, null, null, null, null, null, null, null, null, null,
+        null, null, null, null, null, null, null, null, null, null, null,
+        null, null, null, null, null, null, null, null, null, null, null,
+        null, null, null, null, null, null, null, null, null, null, null,
+        null, null, null, null, null, null, null, null, null, null, null,
+        null, null, null, null, null, null, null, null, null, null, null,
+        null, null, null, null, null, null, null, null, null, null, null,
+        null, null, null, null, null, null, null, null, null, null, null,
+        null, null, null, null, null, null, null, null, null, null, null,
+        null, null, null, null, null, null, null, null, null, null, null,
+        null, null, null, null, null, null, null, null, null, null, null,
+        null, null, null, null,
+        [
+          "suggest.kyjxaqliug8e"
+        ],
+        null, null, null, null, null, null, null, null, null, null, null,
+        null, null, null, null, null,
+        [],
+        null, null, null, null, null, null, null, null, null, null, null,
+        null, null,
+        [
+          "suggest.ibnoqafvejzf"
+        ],
+        []
+      ]
+    },
+    "dsl_suggesteddeletions": {
+      "sgsl_sugg": [
+        []
+      ]
+    },
+    "dsl_entitypositionmap": {
+      "inline": [
+        null, null, null, null, null, null, null, null, null, null, null,
+        null, null, null, null, null, null, null, null, null, null, null,
+        null,
+        [
+          "kix.4dvgd8j6ntih"
+        ]
+      ]
+    },
+    "dsl_entitymap": {
+      "kix.4dvgd8j6ntih": {
+        "ee_eo": {
+          "eo_type": 0,
+          "i_wth": 468,
+          "i_ht": 300,
+          "eo_lco": {
+            "lc_ct": 0,
+            "lc_sci": "",
+            "lc_oi": "",
+            "lc_cs": ""
+          },
+          "eo_ml": 9,
+          "eo_mr": 9,
+          "eo_mt": 9,
+          "eo_mb": 9,
+          "eo_hb": false,
+          "eo_bo": {
+            "ln_c": "#000000",
+            "ln_w": 0,
+            "ln_s": 0
+          },
+          "eo_at": null,
+          "eo_ad": null,
+          "eo_rtd": "",
+          "i_bri": 0,
+          "i_cont": 0,
+          "i_opa": 1,
+          "i_clst": {
+            "cv": {
+              "op": "set",
+              "opValue": []
+            }
+          },
+          "i_cid": "1ilpdzBUvZ_K0khKnGp8970CDY2yqU9zrOrui8so",
+          "i_crop": {
+            "crop_oxr": 0,
+            "crop_oyr": 0,
+            "crop_wr": 1,
+            "crop_hr": 1,
+            "crop_rot": 0
+          },
+          "i_rot": 0,
+          "i_src": "https://lh3.googleusercontent.com/proxy/TProebWlNVqiqrqzrJApv6sLRpnmnwrruVHV332QlVubA3VX-WuJjHmNx84qLDBucowixZ8eiq5lbg_7h-6CufNPuoqNbSkO69sCoAekpfg9xgLZDBWNmwQN-qZRnOCvG7hmwQ=s2048"
+        }
+      },
+      "kix.r139o3ivf8cd": {
+        "le_nb": {
+          "nl_0": {
+            "b_a": 0,
+            "b_ifl": 18,
+            "b_il": 36,
+            "b_gt": 10,
+            "b_sn": 1,
+            "b_ts": {
+              "ts_bd": false,
+              "ts_fs": 11,
+              "ts_ff": "Arial",
+              "ts_it": false,
+              "ts_sc": false,
+              "ts_st": false,
+              "ts_tw": 400,
+              "ts_un": false,
+              "ts_va": "nor",
+              "ts_bgc2": {
+                "clr_type": 0,
+                "hclr_color": null
+              },
+              "ts_fgc2": {
+                "clr_type": 0,
+                "hclr_color": "#000000"
+              },
+              "ts_bd_i": true,
+              "ts_fs_i": true,
+              "ts_ff_i": true,
+              "ts_it_i": true,
+              "ts_sc_i": true,
+              "ts_st_i": true,
+              "ts_un_i": false,
+              "ts_va_i": true,
+              "ts_bgc2_i": true,
+              "ts_fgc2_i": true
+            },
+            "b_gf": "%0.",
+            "b_gs": ""
+          },
+          "nl_1": {
+            "b_a": 0,
+            "b_ifl": 54,
+            "b_il": 72,
+            "b_gt": 13,
+            "b_sn": 1,
+            "b_ts": {
+              "ts_bd": false,
+              "ts_fs": 11,
+              "ts_ff": "Arial",
+              "ts_it": false,
+              "ts_sc": false,
+              "ts_st": false,
+              "ts_tw": 400,
+              "ts_un": false,
+              "ts_va": "nor",
+              "ts_bgc2": {
+                "clr_type": 0,
+                "hclr_color": null
+              },
+              "ts_fgc2": {
+                "clr_type": 0,
+                "hclr_color": "#000000"
+              },
+              "ts_bd_i": true,
+              "ts_fs_i": true,
+              "ts_ff_i": true,
+              "ts_it_i": true,
+              "ts_sc_i": true,
+              "ts_st_i": true,
+              "ts_un_i": false,
+              "ts_va_i": true,
+              "ts_bgc2_i": true,
+              "ts_fgc2_i": true
+            },
+            "b_gf": "%1.",
+            "b_gs": ""
+          },
+          "nl_2": {
+            "b_a": 2,
+            "b_ifl": 90,
+            "b_il": 108,
+            "b_gt": 15,
+            "b_sn": 1,
+            "b_ts": {
+              "ts_bd": false,
+              "ts_fs": 11,
+              "ts_ff": "Arial",
+              "ts_it": false,
+              "ts_sc": false,
+              "ts_st": false,
+              "ts_tw": 400,
+              "ts_un": false,
+              "ts_va": "nor",
+              "ts_bgc2": {
+                "clr_type": 0,
+                "hclr_color": null
+              },
+              "ts_fgc2": {
+                "clr_type": 0,
+                "hclr_color": "#000000"
+              },
+              "ts_bd_i": true,
+              "ts_fs_i": true,
+              "ts_ff_i": true,
+              "ts_it_i": true,
+              "ts_sc_i": true,
+              "ts_st_i": true,
+              "ts_un_i": false,
+              "ts_va_i": true,
+              "ts_bgc2_i": true,
+              "ts_fgc2_i": true
+            },
+            "b_gf": "%2.",
+            "b_gs": ""
+          },
+          "nl_3": {
+            "b_a": 0,
+            "b_ifl": 126,
+            "b_il": 144,
+            "b_gt": 10,
+            "b_sn": 1,
+            "b_ts": {
+              "ts_bd": false,
+              "ts_fs": 11,
+              "ts_ff": "Arial",
+              "ts_it": false,
+              "ts_sc": false,
+              "ts_st": false,
+              "ts_tw": 400,
+              "ts_un": false,
+              "ts_va": "nor",
+              "ts_bgc2": {
+                "clr_type": 0,
+                "hclr_color": null
+              },
+              "ts_fgc2": {
+                "clr_type": 0,
+                "hclr_color": "#000000"
+              },
+              "ts_bd_i": true,
+              "ts_fs_i": true,
+              "ts_ff_i": true,
+              "ts_it_i": true,
+              "ts_sc_i": true,
+              "ts_st_i": true,
+              "ts_un_i": false,
+              "ts_va_i": true,
+              "ts_bgc2_i": true,
+              "ts_fgc2_i": true
+            },
+            "b_gf": "%3.",
+            "b_gs": ""
+          },
+          "nl_4": {
+            "b_a": 0,
+            "b_ifl": 162,
+            "b_il": 180,
+            "b_gt": 13,
+            "b_sn": 1,
+            "b_ts": {
+              "ts_bd": false,
+              "ts_fs": 11,
+              "ts_ff": "Arial",
+              "ts_it": false,
+              "ts_sc": false,
+              "ts_st": false,
+              "ts_tw": 400,
+              "ts_un": false,
+              "ts_va": "nor",
+              "ts_bgc2": {
+                "clr_type": 0,
+                "hclr_color": null
+              },
+              "ts_fgc2": {
+                "clr_type": 0,
+                "hclr_color": "#000000"
+              },
+              "ts_bd_i": true,
+              "ts_fs_i": true,
+              "ts_ff_i": true,
+              "ts_it_i": true,
+              "ts_sc_i": true,
+              "ts_st_i": true,
+              "ts_un_i": false,
+              "ts_va_i": true,
+              "ts_bgc2_i": true,
+              "ts_fgc2_i": true
+            },
+            "b_gf": "%4.",
+            "b_gs": ""
+          },
+          "nl_5": {
+            "b_a": 2,
+            "b_ifl": 198,
+            "b_il": 216,
+            "b_gt": 15,
+            "b_sn": 1,
+            "b_ts": {
+              "ts_bd": false,
+              "ts_fs": 11,
+              "ts_ff": "Arial",
+              "ts_it": false,
+              "ts_sc": false,
+              "ts_st": false,
+              "ts_tw": 400,
+              "ts_un": false,
+              "ts_va": "nor",
+              "ts_bgc2": {
+                "clr_type": 0,
+                "hclr_color": null
+              },
+              "ts_fgc2": {
+                "clr_type": 0,
+                "hclr_color": "#000000"
+              },
+              "ts_bd_i": true,
+              "ts_fs_i": true,
+              "ts_ff_i": true,
+              "ts_it_i": true,
+              "ts_sc_i": true,
+              "ts_st_i": true,
+              "ts_un_i": false,
+              "ts_va_i": true,
+              "ts_bgc2_i": true,
+              "ts_fgc2_i": true
+            },
+            "b_gf": "%5.",
+            "b_gs": ""
+          },
+          "nl_6": {
+            "b_a": 0,
+            "b_ifl": 234,
+            "b_il": 252,
+            "b_gt": 10,
+            "b_sn": 1,
+            "b_ts": {
+              "ts_bd": false,
+              "ts_fs": 11,
+              "ts_ff": "Arial",
+              "ts_it": false,
+              "ts_sc": false,
+              "ts_st": false,
+              "ts_tw": 400,
+              "ts_un": false,
+              "ts_va": "nor",
+              "ts_bgc2": {
+                "clr_type": 0,
+                "hclr_color": null
+              },
+              "ts_fgc2": {
+                "clr_type": 0,
+                "hclr_color": "#000000"
+              },
+              "ts_bd_i": true,
+              "ts_fs_i": true,
+              "ts_ff_i": true,
+              "ts_it_i": true,
+              "ts_sc_i": true,
+              "ts_st_i": true,
+              "ts_un_i": false,
+              "ts_va_i": true,
+              "ts_bgc2_i": true,
+              "ts_fgc2_i": true
+            },
+            "b_gf": "%6.",
+            "b_gs": ""
+          },
+          "nl_7": {
+            "b_a": 0,
+            "b_ifl": 270,
+            "b_il": 288,
+            "b_gt": 13,
+            "b_sn": 1,
+            "b_ts": {
+              "ts_bd": false,
+              "ts_fs": 11,
+              "ts_ff": "Arial",
+              "ts_it": false,
+              "ts_sc": false,
+              "ts_st": false,
+              "ts_tw": 400,
+              "ts_un": false,
+              "ts_va": "nor",
+              "ts_bgc2": {
+                "clr_type": 0,
+                "hclr_color": null
+              },
+              "ts_fgc2": {
+                "clr_type": 0,
+                "hclr_color": "#000000"
+              },
+              "ts_bd_i": true,
+              "ts_fs_i": true,
+              "ts_ff_i": true,
+              "ts_it_i": true,
+              "ts_sc_i": true,
+              "ts_st_i": true,
+              "ts_un_i": false,
+              "ts_va_i": true,
+              "ts_bgc2_i": true,
+              "ts_fgc2_i": true
+            },
+            "b_gf": "%7.",
+            "b_gs": ""
+          },
+          "nl_8": {
+            "b_a": 2,
+            "b_ifl": 306,
+            "b_il": 324,
+            "b_gt": 15,
+            "b_sn": 1,
+            "b_ts": {
+              "ts_bd": false,
+              "ts_fs": 11,
+              "ts_ff": "Arial",
+              "ts_it": false,
+              "ts_sc": false,
+              "ts_st": false,
+              "ts_tw": 400,
+              "ts_un": false,
+              "ts_va": "nor",
+              "ts_bgc2": {
+                "clr_type": 0,
+                "hclr_color": null
+              },
+              "ts_fgc2": {
+                "clr_type": 0,
+                "hclr_color": "#000000"
+              },
+              "ts_bd_i": true,
+              "ts_fs_i": true,
+              "ts_ff_i": true,
+              "ts_it_i": true,
+              "ts_sc_i": true,
+              "ts_st_i": true,
+              "ts_un_i": false,
+              "ts_va_i": true,
+              "ts_bgc2_i": true,
+              "ts_fgc2_i": true
+            },
+            "b_gf": "%8.",
+            "b_gs": ""
+          }
+        }
+      }
+    },
+    "dsl_entitytypemap": {
+      "kix.4dvgd8j6ntih": "inline",
+      "kix.r139o3ivf8cd": "list"
+    },
+    "dsl_relateddocslices": {}
+  },
+  "autotext_content": {}
+}

--- a/packages/source-gdocs-paste/tsconfig.json
+++ b/packages/source-gdocs-paste/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist/commonjs"
+  },
+  "include": [
+    "src/**/*"
+  ]
+}


### PR DESCRIPTION
This is a prototype source to support copy/paste with minimal formatting preserved from Google Docs.

Todo:

- [ ] translator -> common atjson
- [ ] Images (this will be harder - putting in placeholders is no problem, but it's unlikely editors are adding images in google docs anyhow)
- [ ] superscript/subscript - google implements this in a weird way
- [ ] nested lists
- [ ] bulleted/numbered lists (currently only generic 'lists' without a bullet/number type are supported)
- [ ] horizontal rules / section breaks
- [ ] well-tested paragraph support
- [ ] soft line breaks
- [ ] quotations (? - not sure how to do this, as google docs doesn't natively support it to my knowledge) 
- [ ] other stuff?

n.b. that the goal of this is _not_ to have a very high-fidelity representation, so we will drop lots of formatting from Google Docs (e.g., fonts, font sizing, font colors, etc, etc).