### PR TITLE
Some tweaks to improve the gdocs source

### DIFF
--- a/packages/source-gdocs-paste/src/gdocs-parser.ts
+++ b/packages/source-gdocs-paste/src/gdocs-parser.ts
@@ -1,0 +1,33 @@
+import extractTextStyles from './text-styles';
+import extractParagraphStyles from './paragraph-styles';
+import extractListStyles from './list-styles';
+
+export default class GDocsParser {
+
+  gdocsSource: string;
+
+  constructor(gdocsSource: string) {
+    this.gdocsSource = gdocsSource;
+  }
+
+  getContent(): string {
+    return this.gdocsSource.resolved.dsl_spacers;
+  }
+
+  getAnnotations(): Annotation[] {
+    let transforms = {
+      'text': extractTextStyles,
+      'paragraph': extractParagraphStyles,
+      'list': extractListStyles
+    }
+
+    let annotations = this.gdocsSource.resolved.dsl_styleslices.map(styleSlice => {
+      if (transforms[styleSlice.stsl_type]) {
+        return transforms[styleSlice.stsl_type](styleSlice.stsl_styles, this.gdocsSource.resolved.dsl_entitymap);
+      }
+    });
+
+    return [].concat.apply([], annotations).filter(a => a !== undefined);
+  }
+
+}

--- a/packages/source-gdocs-paste/src/index.ts
+++ b/packages/source-gdocs-paste/src/index.ts
@@ -28,11 +28,15 @@ export default class extends Document {
     doc.where({ type: '-gdocs-ts_bd' }).set({ type: 'bold' });
     doc.where({ type: '-gdocs-ts_it' }).set({ type: 'italic' });
 
-    doc.where({ type: '-gdocs-ps_hd' }).set({ type: 'heading' });
-    doc.where({ type: '-gdocs-ps_hd' }).map({ attributes: { '-gdocs-level': 'level' });
+    doc.where({ type: '-gdocs-ps_hd' })
+      .set({ type: 'heading' })
+      .map({ attributes: { '-gdocs-level': 'level' });
 
     // FIXME list conversion is incomplete, needs fixing.
-    doc.where({ type: '-gdocs-list' }).set({ type: 'ordered-list' });
+    doc.where({ type: '-gdocs-list' }).set(
+      { type: 'list' },
+      { attributes: { type: 'numbered' } }
+    );
     doc.where({ type: '-gdocs-list-item' }).set({ type: 'list-item' });
     
     return doc;

--- a/packages/source-gdocs-paste/src/list-styles.ts
+++ b/packages/source-gdocs-paste/src/list-styles.ts
@@ -17,21 +17,25 @@ export default function extractListStyles(lists): Annotation[] {
 
     if (!listAnnotations[list['ls_id']]) {
       listAnnotations[list['ls_id']] = {
-        type: 'list',
-        ls_id: list['ls_id'],
+        type: '-gdocs-list',
         start: lastParagraphStart,
-        end: i
+        end: i,
+        attributes: {
+          '-gdocs-ls_id': list['ls_id']
+        }
       }
     } else {
       listAnnotations[list['ls_id']].end = i;
     }
 
     annotations.push({
-      type: 'list-item',
-      ls_nest: list['ls_nest'],
-      ls_id: list['ls_id'],
+      type: '-gdocs-list-item',
       start: lastParagraphStart,
-      end: i
+      end: i,
+      attributes: {
+        '-gdocs-ls_nest': list['ls_nest'],
+        '-gdocs-ls_id': list['ls_id']
+      }
     });
 
     lastParagraphStart = i + 1;

--- a/packages/source-gdocs-paste/src/paragraph-styles.ts
+++ b/packages/source-gdocs-paste/src/paragraph-styles.ts
@@ -42,10 +42,12 @@ export default function extractParagraphStyles(styles): Annotation[] {
 
     if (style['ps_hd'] !== 0) {
       annotations.push({
-        type: 'ps_hd',
-        level: style['ps_hd'],
+        type: '-gdocs-ps_hd',
         start: lastParagraphStart,
-        end: i
+        end: i,
+        attributes: {
+          '-gdocs-level': style['ps_hd']
+        }
       });
     }
 

--- a/packages/source-gdocs-paste/src/schema.ts
+++ b/packages/source-gdocs-paste/src/schema.ts
@@ -1,0 +1,34 @@
+export default {
+  '-gdocs-list': {
+    display: 'block',
+    attributes: [
+      '-gdocs-ls-id'
+    ]
+  },
+
+  '-gdocs-list-item': {
+    display: 'block',
+    attributes: [
+      '-gdocs-ls_nest', '-gdocs-ls_id'
+    ]
+  },
+
+  '-gdocs-ps_hd': {
+    display: 'block',
+    attributes: [
+      '-gdocs-level'
+    ]
+  }
+
+  '-gdocs-ts_bd': {
+    display: 'inline'
+  }
+
+  '-gdocs-ts_it': {
+    display: 'inline'
+  }
+
+  '-gdocs-ts_un': {
+    display: 'inline'
+  }
+}

--- a/packages/source-gdocs-paste/src/text-styles.ts
+++ b/packages/source-gdocs-paste/src/text-styles.ts
@@ -11,7 +11,7 @@ export default function extractTextStyles(styles): Annotation[] {
 
     for (let styleType of ['ts_bd', 'ts_it', 'ts_un']) {
       if (style[styleType] === true && !state[styleType]) {
-        state[styleType] = { type: styleType, start: i };
+        state[styleType] = { type: '-gdocs-' + styleType, start: i };
       } else if (style[styleType] === false && style[styleType + '_i'] === false && state[styleType]) {
         state[styleType].end = i;
         annotations.push(state[styleType]);

--- a/packages/source-gdocs-paste/test/atjson-source-gdocs-paste-test.ts
+++ b/packages/source-gdocs-paste/test/atjson-source-gdocs-paste-test.ts
@@ -1,5 +1,4 @@
 import Document from '@atjson/document';
-import { HIR } from '@atjson/hir';
 import GDocsSource from '@atjson/source-gdocs-paste';
 import * as fs from 'fs';
 import * as path from 'path';

--- a/packages/source-gdocs-paste/test/atjson-source-gdocs-paste-test.ts
+++ b/packages/source-gdocs-paste/test/atjson-source-gdocs-paste-test.ts
@@ -1,6 +1,6 @@
 import Document from '@atjson/document';
 import { HIR } from '@atjson/hir';
-import KIXSource from '@atjson/source-gdocs-paste';
+import GDocsSource from '@atjson/source-gdocs-paste';
 import * as fs from 'fs';
 import * as path from 'path';
 
@@ -18,82 +18,82 @@ describe('@atjson/source-gdocs-paste', () => {
       expect(atjson).toHaveProperty('resolved')
     });
 
-    it('does not throw an error when instantiating with KIXSource', () => {
-      expect(new KIXSource(atjson)).toBeDefined();
+    it('does not throw an error when instantiating with GDocsSource', () => {
+      expect(new GDocsSource(atjson)).toBeDefined();
     });
 
     it('correctly sets the content', () => {
-      let gdocs = new KIXSource(atjson);
-      expect(gdocs.getContent().length).toEqual(384);
-      expect(gdocs.getContent()).toMatchSnapshot();
+      let gdocs = new GDocsSource(atjson);
+      expect(gdocs.content.length).toEqual(384);
+      expect(gdocs.content).toMatchSnapshot();
     });
 
     it('extracts bold', () => {
-      let gdocs = new KIXSource(atjson);
-      let annotations = gdocs.getAnnotations().filter(a => a.type === 'ts_bd');
+      let gdocs = new GDocsSource(atjson);
+      let annotations = gdocs.annotations.filter(a => a.type === '-gdocs-ts_bd');
       expect(annotations.length).toEqual(2);
 
       let [a0, a1] = annotations;
-      expect(gdocs.getContent().substring(a0.start, a0.end)).toEqual('simple te');
-      expect(gdocs.getContent().substring(a1.start, a1.end)).toEqual('re is so');
+      expect(gdocs.content.substring(a0.start, a0.end)).toEqual('simple te');
+      expect(gdocs.content.substring(a1.start, a1.end)).toEqual('re is so');
     });
 
     it('extracts italic', () => {
-      let gdocs = new KIXSource(atjson);
-      let annotations = gdocs.getAnnotations().filter(a => a.type === 'ts_it');
+      let gdocs = new GDocsSource(atjson);
+      let annotations = gdocs.annotations.filter(a => a.type === '-gdocs-ts_it');
       expect(annotations.length).toEqual(2);
 
       let [a0, a1] = annotations;
-      expect(gdocs.getContent().substring(a0.start, a0.end)).toEqual('simple ');
-      expect(gdocs.getContent().substring(a1.start, a1.end)).toEqual('some ');
+      expect(gdocs.content.substring(a0.start, a0.end)).toEqual('simple ');
+      expect(gdocs.content.substring(a1.start, a1.end)).toEqual('some ');
     });
 
     it('extracts headings', () => {
-      let gdocs = new KIXSource(atjson);
-      let annotations = gdocs.getAnnotations().filter(a => a.type === 'ps_hd').sort((a,b) => a.start - b.start);
+      let gdocs = new GDocsSource(atjson);
+      let annotations = gdocs.annotations.filter(a => a.type === '-gdocs-ps_hd').sort((a,b) => a.start - b.start);
       expect(annotations.length).toEqual(4);
 
       let [a0, a1, a2, a3] = annotations;
 
-      expect(gdocs.getContent().substring(a0.start, a0.end)).toEqual('Heading 1');
-      expect(a0.level).toEqual(1);
+      expect(gdocs.content.substring(a0.start, a0.end)).toEqual('Heading 1');
+      expect(a0.attributes['-gdocs-level']).toEqual(1);
 
-      expect(gdocs.getContent().substring(a1.start, a1.end)).toEqual('Heading 2');
-      expect(a1.level).toEqual(2);
+      expect(gdocs.content.substring(a1.start, a1.end)).toEqual('Heading 2');
+      expect(a1.attributes['-gdocs-level']).toEqual(2);
 
-      expect(gdocs.getContent().substring(a2.start, a2.end)).toEqual('Title');
-      expect(a2.level).toEqual(100);
+      expect(gdocs.content.substring(a2.start, a2.end)).toEqual('Title');
+      expect(a2.attributes['-gdocs-level']).toEqual(100);
 
-      expect(gdocs.getContent().substring(a3.start, a3.end)).toEqual('Subtitle');
-      expect(a3.level).toEqual(101);
+      expect(gdocs.content.substring(a3.start, a3.end)).toEqual('Subtitle');
+      expect(a3.attributes['-gdocs-level']).toEqual(101);
 
     });
 
     it('extracts lists', () => {
-      let gdocs = new KIXSource(atjson);
-      let annotations = gdocs.getAnnotations().filter(a => a.type === 'list');
+      let gdocs = new GDocsSource(atjson);
+      let annotations = gdocs.annotations.filter(a => a.type === '-gdocs-list');
       expect(annotations.length).toEqual(1);
 
       let a0 = annotations[0];
       
-      expect(gdocs.getContent().substring(a0.start, a0.end)).toEqual('Here’s a numbered list\nAnd another item');
-      expect(a0.ls_id).toEqual('kix.r139o3ivf8cd');
+      expect(gdocs.content.substring(a0.start, a0.end)).toEqual('Here’s a numbered list\nAnd another item');
+      expect(a0.attributes['-gdocs-ls_id']).toEqual('kix.r139o3ivf8cd');
     });
 
     it('extracts list items', () => {
-      let gdocs = new KIXSource(atjson);
-      let annotations = gdocs.getAnnotations().filter(a => a.type === 'list-item');
+      let gdocs = new GDocsSource(atjson);
+      let annotations = gdocs.annotations.filter(a => a.type === '-gdocs-list-item');
       expect(annotations.length).toEqual(2);
 
       let [a0, a1] = annotations;
 
-      expect(gdocs.getContent().substring(a0.start, a0.end)).toEqual('Here’s a numbered list');
-      expect(a0.ls_id).toEqual('kix.r139o3ivf8cd');
-      expect(a0.ls_nest).toEqual(0);
+      expect(gdocs.content.substring(a0.start, a0.end)).toEqual('Here’s a numbered list');
+      expect(a0.attributes['-gdocs-ls_id']).toEqual('kix.r139o3ivf8cd');
+      expect(a0.attributes['-gdocs-ls_nest']).toEqual(0);
 
-      expect(gdocs.getContent().substring(a1.start, a1.end)).toEqual('And another item');
-      expect(a1.ls_id).toEqual('kix.r139o3ivf8cd');
-      expect(a1.ls_nest).toEqual(0);
+      expect(gdocs.content.substring(a1.start, a1.end)).toEqual('And another item');
+      expect(a1.attributes['-gdocs-ls_id']).toEqual('kix.r139o3ivf8cd');
+      expect(a1.attributes['-gdocs-ls_nest']).toEqual(0);
     });
 
     it('extracts images');

--- a/packages/source-gdocs-paste/test/atjson-source-gdocs-translator-test.ts
+++ b/packages/source-gdocs-paste/test/atjson-source-gdocs-translator-test.ts
@@ -1,0 +1,40 @@
+import GDocsSource from '@atjson/source-gdocs-paste';
+import * as fs from 'fs';
+import * as path from 'path';
+
+describe('@atjson/source-gdocs-paste', () => {
+  var atjson;
+
+  beforeAll(() => {
+    let fixturePath = path.join(__dirname, 'fixtures', 'complex.json');
+    let rawJSON = JSON.parse(fs.readFileSync(fixturePath));
+    let gdocs = new GDocsSource(rawJSON);
+    atjson = gdocs.toCommonSchema();
+  });
+
+  it('correctly converts -gdocs-ts_bd to bold', () => {
+    let bolds = atjson.annotations.filter(a => a.type === 'bold');
+    expect(bolds.length).toEqual(2);
+  });
+
+  it('correctly converts italic', () => {
+    let italics = atjson.annotations.filter(a => a.type === 'italic');
+    expect(italics.length).toEqual(2);
+  });
+
+  it('correctly converts headings', () => {
+    let headings = atjson.annotations.filter(a => a.type === 'heading');
+    expect(headings.length).toEqual(4);
+    expect(headings.map(h => h.attributes.level)).toEqual([1, 2, 100, 101]);
+  });
+
+  it('correctly converts lists', () => {
+    let lists = atjson.annotations.filter(a => a.type === 'list');
+    expect(lists.length).toEqual(1);
+  });
+
+  it('correctly converts list-items', () => {
+    let listItems = atjson.annotations.filter(a => a.type === 'list-item');
+    expect(listItems.length).toEqual(2);
+  });
+});


### PR DESCRIPTION
Move gdocs source into better alignment with current sources, use -gdocs- prefixes, and add a toCommonSchema translator