### PR TITLE
Fix ambiguous bold italic

### DIFF
--- a/packages/renderer-commonmark/src/index.ts
+++ b/packages/renderer-commonmark/src/index.ts
@@ -56,10 +56,16 @@ function getNumberOfRequiredBackticks(text: string) {
 function render(renderer: CommonMarkRenderer, node: HIRNode, parent?: HIRNode, index?: number): string {
   if (index > 0) {
     node.previous = parent.children[index - 1];
+  } else {
+    node.previous = null;
   }
+
   if (parent && index < parent.children.length) {
     node.next = parent.children[index + 1];
+  } else {
+    node.next = null;
   }
+
   node.parent = parent;
   node.children = node.children();
 

--- a/packages/renderer-commonmark/src/index.ts
+++ b/packages/renderer-commonmark/src/index.ts
@@ -69,27 +69,27 @@ function render(renderer: CommonMarkRenderer, node: HIRNode, parent?: HIRNode, i
   node.parent = parent;
   node.children = node.children();
 
+  let generator;
   if (renderer[node.type]) {
-    let generator = renderer[node.type](node, parent);
+    generator = renderer[node.type](node, parent);
     let result = generator.next();
     if (result.done) {
       return result.value;
     }
-    return generator.next(node.children.map((childNode: HIRNode, idx: number) => {
-      if (childNode.type === 'text' && typeof childNode.text === 'string') {
-        return renderer.text(childNode.text);
-      } else {
-        return render(renderer, childNode, node, idx);
-      }
-    }).join('')).value;
+  }
+
+  let fragment = node.children.map((childNode: HIRNode, idx: number) => {
+    if (childNode.type === 'text' && typeof childNode.text === 'string') {
+      return renderer.text(childNode.text);
+    } else {
+      return render(renderer, childNode, node, idx);
+    }
+  }).join('');
+
+  if (generator) {
+    return generator.next(fragment).value;
   } else {
-    return node.children.map((childNode: HIRNode, idx: number) => {
-      if (childNode.type === 'text' && typeof childNode.text === 'string') {
-        return renderer.text(childNode.text);
-      } else {
-        return render(renderer, childNode, node, idx);
-      }
-    }).join('');
+    return fragment;
   }
 }
 

--- a/packages/renderer-commonmark/test/commonmark-test.ts
+++ b/packages/renderer-commonmark/test/commonmark-test.ts
@@ -227,4 +227,31 @@ After all the lists
     let renderer = new CommonMarkRenderer();
     expect(renderer.render(document)).toBe('This is **bold** text and a [link](https://example.com).');
   });
+
+  test('unambiguous nesting of bold and italic', () => {
+    let document = new Document({
+      content: '\uFFFCbold then italic\uFFFC \uFFFCitalic then bold\uFFFC',
+      annotations: [{
+        type: 'parse-token', start: 0, end: 1
+      }, {
+        type: 'bold', start: 0, end: 18
+      }, {
+        type: 'italic', start: 1, end: 17
+      }, {
+        type: 'parse-token', start: 17, end: 18
+      }, {
+        type: 'parse-token', start: 19, end: 20
+      }, {
+        type: 'italic', start: 19, end: 37
+      }, {
+        type: 'bold', start: 20, end: 36
+      }, {
+        type: 'parse-token', start: 36, end: 37
+      }],
+      schema
+    });
+
+    let renderer = new CommonMarkRenderer();
+    expect(renderer.render(document)).toBe('**_bold then italic_** *__italic then bold__*');
+  });
 });


### PR DESCRIPTION
This refactors renderer-commonmark to use HIRNodes directly so we have more context about what children / parents / sibling nodes are for annotations.

It's a bit messier, but it's fortunately a bit less opaque, since all the code lives in the file.