### PR TITLE
<text-selection> & <text-input>

### DIFF
--- a/packages/editor/demo.ts
+++ b/packages/editor/demo.ts
@@ -14,12 +14,11 @@ if (module.hot) {
 }
 
 let doc = new Document({
-  content: 'Hello, world',
-  annotations: [{
-    type: 'bold',
-    start: 0,
-    end: 5
-  }]
+  content: 'Some text that is both bold and italic plus something after.',
+  annotations: [
+    { type: 'bold', start: 23, end: 31 },
+    { type: 'italic', start: 28, end: 38 }
+  ]
 });
 
 let editor = document.createElement('text-editor');

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -1,65 +1,11 @@
 import { HIR } from '@atjson/hir';
 import events from './mixins/events';
 import './text-selection';
+import './text-input';
 
 const TEXT_NODE_TYPE = 3;
 
 type Element = TextNode | HTMLElement;
-
-function getNodeAndOffset(node: Element | null, offset: number): { node: Element | null, offset: number } | never {
-  if (node == null) {
-    return { node: null, offset };
-  } else if (node.nodeType === TEXT_NODE_TYPE) {
-    return { node, offset };
-  } else if (node.childNodes.length > 0) {
-    let offsetNode = node.childNodes[offset];
-
-    // If the offset node has a single child node,
-    // use that node instead of the parent
-    if (offsetNode.nodeType !== TEXT_NODE_TYPE &&
-        offsetNode.childNodes.length === 1) {
-      offsetNode = offsetNode.childNodes[0];
-    }
-
-    // The offset node is a text node; quickly return
-    if (offsetNode.nodeType === TEXT_NODE_TYPE) {
-      return { node: offsetNode, offset: 0 };
-
-    // Find the closest text node and return that
-    } else if (!offsetNode.hasChildNodes()) {
-      let adjustedOffset = offset - 1;
-
-      // Look for the nearest preceding text node
-      while (offsetNode.nodeType !== TEXT_NODE_TYPE &&
-             adjustedOffset > 0) {
-        offsetNode = node.childNodes[adjustedOffset--];
-      }
-
-      if (offsetNode.nodeType === TEXT_NODE_TYPE) {
-        offset = offsetNode.length;
-
-      // Look for the next text node following the offset
-      } else {
-        adjustedOffset = offset;
-        offset = 0;
-        while (offsetNode.nodeType !== TEXT_NODE_TYPE &&
-               adjustedOffset < node.childNodes.length) {
-          offsetNode = node.childNodes[adjustedOffset++];
-        }
-      }
-
-      if (offsetNode.nodeType !== TEXT_NODE_TYPE) {
-        throw new Error("A node / offset pair couldn't be found for the selection.");
-      } else {
-        return { node: offsetNode, offset };
-      }
-    } else {
-      throw new Error("The selection for this node is ambiguous- we received a node with child nodes, but expected to get a leaf node");
-    }
-  } else {
-    return { node: null, offset };
-  }
-}
 
 function compile(editor: Editor, hir: Map<Element, HIRNode>, nodes: HIRNode[]): Element[] {
   return nodes.map((node: HIRNode) => {
@@ -79,10 +25,11 @@ function compile(editor: Editor, hir: Map<Element, HIRNode>, nodes: HIRNode[]): 
 }
 
 export default class Editor extends events(HTMLElement) {
-  static template = '<text-selection><div class="editor" contenteditable></div></text-selection><hr><div class="output"></div>';
+  static template = '<text-input><text-selection><div class="editor" contenteditable></div></text-selection></text-input><hr><div class="output"></div>';
   static events = {
-    'beforeinput': 'beforeinput',
-    'change text-selection': 'updateSelection'
+    'change text-selection'(evt) {
+      this.selection = evt.detail;
+    }
   };
 
   text({ text }) {
@@ -105,50 +52,6 @@ export default class Editor extends events(HTMLElement) {
     return document.createElement('br');
   }
 
-  beforeinput(evt) {
-    let ranges = evt.getTargetRanges();
-    let editor = this.querySelector('.editor');
-
-    let base = getNodeAndOffset(ranges[0].startContainer, ranges[0].startOffset);
-    let extent = getNodeAndOffset(ranges[0].endContainer, ranges[0].endOffset);
-    let start = editor.hir.get(base.node).start + base.offset;
-    let end = editor.hir.get(extent.node).end + extent.offset;
-
-    switch (evt.inputType) {
-    case 'insertText':
-      this.document.insertText(start, evt.data);
-      break;
-    case 'insertLineBreak':
-      this.document.insertText(start, '\u2028', true);
-      this.document.addAnnotations({
-        type: 'line-break',
-        start: start,
-        end: end + 1
-      });
-      break;
-    case 'formatBold':
-      this.document.addAnnotations({
-        type: 'bold',
-        start,
-        end
-      });
-    case 'insertParagraph':
-      this.document.insertText(start, '\n', true);
-      this.document.addAnnotations({
-        type: 'paragraph',
-        start: end + 1,
-        end: end + 1
-      });
-      break;
-    case 'deleteContentBackward':
-    case 'deleteContentForward':
-      this.document.deleteText({ start, end });
-      break;
-    }
-
-    this.render(this.querySelector('.output'));
-  }
-
   render(editor) {
     editor.innerHTML = '';
     editor.hir = new Map<Element, HIRNode>();
@@ -157,11 +60,6 @@ export default class Editor extends events(HTMLElement) {
     children.forEach((element: Element) => {
       editor.appendChild(element);
     });
-  }
-
-  updateSelection(evt) {
-    console.log(evt.detail);
-    this.cursor = evt.detail;
   }
 
   connectedCallback() {

--- a/packages/editor/src/text-input.ts
+++ b/packages/editor/src/text-input.ts
@@ -1,0 +1,93 @@
+import events from './mixins/events';
+
+type Constructor<T = {}> = new (...args: any[]) => T;
+
+const supports = {
+  beforeinput: InputEvent.prototype.hasOwnProperty('inputType')
+};
+
+function getRangeFrom() {
+
+}
+
+/**
+ * The keyboard mixin normalizes keyboard input across browsers.
+ * This is due to varying levels of support by browser vendors
+ * of different Web APIs. The Input Events API provides a fairly
+ * robust set of events that we can use to correctly detect input
+ * from people fluent in CJK languages (Chinese, Japanese, and Korean).
+ * These languages share a feature that _most_ input methods are
+ * done through a series of characters.
+ *
+ * For example, in Japanese, the following sequence of roman
+ * characters will result in the following set of text:
+ *
+ * | w | wa | wat | wata | watas | watash | watashi |
+ * | w | わ | わt | わた | わたs | わたsh | 私      |
+ *
+ * This results in text that does not map 1:1 to the keys that
+ * the person typed on their keyboard.
+ *
+ * This is the same series of events that we receive from
+ * autocorrect and predictive text keyboards.
+ *
+ * Our approach here is to do the best we can to get the most
+ * accurate set of events from the user's keyboard. We can only
+ * promise accuracy to the level of what is provided by the
+ * fidelity of the web API that's available for use in the browser.
+ */
+class TextInput extends events(HTMLElement) {
+  static events = {
+    'beforeinput': 'beforeinput',
+    'change text-selection'(evt) {
+      this.selection = evt.detail;
+    }
+    'clear text-selection'() {
+      this.selection = null;
+    }
+  };
+  private selection?: { start: number, end: number, collapsed: boolean } | null;
+
+  beforeinput(evt: InputEvent) {
+    let ranges = evt.getTargetRanges();
+    let { start, end } = this.selection;
+    console.log(this.selection);
+     debugger;
+    switch (evt.inputType) {
+    case 'insertText':
+      this.dispatchEvent(new CustomEvent('insertText', [start, evt.data]));
+      break;
+    case 'insertLineBreak':
+      this.dispatchEvent(new CustomEvent('insertText', [start, '\u2028', true]));
+      new CustomEvent('addAnnotation', {
+        type: 'line-break',
+        start,
+        end: end + 1
+      });
+      break;
+    case 'deleteContentBackward':
+      if (this.selection.collapsed) {
+        start--;
+      }
+      this.dispatchEvent(new CustomEvent('deleteText', {
+        start,
+        end
+      }));
+      break;
+    case 'deleteContentForward':
+
+      if (this.selection.collapsed) {
+        end++;
+      }
+      this.dispatchEvent(new CustomEvent('deleteText', {
+        start,
+        end
+      }));
+      break;
+    }
+  }
+};
+
+customElements.define('text-input', TextInput);
+
+export default TextInput;


### PR DESCRIPTION
This is some refactoring I did to structure the editor a bit better with regard to text input / text selection; this will allow us to expose APIs from the `<text-input>` element so they correlate to the document more easily.

I did this on the flight back from London, so it may be a bit silly here and there. Docs obviously needed, and we probably also need to find a good namespace for this editor.