### PR TITLE
Declare optional delimiter, next, parent, and previous properties on HIRNode.

### DIFF
--- a/packages/hir/src/hir-node.ts
+++ b/packages/hir/src/hir-node.ts
@@ -22,6 +22,10 @@ export default class HIRNode {
   text?: string;
 
   rank: number;
+  delimiter?: string;
+  next?: HIRNode;
+  parent?: HIRNode;
+  previous?: HIRNode;
 
   private child: HIRNode | undefined;
   private sibling: HIRNode | undefined;

--- a/packages/renderer-commonmark/src/index.ts
+++ b/packages/renderer-commonmark/src/index.ts
@@ -57,13 +57,13 @@ function render(renderer: CommonMarkRenderer, node: HIRNode, parent?: HIRNode, i
   if (index > 0) {
     node.previous = parent.children[index - 1];
   } else {
-    node.previous = null;
+    node.previous = undefined;
   }
 
   if (parent && index < parent.children.length) {
     node.next = parent.children[index + 1];
   } else {
-    node.next = null;
+    node.next = undefined;
   }
 
   node.parent = parent;
@@ -401,7 +401,7 @@ export default class CommonmarkRenderer {
       return text + '\n';
     }
     return text + '\n\n';
-  },
+  }
 
   render(document: Document): string {
     let graph = new HIR(document);


### PR DESCRIPTION
Quieting some of TypeScript's warnings.

I don't believe there should be any semantic differences on setting a node's `next`/`previous` property to `undefined` over `null`ing it out, but do give it a thought, please.