### PR TITLE
Hoist dependencies and add info to Contributing guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,11 +1,53 @@
-FIXME iirc, @tswicegood had some good pointers on good defaults for CONTRIBUTING.md
+:tipping_hand_woman: AtJSON has a [Code of Conduct](https://github.com/CondeNast-Copilot/atjson/blob/latest/CODE_OF_CONDUCT.md) that we expect all of our contributors to abide by, please check it out before contributing!
 
-This is a Lerna repository, with a bunch of sub-modules. To build and get started, do the following:
+***
 
+AtJSON is comprised of a bunch of packages, monorepo style. We use [lerna](https://lernajs.io) to manage these dependencies.
+
+:computer: To get started contributing, you'll need to install the TypeScript compiler and lerna installed on your computer:
+
+If you have `npm` installed, the following commands should suffice:
+
+```bash
+npm install -g typescript
+npm install -g lerna
 ```
-yarn install
-lerna bootstrap
-jest
+
+After installing these, clone atjson onto your computer and navigate into the project.
+
+```bash
+git clone https://github.com/CondeNast-Copilot/atjson.git
+cd atjson
 ```
 
-All of the tests should pass.
+Now install the dependencies :sparkles:
+
+```bash
+lerna bootstrap --hoist
+```
+
+And run the tests: :woman_scientist:
+
+```bash
+npm test
+```
+
+We use [:black_joker: Jest](https://facebook.github.io/jest) to run our tests, which is \~fantastic\~, if you ask us. We recommend looking at the Jest's documentation for [expectations](https://facebook.github.io/jest/docs/en/expect.html) to get started writing these. If you want to run tests for a specific package, you can do so by navigating to that package and running:
+
+```bash
+npm test
+```
+
+If you're doing some test driven development, you can continuously run this by running:
+
+```bash
+npm test -- --watch
+```
+
+And if you've caused some snapshots to become invalid, you can regenerate the snapshots by running:
+
+```bash
+npm test -- -u
+```
+
+:heart: Happy Contributing :heart:

--- a/packages/document/package.json
+++ b/packages/document/package.json
@@ -14,9 +14,5 @@
   "license": "Apache-2.0",
   "publishConfig": {
     "access": "public"
-  },
-  "devDependencies": {
-    "tslint": "^5.9.1",
-    "typescript": "^2.6.2"
   }
 }

--- a/packages/hir/package.json
+++ b/packages/hir/package.json
@@ -19,10 +19,6 @@
   "publishConfig": {
     "access": "public"
   },
-  "devDependencies": {
-    "tslint": "^5.9.1",
-    "typescript": "^2.6.2"
-  },
   "dependencies": {
     "@atjson/document": "^0.7.14"
   }

--- a/packages/renderer-commonmark/package.json
+++ b/packages/renderer-commonmark/package.json
@@ -17,9 +17,7 @@
   "devDependencies": {
     "@atjson/source-commonmark": "^0.7.14",
     "commonmark-spec": "^0.28.0",
-    "markdown-it": "^8.4.1",
-    "tslint": "^5.9.1",
-    "typescript": "^2.6.2"
+    "markdown-it": "^8.4.1"
   },
   "dependencies": {
     "@atjson/document": "^0.7.14",

--- a/packages/renderer-hir/package.json
+++ b/packages/renderer-hir/package.json
@@ -14,10 +14,6 @@
   "publishConfig": {
     "access": "public"
   },
-  "devDependencies": {
-    "tslint": "^5.9.1",
-    "typescript": "^2.6.2"
-  },
   "dependencies": {
     "@atjson/document": "^0.7.14",
     "@atjson/hir": "^0.7.14"

--- a/packages/renderer-plain-text/package.json
+++ b/packages/renderer-plain-text/package.json
@@ -17,10 +17,7 @@
   "devDependencies": {
     "@atjson/document": "^0.7.14",
     "@atjson/hir": "^0.7.14",
-    "@atjson/source-html": "^0.7.14",
-    "parse5": "^4.0.0",
-    "tslint": "^5.9.1",
-    "typescript": "^2.6.2"
+    "@atjson/source-html": "^0.7.14"
   },
   "dependencies": {
     "@atjson/renderer-hir": "^0.7.14"

--- a/packages/renderer-react/package.json
+++ b/packages/renderer-react/package.json
@@ -19,9 +19,7 @@
     "@atjson/hir": "^0.7.14",
     "@types/react": "^16.0.36",
     "@types/react-dom": "^16.0.3",
-    "react-dom": "^16.2.0",
-    "tslint": "^5.9.1",
-    "typescript": "^2.6.2"
+    "react-dom": "^16.2.0"
   },
   "dependencies": {
     "@atjson/renderer-hir": "^0.7.14",

--- a/packages/source-commonmark/package.json
+++ b/packages/source-commonmark/package.json
@@ -18,8 +18,7 @@
     "@atjson/hir": "^0.7.14",
     "@atjson/renderer-hir": "^0.7.14",
     "commonmark": "^0.28.1",
-    "commonmark-spec": "^0.28.0",
-    "typescript": "^2.4.2"
+    "commonmark-spec": "^0.28.0"
   },
   "dependencies": {
     "@atjson/document": "^0.7.14",
@@ -28,6 +27,6 @@
     "@types/entities": "^1.1.0",
     "@types/markdown-it": "^0.0.4",
     "entities": "^1.1.1",
-    "markdown-it": "^8.4.0"
+    "markdown-it": "^8.4.1"
   }
 }

--- a/packages/source-gdocs-paste/package.json
+++ b/packages/source-gdocs-paste/package.json
@@ -14,9 +14,6 @@
   "publishConfig": {
     "access": "public"
   },
-  "devDependencies": {
-    "typescript": "^2.6.2"
-  },
   "dependencies": {
     "@atjson/document": "^0.7.14",
     "@atjson/schema": "^0.7.14"

--- a/packages/source-html/package.json
+++ b/packages/source-html/package.json
@@ -17,8 +17,7 @@
   "devDependencies": {
     "@atjson/hir": "^0.7.14",
     "@atjson/renderer-hir": "^0.7.14",
-    "@types/node": "^9.6.5",
-    "typescript": "^2.6.2"
+    "@types/node": "^9.6.5"
   },
   "dependencies": {
     "@atjson/document": "^0.7.14",

--- a/packages/source-html/tsconfig.json
+++ b/packages/source-html/tsconfig.json
@@ -4,7 +4,7 @@
     "baseUrl": ".",
     "outDir": "./dist/commonjs",
     "paths": {
-      "parse5": ["./node_modules/parse5/lib/index.d.ts"]
+      "parse5": ["../../node_modules/parse5/lib/index.d.ts"]
     }
   },
   "include": [


### PR DESCRIPTION
I'm fiddling with options to prevent any further busted npm publishes. This time it's using `lerna bootstrap --hoist`.

Also, please review the ✨\~new\~:sparkles: [contributing guidelines](https://github.com/CondeNast-Copilot/atjson/blob/0718a15ac02280b57a5e938e191b5c629f9b5011/CONTRIBUTING.md).