### PR TITLE
Fix markup around non-breaking spaces and unicode whitespace characters

### DIFF
--- a/packages/@atjson/renderer-commonmark/src/index.ts
+++ b/packages/@atjson/renderer-commonmark/src/index.ts
@@ -5,9 +5,14 @@ export function* split(): Iterable<any> {
   let text = yield;
   let start = 0;
   let end = text.length;
+  let match;
 
-  while (text[start] === ' ' && start < end) { start++; }
-  while (text[end - 1] === ' ' && end > start) { end--; }
+  while ((match = text.slice(start).match(/^(\s|&nbsp;){1}/)) && start < end) {
+    start += match[1].length;
+  }
+  while ((match = text.slice(0, end).match(/(\s|&nbsp;){1}$/)) && end > start) {
+    end -= match[1].length;
+  }
 
   return [
     text.slice(0, start),

--- a/packages/@atjson/renderer-commonmark/test/commonmark-test.ts
+++ b/packages/@atjson/renderer-commonmark/test/commonmark-test.ts
@@ -269,4 +269,25 @@ After all the lists
     let renderer = new CommonMarkRenderer();
     expect(renderer.render(document)).toBe('Some formatting on empty spaces');
   });
+
+  test('non-breaking spaces don\'t recieve formatting', () => {
+    let document = new Document({
+      content: '\u00A0\ntext\n',
+      annotations: [{
+        type: 'bold', start: 0, end: 7
+      }, {
+        type: 'paragraph', start: 0, end: 2
+      }, {
+        type: 'parse-token', start: 1, end: 2
+      }, {
+        type: 'paragraph', start: 2, end: 7
+      }, {
+        type: 'parse-token', start: 6, end: 7
+      }],
+      schema
+    });
+
+    let renderer = new CommonMarkRenderer();
+    expect(renderer.render(document)).toBe('&nbsp;\n\n**text**\n\n');
+  });
 });

--- a/packages/@atjson/renderer-commonmark/test/commonmark-test.ts
+++ b/packages/@atjson/renderer-commonmark/test/commonmark-test.ts
@@ -290,4 +290,25 @@ After all the lists
     let renderer = new CommonMarkRenderer();
     expect(renderer.render(document)).toBe('&nbsp;\n\n**text**\n\n');
   });
+
+  test('line feed characters don\'t recieve formatting', () => {
+    let document = new Document({
+      content: '\u000b\ntext\n',
+      annotations: [{
+        type: 'bold', start: 0, end: 7
+      }, {
+        type: 'paragraph', start: 0, end: 2
+      }, {
+        type: 'parse-token', start: 1, end: 2
+      }, {
+        type: 'paragraph', start: 2, end: 7
+      }, {
+        type: 'parse-token', start: 6, end: 7
+      }],
+      schema
+    });
+
+    let renderer = new CommonMarkRenderer();
+    expect(renderer.render(document)).toBe('\u000b\n\n**text**\n\n');
+  });
 });


### PR DESCRIPTION
Some of our editors were encountering issues where formatting would appear in their article, which would appear like:

```md
some sentence. ****

**&nbsp;**

**The actual thing that's bold**
```

It looks like this in markdown:

![screen shot 2018-04-27 at 11 56 06](https://user-images.githubusercontent.com/177701/39372397-3e319d16-4a12-11e8-8886-e7fb10461b34.png)

We would like it to look like:

```md
some sentence.

&nbsp;

**The actual thing that's bold**
```
