### PR TITLE
Recursively render sub-documents that are attributes

### DIFF
--- a/packages/@atjson/hir/test/hir-node-test.ts
+++ b/packages/@atjson/hir/test/hir-node-test.ts
@@ -1,5 +1,5 @@
-import { Annotation } from '@atjson/document';
-import { HIRNode } from '@atjson/hir';
+import { Annotation, Schema } from '@atjson/document';
+import { HIRNode } from '../src/index';
 import schema from './schema';
 import { bold, document, image, li, node, ol, paragraph } from './utils';
 
@@ -11,7 +11,7 @@ let c = node('c');
 describe('@atjson/hir/hir-node', () => {
 
   it('insert sibling simple case works', () => {
-    let hir = new HIRNode({ type: 'root', start: 0, end: 10 }, schema);
+    let hir = new HIRNode({ type: 'root', start: 0, end: 10 }, schema as Schema);
     hir.insertAnnotation({ type: 'test', start: 0, end: 5 });
     hir.insertAnnotation({ type: 'test', start: 5, end: 10 });
 
@@ -24,14 +24,14 @@ describe('@atjson/hir/hir-node', () => {
   });
 
   it('insert child simple case works', () => {
-    let hir = new HIRNode({ type: 'root', start: 0, end: 10 }, schema);
+    let hir = new HIRNode({ type: 'root', start: 0, end: 10 }, schema as Schema);
     hir.insertAnnotation({ type: 'test', start: 0, end: 5 });
 
     expect(hir.toJSON()).toEqual(document(test()));
   });
 
   it('insert text simple case works', () => {
-    let hir = new HIRNode({ type: 'root', start: 0, end: 10 }, schema);
+    let hir = new HIRNode({ type: 'root', start: 0, end: 10 }, schema as Schema);
     hir.insertAnnotation({ type: 'test', start: 0, end: 5 });
     hir.insertAnnotation({ type: 'test', start: 5, end: 10 });
 
@@ -46,7 +46,7 @@ describe('@atjson/hir/hir-node', () => {
   });
 
   it('insert text nested children case works', () => {
-    let hir = new HIRNode({ type: 'root', start: 0, end: 10 }, schema);
+    let hir = new HIRNode({ type: 'root', start: 0, end: 10 }, schema as Schema);
     hir.insertAnnotation({ type: 'a', start: 0, end: 5 });
     hir.insertAnnotation({ type: 'b', start: 2, end: 4 });
     hir.insertAnnotation({ type: 'c', start: 5, end: 10 });
@@ -62,7 +62,7 @@ describe('@atjson/hir/hir-node', () => {
   });
 
   it('out-of-order insertion of different rank nodes works', () => {
-    let hir = new HIRNode({ type: 'root', start: 0, end: 10 }, schema);
+    let hir = new HIRNode({ type: 'root', start: 0, end: 10 }, schema as Schema);
     hir.insertAnnotation({ type: 'paragraph', start: 4, end: 8 });
     hir.insertAnnotation({ type: 'ordered-list', start: 4, end: 8 });
     hir.insertAnnotation({ type: 'paragraph', start: 8, end: 10 });
@@ -85,7 +85,7 @@ describe('@atjson/hir/hir-node', () => {
   });
 
   it('insert paragraph after bold works', () => {
-    let hir = new HIRNode({ type: 'root', start: 0, end: 10 }, schema);
+    let hir = new HIRNode({ type: 'root', start: 0, end: 10 }, schema as Schema);
     hir.insertAnnotation({ type: 'bold', start: 4, end: 6 });
     hir.insertAnnotation({ type: 'paragraph', start: 0, end: 10 });
 
@@ -99,7 +99,7 @@ describe('@atjson/hir/hir-node', () => {
   });
 
   it('annotations can override display properties', () => {
-    let hir = new HIRNode({ type: 'root', start: 0, end: 10 }, schema);
+    let hir = new HIRNode({ type: 'root', start: 0, end: 10 }, schema as Schema);
     hir.insertAnnotation({ type: 'b', display: 'inline', start: 0, end: 1 });
     hir.insertAnnotation({ type: 'c', display: 'object', start: 0, end: 1 });
     hir.insertAnnotation({ type: 'a', display: 'block', start: 0, end: 1 });
@@ -112,7 +112,7 @@ describe('@atjson/hir/hir-node', () => {
   });
 
   it('correctly inserts zero-length elements at boundaries', () => {
-    let hir = new HIRNode({ type: 'root', start: 0, end: 3 }, schema);
+    let hir = new HIRNode({ type: 'root', start: 0, end: 3 }, schema as Schema);
     hir.insertAnnotation({ type: 'paragraph', start: 0, end: 3 });
     hir.insertAnnotation({ type: 'image', start: 3, end: 3 });
 

--- a/packages/@atjson/hir/test/schema.ts
+++ b/packages/@atjson/hir/test/schema.ts
@@ -1,23 +1,25 @@
+import { Display } from '@atjson/document';
+
 export default {
   'ordered-list': {
-    display: 'block'
+    display: 'block' as Display
   },
   'unordered-list': {
-    display: 'block'
+    display: 'block' as Display
   },
   'list-item': {
-    display: 'block'
+    display: 'block' as Display
   },
   'paragraph': {
-    display: 'paragraph'
+    display: 'paragraph' as Display
   },
   'bold': {
-    display: 'inline'
+    display: 'inline' as Display
   },
   'italic': {
-    display: 'inline'
+    display: 'inline' as Display
   },
   'image': {
-    display: 'object'
+    display: 'object' as Display
   }
 };

--- a/packages/@atjson/hir/test/utils.ts
+++ b/packages/@atjson/hir/test/utils.ts
@@ -10,7 +10,7 @@ function node(type: string) {
   return (...children: node[]) => {
     return {
       type,
-      attributes: undefined,
+      attributes: {},
       children
     };
   };
@@ -18,7 +18,13 @@ function node(type: string) {
 
 let bold = node('bold');
 let document = node('root');
-let image = node('image');
+let image = (attributes={}) => {
+  return {
+    type: 'image',
+    attributes,
+    children: []
+  }
+};
 let italic = node('italic');
 let li = node('list-item');
 let ol = node('ordered-list');

--- a/packages/@atjson/renderer-commonmark/src/index.ts
+++ b/packages/@atjson/renderer-commonmark/src/index.ts
@@ -59,7 +59,7 @@ function getNumberOfRequiredBackticks(text: string) {
 
 export interface Annotation {
   type: string;
-  attributes?: any;
+  attributes: any;
   previous: Annotation | null;
   next: Annotation | null;
   parent: Annotation | null;
@@ -70,7 +70,7 @@ export interface Annotation {
 function hirNodeToMarkdownNode(node: HIRNode, parent: Annotation | null): Annotation {
   let markdownNode: Annotation = {
     type: node.type,
-    attributes: node.attributes,
+    attributes: node.attributes || {},
     parent,
     previous: null,
     next: null,
@@ -93,6 +93,16 @@ function render(renderer: CommonmarkRenderer, node: Annotation, index: number): 
   if (node.parent && index < node.parent.children.length) {
     node.next = node.parent.children[index + 1];
   }
+
+  node.attributes = Object.keys(node.attributes).reduce((attrs: any, key: string) => {
+    let value = node.attributes[key];
+    if (value instanceof HIR) {
+      attrs[key] = render(renderer, hirNodeToMarkdownNode(value.rootNode, null), -1);
+    } else {
+      attrs[key] = value;
+    }
+    return attrs;
+  }, {});
 
   let factory = (renderer as any)[node.type];
   let generator;

--- a/packages/@atjson/renderer-commonmark/test/__snapshots__/commonmark-spec-test.ts.snap
+++ b/packages/@atjson/renderer-commonmark/test/__snapshots__/commonmark-spec-test.ts.snap
@@ -3,7 +3,7 @@
 exports[`ATX headings     # foo
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -21,7 +21,7 @@ Object {
 exports[`ATX headings     # foo
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -41,7 +41,7 @@ exports[`ATX headings  ### foo
    # foo
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -80,7 +80,7 @@ exports[`ATX headings  ### foo
    # foo
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -117,7 +117,7 @@ Object {
 exports[`ATX headings #                  foo                     
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -136,7 +136,7 @@ Object {
 exports[`ATX headings #                  foo                     
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -160,7 +160,7 @@ exports[`ATX headings # foo
 ###### foo
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -229,7 +229,7 @@ exports[`ATX headings # foo
 ###### foo
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -294,7 +294,7 @@ exports[`ATX headings # foo ##################################
 ##### foo ##
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -323,7 +323,7 @@ exports[`ATX headings # foo ##################################
 ##### foo ##
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -351,7 +351,7 @@ Object {
 exports[`ATX headings # foo *bar* \\*baz\\*
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -378,7 +378,7 @@ Object {
 exports[`ATX headings # foo *bar* \\*baz\\*
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -405,7 +405,7 @@ Object {
 exports[`ATX headings # foo#
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -424,7 +424,7 @@ Object {
 exports[`ATX headings # foo#
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -445,7 +445,7 @@ exports[`ATX headings ##
 ### ###
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -478,7 +478,7 @@ exports[`ATX headings ##
 ### ###
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -510,7 +510,7 @@ exports[`ATX headings ## foo ##
   ###   bar    ###
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -539,7 +539,7 @@ exports[`ATX headings ## foo ##
   ###   bar    ###
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -567,7 +567,7 @@ Object {
 exports[`ATX headings ### foo ###     
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -586,7 +586,7 @@ Object {
 exports[`ATX headings ### foo ###     
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -605,7 +605,7 @@ Object {
 exports[`ATX headings ### foo ### b
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -624,7 +624,7 @@ Object {
 exports[`ATX headings ### foo ### b
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -645,7 +645,7 @@ exports[`ATX headings ### foo \\###
 # foo \\#
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -684,7 +684,7 @@ exports[`ATX headings ### foo \\###
 # foo \\#
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -721,7 +721,7 @@ Object {
 exports[`ATX headings ####### foo
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -738,7 +738,7 @@ Object {
 exports[`ATX headings ####### foo
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -757,7 +757,7 @@ exports[`ATX headings #5 bolt
 #hashtag
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -783,7 +783,7 @@ exports[`ATX headings #5 bolt
 #hashtag
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -809,7 +809,7 @@ exports[`ATX headings ****
 ****
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -840,7 +840,7 @@ exports[`ATX headings ****
 ****
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -869,7 +869,7 @@ Object {
 exports[`ATX headings \\## foo
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -886,7 +886,7 @@ Object {
 exports[`ATX headings \\## foo
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -905,7 +905,7 @@ exports[`ATX headings Foo bar
 Bar foo
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -940,7 +940,7 @@ exports[`ATX headings Foo bar
 Bar foo
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -974,7 +974,7 @@ exports[`ATX headings foo
     # bar
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -993,7 +993,7 @@ exports[`ATX headings foo
     # bar
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -1011,7 +1011,7 @@ Object {
 exports[`Autolinks < http://foo.bar >
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -1028,7 +1028,7 @@ Object {
 exports[`Autolinks < http://foo.bar >
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -1045,7 +1045,7 @@ Object {
 exports[`Autolinks <>
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -1062,7 +1062,7 @@ Object {
 exports[`Autolinks <>
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -1079,7 +1079,7 @@ Object {
 exports[`Autolinks <MAILTO:FOO@BAR.BAZ>
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -1104,7 +1104,7 @@ Object {
 exports[`Autolinks <MAILTO:FOO@BAR.BAZ>
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -1129,7 +1129,7 @@ Object {
 exports[`Autolinks <a+b+c:d>
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -1154,7 +1154,7 @@ Object {
 exports[`Autolinks <a+b+c:d>
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -1179,7 +1179,7 @@ Object {
 exports[`Autolinks <foo+special@Bar.baz-bar0.com>
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -1204,7 +1204,7 @@ Object {
 exports[`Autolinks <foo+special@Bar.baz-bar0.com>
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -1229,7 +1229,7 @@ Object {
 exports[`Autolinks <foo.bar.baz>
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -1246,7 +1246,7 @@ Object {
 exports[`Autolinks <foo.bar.baz>
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -1263,7 +1263,7 @@ Object {
 exports[`Autolinks <foo@bar.example.com>
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -1288,7 +1288,7 @@ Object {
 exports[`Autolinks <foo@bar.example.com>
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -1313,7 +1313,7 @@ Object {
 exports[`Autolinks <foo\\+@bar.example.com>
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -1330,7 +1330,7 @@ Object {
 exports[`Autolinks <foo\\+@bar.example.com>
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -1347,7 +1347,7 @@ Object {
 exports[`Autolinks <http://../>
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -1372,7 +1372,7 @@ Object {
 exports[`Autolinks <http://../>
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -1397,7 +1397,7 @@ Object {
 exports[`Autolinks <http://example.com/\\[\\>
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -1422,7 +1422,7 @@ Object {
 exports[`Autolinks <http://example.com/\\[\\>
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -1447,7 +1447,7 @@ Object {
 exports[`Autolinks <http://foo.bar.baz/test?q=hello&id=22&boolean>
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -1472,7 +1472,7 @@ Object {
 exports[`Autolinks <http://foo.bar.baz/test?q=hello&id=22&boolean>
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -1497,7 +1497,7 @@ Object {
 exports[`Autolinks <http://foo.bar.baz>
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -1522,7 +1522,7 @@ Object {
 exports[`Autolinks <http://foo.bar.baz>
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -1547,7 +1547,7 @@ Object {
 exports[`Autolinks <http://foo.bar/baz bim>
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -1564,7 +1564,7 @@ Object {
 exports[`Autolinks <http://foo.bar/baz bim>
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -1581,7 +1581,7 @@ Object {
 exports[`Autolinks <irc://foo.bar:2233/baz>
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -1606,7 +1606,7 @@ Object {
 exports[`Autolinks <irc://foo.bar:2233/baz>
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -1631,7 +1631,7 @@ Object {
 exports[`Autolinks <localhost:5001/foo>
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -1656,7 +1656,7 @@ Object {
 exports[`Autolinks <localhost:5001/foo>
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -1681,7 +1681,7 @@ Object {
 exports[`Autolinks <m:abc>
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -1698,7 +1698,7 @@ Object {
 exports[`Autolinks <m:abc>
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -1715,7 +1715,7 @@ Object {
 exports[`Autolinks <made-up-scheme://foo,bar>
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -1740,7 +1740,7 @@ Object {
 exports[`Autolinks <made-up-scheme://foo,bar>
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -1765,7 +1765,7 @@ Object {
 exports[`Autolinks foo@bar.example.com
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -1782,7 +1782,7 @@ Object {
 exports[`Autolinks foo@bar.example.com
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -1799,7 +1799,7 @@ Object {
 exports[`Autolinks http://example.com
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -1816,7 +1816,7 @@ Object {
 exports[`Autolinks http://example.com
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -1833,7 +1833,7 @@ Object {
 exports[`Backslash escapes     \\[\\]
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -1851,7 +1851,7 @@ Object {
 exports[`Backslash escapes     \\[\\]
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -1869,7 +1869,7 @@ Object {
 exports[`Backslash escapes <a href="/bar\\/)">
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -1887,7 +1887,7 @@ Object {
 exports[`Backslash escapes <a href="/bar\\/)">
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -1905,7 +1905,7 @@ Object {
 exports[`Backslash escapes <http://example.com?find=\\*>
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -1930,7 +1930,7 @@ Object {
 exports[`Backslash escapes <http://example.com?find=\\*>
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -1957,7 +1957,7 @@ exports[`Backslash escapes [foo]
 [foo]: /bar\\* "ti\\*tle"
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -1985,7 +1985,7 @@ exports[`Backslash escapes [foo]
 [foo]: /bar\\* "ti\\*tle"
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -2011,7 +2011,7 @@ Object {
 exports[`Backslash escapes [foo](/bar\\* "ti\\*tle")
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -2037,7 +2037,7 @@ Object {
 exports[`Backslash escapes [foo](/bar\\* "ti\\*tle")
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -2063,7 +2063,7 @@ Object {
 exports[`Backslash escapes \\!\\"\\#\\$\\%\\&\\'\\(\\)\\*\\+\\,\\-\\.\\/\\:\\;\\<\\=\\>\\?\\@\\[\\\\\\]\\^\\_\\\`\\{\\|\\}\\~
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -2080,7 +2080,7 @@ Object {
 exports[`Backslash escapes \\!\\"\\#\\$\\%\\&\\'\\(\\)\\*\\+\\,\\-\\.\\/\\:\\;\\<\\=\\>\\?\\@\\[\\\\\\]\\^\\_\\\`\\{\\|\\}\\~
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -2104,7 +2104,7 @@ exports[`Backslash escapes \\*not emphasized*
 \\[foo]: /url "not a reference"
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -2135,7 +2135,7 @@ exports[`Backslash escapes \\*not emphasized*
 \\[foo]: /url "not a reference"
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -2159,7 +2159,7 @@ Object {
 exports[`Backslash escapes \\\\*emphasis*
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -2183,7 +2183,7 @@ Object {
 exports[`Backslash escapes \\\\*emphasis*
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -2207,7 +2207,7 @@ Object {
 exports[`Backslash escapes \\→\\A\\a\\ \\3\\φ\\«
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -2224,7 +2224,7 @@ Object {
 exports[`Backslash escapes \\→\\A\\a\\ \\3\\φ\\«
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -2241,7 +2241,7 @@ Object {
 exports[`Backslash escapes \`\` \\[\\\` \`\`
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -2264,7 +2264,7 @@ Object {
 exports[`Backslash escapes \`\` \\[\\\` \`\`
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -2289,7 +2289,7 @@ foo
 \`\`\`
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -2311,7 +2311,7 @@ foo
 \`\`\`
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -2333,7 +2333,7 @@ exports[`Backslash escapes ~~~
 ~~~
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -2355,7 +2355,7 @@ exports[`Backslash escapes ~~~
 ~~~
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -2376,7 +2376,7 @@ exports[`Backslash escapes foo\\
 bar
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -2400,7 +2400,7 @@ exports[`Backslash escapes foo\\
 bar
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -2430,7 +2430,7 @@ aaa
   
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -2463,7 +2463,7 @@ aaa
   
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -2491,7 +2491,7 @@ exports[`Block quotes     > # Foo
     > baz
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -2513,7 +2513,7 @@ exports[`Block quotes     > # Foo
     > baz
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -2535,7 +2535,7 @@ exports[`Block quotes    > # Foo
  > baz
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -2570,7 +2570,7 @@ exports[`Block quotes    > # Foo
  > baz
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -2603,7 +2603,7 @@ baz",
 exports[`Block quotes >
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -2618,7 +2618,7 @@ Object {
 exports[`Block quotes >
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -2635,7 +2635,7 @@ exports[`Block quotes >
 > 
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -2652,7 +2652,7 @@ exports[`Block quotes >
 > 
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -2669,7 +2669,7 @@ exports[`Block quotes >
 >  
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -2694,7 +2694,7 @@ exports[`Block quotes >
 >  
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -2719,7 +2719,7 @@ exports[`Block quotes >     code
 >    not code
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -2758,7 +2758,7 @@ exports[`Block quotes >     code
 >    not code
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -2796,7 +2796,7 @@ exports[`Block quotes >     foo
     bar
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -2829,7 +2829,7 @@ exports[`Block quotes >     foo
     bar
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -2863,7 +2863,7 @@ exports[`Block quotes > # Foo
 > baz
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -2898,7 +2898,7 @@ exports[`Block quotes > # Foo
 > baz
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -2933,7 +2933,7 @@ exports[`Block quotes > # Foo
 baz
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -2968,7 +2968,7 @@ exports[`Block quotes > # Foo
 baz
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -3002,7 +3002,7 @@ exports[`Block quotes > > > foo
 bar
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -3039,7 +3039,7 @@ exports[`Block quotes > > > foo
 bar
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -3077,7 +3077,7 @@ foo
 \`\`\`
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -3116,7 +3116,7 @@ foo
 \`\`\`
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -3154,7 +3154,7 @@ exports[`Block quotes > - foo
 - bar
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -3213,7 +3213,7 @@ exports[`Block quotes > - foo
 - bar
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -3273,7 +3273,7 @@ exports[`Block quotes > aaa
 > bbb
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -3316,7 +3316,7 @@ exports[`Block quotes > aaa
 > bbb
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -3359,7 +3359,7 @@ exports[`Block quotes > bar
 baz
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -3391,7 +3391,7 @@ exports[`Block quotes > bar
 baz
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -3423,7 +3423,7 @@ exports[`Block quotes > bar
 baz
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -3455,7 +3455,7 @@ exports[`Block quotes > bar
 baz
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -3486,7 +3486,7 @@ exports[`Block quotes > bar
 baz
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -3511,7 +3511,7 @@ exports[`Block quotes > bar
 baz
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -3537,7 +3537,7 @@ baz
 > foo
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -3564,7 +3564,7 @@ baz
 > foo
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -3591,7 +3591,7 @@ exports[`Block quotes > foo
 > bar
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -3629,7 +3629,7 @@ exports[`Block quotes > foo
 > bar
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -3666,7 +3666,7 @@ exports[`Block quotes > foo
     - bar
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -3691,7 +3691,7 @@ exports[`Block quotes > foo
     - bar
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -3717,7 +3717,7 @@ exports[`Block quotes > foo
 > bar
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -3749,7 +3749,7 @@ exports[`Block quotes > foo
 > bar
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -3780,7 +3780,7 @@ exports[`Block quotes > foo
 > bar
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -3805,7 +3805,7 @@ exports[`Block quotes > foo
 > bar
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -3830,7 +3830,7 @@ exports[`Block quotes > foo
 ---
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -3859,7 +3859,7 @@ exports[`Block quotes > foo
 ---
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -3889,7 +3889,7 @@ exports[`Block quotes ># Foo
 > baz
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -3924,7 +3924,7 @@ exports[`Block quotes ># Foo
 > baz
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -3959,7 +3959,7 @@ exports[`Block quotes >>> foo
 >>baz
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -3998,7 +3998,7 @@ exports[`Block quotes >>> foo
 >>baz
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -4036,7 +4036,7 @@ exports[`Block quotes foo
 > bar
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -4067,7 +4067,7 @@ exports[`Block quotes foo
 > bar
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -4097,7 +4097,7 @@ Object {
 exports[`Code spans *foo\`*\`
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -4121,7 +4121,7 @@ Object {
 exports[`Code spans *foo\`*\`
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -4145,7 +4145,7 @@ Object {
 exports[`Code spans <a href="\`">\`
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -4169,7 +4169,7 @@ Object {
 exports[`Code spans <a href="\`">\`
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -4193,7 +4193,7 @@ Object {
 exports[`Code spans <http://foo.bar.\`baz>\`
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -4219,7 +4219,7 @@ Object {
 exports[`Code spans <http://foo.bar.\`baz>\`
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -4245,7 +4245,7 @@ Object {
 exports[`Code spans [not a \`link](/foo\`)
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -4270,7 +4270,7 @@ Object {
 exports[`Code spans [not a \`link](/foo\`)
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -4295,7 +4295,7 @@ Object {
 exports[`Code spans \` \`\` \`
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -4318,7 +4318,7 @@ Object {
 exports[`Code spans \` \`\` \`
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -4341,7 +4341,7 @@ Object {
 exports[`Code spans \`<a href="\`">\`
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -4365,7 +4365,7 @@ Object {
 exports[`Code spans \`<a href="\`">\`
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -4389,7 +4389,7 @@ Object {
 exports[`Code spans \`<http://foo.bar.\`baz>\`
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -4413,7 +4413,7 @@ Object {
 exports[`Code spans \`<http://foo.bar.\`baz>\`
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -4439,7 +4439,7 @@ foo
 \`\`
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -4464,7 +4464,7 @@ foo
 \`\`
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -4487,7 +4487,7 @@ Object {
 exports[`Code spans \`\` foo \` bar  \`\`
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -4510,7 +4510,7 @@ Object {
 exports[`Code spans \`\` foo \` bar  \`\`
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -4533,7 +4533,7 @@ Object {
 exports[`Code spans \`\`\`foo\`\`
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -4550,7 +4550,7 @@ Object {
 exports[`Code spans \`\`\`foo\`\`
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -4567,7 +4567,7 @@ Object {
 exports[`Code spans \`a  b\`
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -4590,7 +4590,7 @@ Object {
 exports[`Code spans \`a  b\`
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -4613,7 +4613,7 @@ Object {
 exports[`Code spans \`foo
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -4630,7 +4630,7 @@ Object {
 exports[`Code spans \`foo
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -4648,7 +4648,7 @@ exports[`Code spans \`foo   bar
   baz\`
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -4672,7 +4672,7 @@ exports[`Code spans \`foo   bar
   baz\`
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -4695,7 +4695,7 @@ Object {
 exports[`Code spans \`foo \`\` bar\`
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -4718,7 +4718,7 @@ Object {
 exports[`Code spans \`foo \`\` bar\`
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -4741,7 +4741,7 @@ Object {
 exports[`Code spans \`foo\\\`bar\`
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -4765,7 +4765,7 @@ Object {
 exports[`Code spans \`foo\\\`bar\`
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -4789,7 +4789,7 @@ Object {
 exports[`Code spans \`foo\`
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -4812,7 +4812,7 @@ Object {
 exports[`Code spans \`foo\`
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -4835,7 +4835,7 @@ Object {
 exports[`Code spans \`foo\`\`bar\`\`
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -4859,7 +4859,7 @@ Object {
 exports[`Code spans \`foo\`\`bar\`\`
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -4883,7 +4883,7 @@ Object {
 exports[`Emphasis and strong emphasis *(**foo**)*
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -4914,7 +4914,7 @@ Object {
 exports[`Emphasis and strong emphasis *(**foo**)*
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -4945,7 +4945,7 @@ Object {
 exports[`Emphasis and strong emphasis *(*foo)
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -4962,7 +4962,7 @@ Object {
 exports[`Emphasis and strong emphasis *(*foo)
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -4979,7 +4979,7 @@ Object {
 exports[`Emphasis and strong emphasis *(*foo*)*
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -5010,7 +5010,7 @@ Object {
 exports[`Emphasis and strong emphasis *(*foo*)*
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -5041,7 +5041,7 @@ Object {
 exports[`Emphasis and strong emphasis ** foo bar**
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -5058,7 +5058,7 @@ Object {
 exports[`Emphasis and strong emphasis ** foo bar**
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -5075,7 +5075,7 @@ Object {
 exports[`Emphasis and strong emphasis ** is not an empty emphasis
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -5092,7 +5092,7 @@ Object {
 exports[`Emphasis and strong emphasis ** is not an empty emphasis
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -5109,7 +5109,7 @@ Object {
 exports[`Emphasis and strong emphasis **(**foo)
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -5126,7 +5126,7 @@ Object {
 exports[`Emphasis and strong emphasis **(**foo)
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -5143,7 +5143,7 @@ Object {
 exports[`Emphasis and strong emphasis **** is not an empty strong emphasis
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -5160,7 +5160,7 @@ Object {
 exports[`Emphasis and strong emphasis **** is not an empty strong emphasis
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -5177,7 +5177,7 @@ Object {
 exports[`Emphasis and strong emphasis ******foo******
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -5212,7 +5212,7 @@ Object {
 exports[`Emphasis and strong emphasis ******foo******
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -5247,7 +5247,7 @@ Object {
 exports[`Emphasis and strong emphasis ****foo*
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -5271,7 +5271,7 @@ Object {
 exports[`Emphasis and strong emphasis ****foo*
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -5295,7 +5295,7 @@ Object {
 exports[`Emphasis and strong emphasis ****foo****
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -5324,7 +5324,7 @@ Object {
 exports[`Emphasis and strong emphasis ****foo****
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -5353,7 +5353,7 @@ Object {
 exports[`Emphasis and strong emphasis ***foo* bar**
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -5383,7 +5383,7 @@ Object {
 exports[`Emphasis and strong emphasis ***foo* bar**
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -5413,7 +5413,7 @@ Object {
 exports[`Emphasis and strong emphasis ***foo**
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -5437,7 +5437,7 @@ Object {
 exports[`Emphasis and strong emphasis ***foo**
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -5461,7 +5461,7 @@ Object {
 exports[`Emphasis and strong emphasis ***foo** bar*
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -5491,7 +5491,7 @@ Object {
 exports[`Emphasis and strong emphasis ***foo** bar*
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -5521,7 +5521,7 @@ Object {
 exports[`Emphasis and strong emphasis ***foo***
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -5550,7 +5550,7 @@ Object {
 exports[`Emphasis and strong emphasis ***foo***
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -5579,7 +5579,7 @@ Object {
 exports[`Emphasis and strong emphasis **<a href="**">
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -5603,7 +5603,7 @@ Object {
 exports[`Emphasis and strong emphasis **<a href="**">
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -5628,7 +5628,7 @@ exports[`Emphasis and strong emphasis **Gomphocarpus (*Gomphocarpus physocarpus*
 *Asclepias physocarpa*)**
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -5669,7 +5669,7 @@ exports[`Emphasis and strong emphasis **Gomphocarpus (*Gomphocarpus physocarpus*
 *Asclepias physocarpa*)**
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -5709,7 +5709,7 @@ Object {
 exports[`Emphasis and strong emphasis **a<http://foo.bar/?q=**>
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -5735,7 +5735,7 @@ Object {
 exports[`Emphasis and strong emphasis **a<http://foo.bar/?q=**>
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -5762,7 +5762,7 @@ exports[`Emphasis and strong emphasis **foo
 bar**
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -5787,7 +5787,7 @@ exports[`Emphasis and strong emphasis **foo
 bar**
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -5811,7 +5811,7 @@ bar",
 exports[`Emphasis and strong emphasis **foo "*bar*" foo**
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -5842,7 +5842,7 @@ Object {
 exports[`Emphasis and strong emphasis **foo "*bar*" foo**
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -5873,7 +5873,7 @@ Object {
 exports[`Emphasis and strong emphasis **foo **bar baz**
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -5897,7 +5897,7 @@ Object {
 exports[`Emphasis and strong emphasis **foo **bar baz**
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -5921,7 +5921,7 @@ Object {
 exports[`Emphasis and strong emphasis **foo **bar****
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -5951,7 +5951,7 @@ Object {
 exports[`Emphasis and strong emphasis **foo **bar****
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -5982,7 +5982,7 @@ exports[`Emphasis and strong emphasis **foo *bar **baz**
 bim* bop**
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -6023,7 +6023,7 @@ exports[`Emphasis and strong emphasis **foo *bar **baz**
 bim* bop**
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -6063,7 +6063,7 @@ bim",
 exports[`Emphasis and strong emphasis **foo *bar* baz**
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -6094,7 +6094,7 @@ Object {
 exports[`Emphasis and strong emphasis **foo *bar* baz**
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -6125,7 +6125,7 @@ Object {
 exports[`Emphasis and strong emphasis **foo *bar***
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -6155,7 +6155,7 @@ Object {
 exports[`Emphasis and strong emphasis **foo *bar***
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -6185,7 +6185,7 @@ Object {
 exports[`Emphasis and strong emphasis **foo [*bar*](/url)**
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -6223,7 +6223,7 @@ Object {
 exports[`Emphasis and strong emphasis **foo [*bar*](/url)**
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -6261,7 +6261,7 @@ Object {
 exports[`Emphasis and strong emphasis **foo [bar](/url)**
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -6293,7 +6293,7 @@ Object {
 exports[`Emphasis and strong emphasis **foo [bar](/url)**
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -6325,7 +6325,7 @@ Object {
 exports[`Emphasis and strong emphasis **foo bar **
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -6342,7 +6342,7 @@ Object {
 exports[`Emphasis and strong emphasis **foo bar **
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -6359,7 +6359,7 @@ Object {
 exports[`Emphasis and strong emphasis **foo bar**
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -6382,7 +6382,7 @@ Object {
 exports[`Emphasis and strong emphasis **foo bar**
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -6405,7 +6405,7 @@ Object {
 exports[`Emphasis and strong emphasis **foo*
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -6429,7 +6429,7 @@ Object {
 exports[`Emphasis and strong emphasis **foo*
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -6453,7 +6453,7 @@ Object {
 exports[`Emphasis and strong emphasis **foo**
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -6476,7 +6476,7 @@ Object {
 exports[`Emphasis and strong emphasis **foo**
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -6499,7 +6499,7 @@ Object {
 exports[`Emphasis and strong emphasis **foo***
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -6523,7 +6523,7 @@ Object {
 exports[`Emphasis and strong emphasis **foo***
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -6547,7 +6547,7 @@ Object {
 exports[`Emphasis and strong emphasis **foo**bar
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -6571,7 +6571,7 @@ Object {
 exports[`Emphasis and strong emphasis **foo**bar
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -6595,7 +6595,7 @@ Object {
 exports[`Emphasis and strong emphasis **foo*bar*baz**
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -6626,7 +6626,7 @@ Object {
 exports[`Emphasis and strong emphasis **foo*bar*baz**
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -6657,7 +6657,7 @@ Object {
 exports[`Emphasis and strong emphasis *<img src="foo" title="*"/>
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -6681,7 +6681,7 @@ Object {
 exports[`Emphasis and strong emphasis *<img src="foo" title="*"/>
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -6705,7 +6705,7 @@ Object {
 exports[`Emphasis and strong emphasis *[bar*](/url)
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -6731,7 +6731,7 @@ Object {
 exports[`Emphasis and strong emphasis *[bar*](/url)
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -6757,7 +6757,7 @@ Object {
 exports[`Emphasis and strong emphasis *_foo_*
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -6786,7 +6786,7 @@ Object {
 exports[`Emphasis and strong emphasis *_foo_*
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -6815,7 +6815,7 @@ Object {
 exports[`Emphasis and strong emphasis *a \`*\`*
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -6845,7 +6845,7 @@ Object {
 exports[`Emphasis and strong emphasis *a \`*\`*
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -6876,7 +6876,7 @@ exports[`Emphasis and strong emphasis *foo
 bar*
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -6901,7 +6901,7 @@ exports[`Emphasis and strong emphasis *foo
 bar*
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -6925,7 +6925,7 @@ bar",
 exports[`Emphasis and strong emphasis *foo **bar *baz* bim** bop*
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -6964,7 +6964,7 @@ Object {
 exports[`Emphasis and strong emphasis *foo **bar *baz* bim** bop*
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -7003,7 +7003,7 @@ Object {
 exports[`Emphasis and strong emphasis *foo **bar** baz*
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -7034,7 +7034,7 @@ Object {
 exports[`Emphasis and strong emphasis *foo **bar** baz*
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -7065,7 +7065,7 @@ Object {
 exports[`Emphasis and strong emphasis *foo **bar***
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -7095,7 +7095,7 @@ Object {
 exports[`Emphasis and strong emphasis *foo **bar***
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -7125,7 +7125,7 @@ Object {
 exports[`Emphasis and strong emphasis *foo *bar baz*
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -7149,7 +7149,7 @@ Object {
 exports[`Emphasis and strong emphasis *foo *bar baz*
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -7173,7 +7173,7 @@ Object {
 exports[`Emphasis and strong emphasis *foo *bar**
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -7203,7 +7203,7 @@ Object {
 exports[`Emphasis and strong emphasis *foo *bar**
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -7233,7 +7233,7 @@ Object {
 exports[`Emphasis and strong emphasis *foo [*bar*](/url)*
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -7271,7 +7271,7 @@ Object {
 exports[`Emphasis and strong emphasis *foo [*bar*](/url)*
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -7309,7 +7309,7 @@ Object {
 exports[`Emphasis and strong emphasis *foo [bar](/url)*
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -7341,7 +7341,7 @@ Object {
 exports[`Emphasis and strong emphasis *foo [bar](/url)*
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -7373,7 +7373,7 @@ Object {
 exports[`Emphasis and strong emphasis *foo __bar *baz bim__ bam*
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -7404,7 +7404,7 @@ Object {
 exports[`Emphasis and strong emphasis *foo __bar *baz bim__ bam*
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -7435,7 +7435,7 @@ Object {
 exports[`Emphasis and strong emphasis *foo _bar* baz_
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -7459,7 +7459,7 @@ Object {
 exports[`Emphasis and strong emphasis *foo _bar* baz_
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -7484,7 +7484,7 @@ exports[`Emphasis and strong emphasis *foo bar
 *
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -7503,7 +7503,7 @@ exports[`Emphasis and strong emphasis *foo bar
 *
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -7521,7 +7521,7 @@ Object {
 exports[`Emphasis and strong emphasis *foo bar *
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -7538,7 +7538,7 @@ Object {
 exports[`Emphasis and strong emphasis *foo bar *
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -7555,7 +7555,7 @@ Object {
 exports[`Emphasis and strong emphasis *foo bar*
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -7578,7 +7578,7 @@ Object {
 exports[`Emphasis and strong emphasis *foo bar*
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -7601,7 +7601,7 @@ Object {
 exports[`Emphasis and strong emphasis *foo**
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -7625,7 +7625,7 @@ Object {
 exports[`Emphasis and strong emphasis *foo**
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -7649,7 +7649,7 @@ Object {
 exports[`Emphasis and strong emphasis *foo****
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -7673,7 +7673,7 @@ Object {
 exports[`Emphasis and strong emphasis *foo****
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -7697,7 +7697,7 @@ Object {
 exports[`Emphasis and strong emphasis *foo**bar***
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -7727,7 +7727,7 @@ Object {
 exports[`Emphasis and strong emphasis *foo**bar***
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -7757,7 +7757,7 @@ Object {
 exports[`Emphasis and strong emphasis *foo**bar**baz*
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -7788,7 +7788,7 @@ Object {
 exports[`Emphasis and strong emphasis *foo**bar**baz*
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -7819,7 +7819,7 @@ Object {
 exports[`Emphasis and strong emphasis *foo*bar
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -7843,7 +7843,7 @@ Object {
 exports[`Emphasis and strong emphasis *foo*bar
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -7867,7 +7867,7 @@ Object {
 exports[`Emphasis and strong emphasis * a *
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -7884,7 +7884,7 @@ Object {
 exports[`Emphasis and strong emphasis * a *
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -7901,7 +7901,7 @@ Object {
 exports[`Emphasis and strong emphasis _ foo bar_
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -7918,7 +7918,7 @@ Object {
 exports[`Emphasis and strong emphasis _ foo bar_
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -7935,7 +7935,7 @@ Object {
 exports[`Emphasis and strong emphasis _(__foo__)_
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -7966,7 +7966,7 @@ Object {
 exports[`Emphasis and strong emphasis _(__foo__)_
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -7997,7 +7997,7 @@ Object {
 exports[`Emphasis and strong emphasis _(_foo)
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -8014,7 +8014,7 @@ Object {
 exports[`Emphasis and strong emphasis _(_foo)
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -8031,7 +8031,7 @@ Object {
 exports[`Emphasis and strong emphasis _(_foo_)_
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -8062,7 +8062,7 @@ Object {
 exports[`Emphasis and strong emphasis _(_foo_)_
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -8093,7 +8093,7 @@ Object {
 exports[`Emphasis and strong emphasis _(bar)_.
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -8117,7 +8117,7 @@ Object {
 exports[`Emphasis and strong emphasis _(bar)_.
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -8141,7 +8141,7 @@ Object {
 exports[`Emphasis and strong emphasis _*foo*_
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -8170,7 +8170,7 @@ Object {
 exports[`Emphasis and strong emphasis _*foo*_
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -8200,7 +8200,7 @@ exports[`Emphasis and strong emphasis __
 foo bar__
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -8219,7 +8219,7 @@ exports[`Emphasis and strong emphasis __
 foo bar__
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -8237,7 +8237,7 @@ foo bar__",
 exports[`Emphasis and strong emphasis __ foo bar__
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -8254,7 +8254,7 @@ Object {
 exports[`Emphasis and strong emphasis __ foo bar__
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -8271,7 +8271,7 @@ Object {
 exports[`Emphasis and strong emphasis __ is not an empty emphasis
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -8288,7 +8288,7 @@ Object {
 exports[`Emphasis and strong emphasis __ is not an empty emphasis
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -8305,7 +8305,7 @@ Object {
 exports[`Emphasis and strong emphasis __(__foo)
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -8322,7 +8322,7 @@ Object {
 exports[`Emphasis and strong emphasis __(__foo)
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -8339,7 +8339,7 @@ Object {
 exports[`Emphasis and strong emphasis __(bar)__.
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -8363,7 +8363,7 @@ Object {
 exports[`Emphasis and strong emphasis __(bar)__.
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -8387,7 +8387,7 @@ Object {
 exports[`Emphasis and strong emphasis __<a href="__">
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -8411,7 +8411,7 @@ Object {
 exports[`Emphasis and strong emphasis __<a href="__">
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -8435,7 +8435,7 @@ Object {
 exports[`Emphasis and strong emphasis ____ is not an empty strong emphasis
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -8452,7 +8452,7 @@ Object {
 exports[`Emphasis and strong emphasis ____ is not an empty strong emphasis
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -8469,7 +8469,7 @@ Object {
 exports[`Emphasis and strong emphasis _____foo_____
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -8504,7 +8504,7 @@ Object {
 exports[`Emphasis and strong emphasis _____foo_____
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -8539,7 +8539,7 @@ Object {
 exports[`Emphasis and strong emphasis ____foo_
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -8563,7 +8563,7 @@ Object {
 exports[`Emphasis and strong emphasis ____foo_
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -8587,7 +8587,7 @@ Object {
 exports[`Emphasis and strong emphasis ____foo__ bar__
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -8617,7 +8617,7 @@ Object {
 exports[`Emphasis and strong emphasis ____foo__ bar__
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -8647,7 +8647,7 @@ Object {
 exports[`Emphasis and strong emphasis ____foo____
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -8676,7 +8676,7 @@ Object {
 exports[`Emphasis and strong emphasis ____foo____
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -8705,7 +8705,7 @@ Object {
 exports[`Emphasis and strong emphasis ___foo__
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -8729,7 +8729,7 @@ Object {
 exports[`Emphasis and strong emphasis ___foo__
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -8753,7 +8753,7 @@ Object {
 exports[`Emphasis and strong emphasis __a<http://foo.bar/?q=__>
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -8779,7 +8779,7 @@ Object {
 exports[`Emphasis and strong emphasis __a<http://foo.bar/?q=__>
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -8805,7 +8805,7 @@ Object {
 exports[`Emphasis and strong emphasis __foo __bar__ baz__
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -8836,7 +8836,7 @@ Object {
 exports[`Emphasis and strong emphasis __foo __bar__ baz__
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -8867,7 +8867,7 @@ Object {
 exports[`Emphasis and strong emphasis __foo _bar_ baz__
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -8898,7 +8898,7 @@ Object {
 exports[`Emphasis and strong emphasis __foo _bar_ baz__
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -8929,7 +8929,7 @@ Object {
 exports[`Emphasis and strong emphasis __foo bar __
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -8946,7 +8946,7 @@ Object {
 exports[`Emphasis and strong emphasis __foo bar __
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -8963,7 +8963,7 @@ Object {
 exports[`Emphasis and strong emphasis __foo bar__
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -8986,7 +8986,7 @@ Object {
 exports[`Emphasis and strong emphasis __foo bar__
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -9009,7 +9009,7 @@ Object {
 exports[`Emphasis and strong emphasis __foo, __bar__, baz__
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -9040,7 +9040,7 @@ Object {
 exports[`Emphasis and strong emphasis __foo, __bar__, baz__
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -9071,7 +9071,7 @@ Object {
 exports[`Emphasis and strong emphasis __foo_
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -9095,7 +9095,7 @@ Object {
 exports[`Emphasis and strong emphasis __foo_
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -9119,7 +9119,7 @@ Object {
 exports[`Emphasis and strong emphasis __foo_ bar_
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -9149,7 +9149,7 @@ Object {
 exports[`Emphasis and strong emphasis __foo_ bar_
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -9179,7 +9179,7 @@ Object {
 exports[`Emphasis and strong emphasis __foo__
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -9202,7 +9202,7 @@ Object {
 exports[`Emphasis and strong emphasis __foo__
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -9225,7 +9225,7 @@ Object {
 exports[`Emphasis and strong emphasis __foo___
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -9249,7 +9249,7 @@ Object {
 exports[`Emphasis and strong emphasis __foo___
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -9273,7 +9273,7 @@ Object {
 exports[`Emphasis and strong emphasis __foo__bar
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -9290,7 +9290,7 @@ Object {
 exports[`Emphasis and strong emphasis __foo__bar
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -9307,7 +9307,7 @@ Object {
 exports[`Emphasis and strong emphasis __foo__bar__baz__
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -9330,7 +9330,7 @@ Object {
 exports[`Emphasis and strong emphasis __foo__bar__baz__
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -9353,7 +9353,7 @@ Object {
 exports[`Emphasis and strong emphasis __пристаням__стремятся
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -9370,7 +9370,7 @@ Object {
 exports[`Emphasis and strong emphasis __пристаням__стремятся
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -9387,7 +9387,7 @@ Object {
 exports[`Emphasis and strong emphasis _a \`_\`_
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -9417,7 +9417,7 @@ Object {
 exports[`Emphasis and strong emphasis _a \`_\`_
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -9447,7 +9447,7 @@ Object {
 exports[`Emphasis and strong emphasis _foo [bar_](/url)
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -9473,7 +9473,7 @@ Object {
 exports[`Emphasis and strong emphasis _foo [bar_](/url)
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -9499,7 +9499,7 @@ Object {
 exports[`Emphasis and strong emphasis _foo __bar__ baz_
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -9530,7 +9530,7 @@ Object {
 exports[`Emphasis and strong emphasis _foo __bar__ baz_
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -9561,7 +9561,7 @@ Object {
 exports[`Emphasis and strong emphasis _foo _bar_ baz_
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -9592,7 +9592,7 @@ Object {
 exports[`Emphasis and strong emphasis _foo _bar_ baz_
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -9623,7 +9623,7 @@ Object {
 exports[`Emphasis and strong emphasis _foo bar _
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -9640,7 +9640,7 @@ Object {
 exports[`Emphasis and strong emphasis _foo bar _
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -9657,7 +9657,7 @@ Object {
 exports[`Emphasis and strong emphasis _foo bar_
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -9680,7 +9680,7 @@ Object {
 exports[`Emphasis and strong emphasis _foo bar_
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -9703,7 +9703,7 @@ Object {
 exports[`Emphasis and strong emphasis _foo*
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -9720,7 +9720,7 @@ Object {
 exports[`Emphasis and strong emphasis _foo*
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -9737,7 +9737,7 @@ Object {
 exports[`Emphasis and strong emphasis _foo__
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -9761,7 +9761,7 @@ Object {
 exports[`Emphasis and strong emphasis _foo__
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -9785,7 +9785,7 @@ Object {
 exports[`Emphasis and strong emphasis _foo____
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -9809,7 +9809,7 @@ Object {
 exports[`Emphasis and strong emphasis _foo____
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -9833,7 +9833,7 @@ Object {
 exports[`Emphasis and strong emphasis _foo_bar
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -9850,7 +9850,7 @@ Object {
 exports[`Emphasis and strong emphasis _foo_bar
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -9867,7 +9867,7 @@ Object {
 exports[`Emphasis and strong emphasis _foo_bar_baz_
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -9890,7 +9890,7 @@ Object {
 exports[`Emphasis and strong emphasis _foo_bar_baz_
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -9913,7 +9913,7 @@ Object {
 exports[`Emphasis and strong emphasis _пристаням_стремятся
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -9930,7 +9930,7 @@ Object {
 exports[`Emphasis and strong emphasis _пристаням_стремятся
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -9947,7 +9947,7 @@ Object {
 exports[`Emphasis and strong emphasis 5*6*78
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -9972,7 +9972,7 @@ Object {
 exports[`Emphasis and strong emphasis 5*6*78
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -9997,7 +9997,7 @@ Object {
 exports[`Emphasis and strong emphasis 5__6__78
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -10014,7 +10014,7 @@ Object {
 exports[`Emphasis and strong emphasis 5__6__78
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -10031,7 +10031,7 @@ Object {
 exports[`Emphasis and strong emphasis 5_6_78
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -10048,7 +10048,7 @@ Object {
 exports[`Emphasis and strong emphasis 5_6_78
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -10065,7 +10065,7 @@ Object {
 exports[`Emphasis and strong emphasis a * foo bar*
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -10082,7 +10082,7 @@ Object {
 exports[`Emphasis and strong emphasis a * foo bar*
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -10099,7 +10099,7 @@ Object {
 exports[`Emphasis and strong emphasis a*"foo"*
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -10116,7 +10116,7 @@ Object {
 exports[`Emphasis and strong emphasis a*"foo"*
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -10133,7 +10133,7 @@ Object {
 exports[`Emphasis and strong emphasis a**"foo"**
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -10150,7 +10150,7 @@ Object {
 exports[`Emphasis and strong emphasis a**"foo"**
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -10167,7 +10167,7 @@ Object {
 exports[`Emphasis and strong emphasis a_"foo"_
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -10184,7 +10184,7 @@ Object {
 exports[`Emphasis and strong emphasis a_"foo"_
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -10201,7 +10201,7 @@ Object {
 exports[`Emphasis and strong emphasis a__"foo"__
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -10218,7 +10218,7 @@ Object {
 exports[`Emphasis and strong emphasis a__"foo"__
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -10235,7 +10235,7 @@ Object {
 exports[`Emphasis and strong emphasis aa_"bb"_cc
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -10252,7 +10252,7 @@ Object {
 exports[`Emphasis and strong emphasis aa_"bb"_cc
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -10269,7 +10269,7 @@ Object {
 exports[`Emphasis and strong emphasis foo ***
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -10286,7 +10286,7 @@ Object {
 exports[`Emphasis and strong emphasis foo ***
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -10303,7 +10303,7 @@ Object {
 exports[`Emphasis and strong emphasis foo *****
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -10320,7 +10320,7 @@ Object {
 exports[`Emphasis and strong emphasis foo *****
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -10337,7 +10337,7 @@ Object {
 exports[`Emphasis and strong emphasis foo **\\***
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -10361,7 +10361,7 @@ Object {
 exports[`Emphasis and strong emphasis foo **\\***
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -10385,7 +10385,7 @@ Object {
 exports[`Emphasis and strong emphasis foo **_**
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -10409,7 +10409,7 @@ Object {
 exports[`Emphasis and strong emphasis foo **_**
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -10433,7 +10433,7 @@ Object {
 exports[`Emphasis and strong emphasis foo *\\**
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -10457,7 +10457,7 @@ Object {
 exports[`Emphasis and strong emphasis foo *\\**
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -10481,7 +10481,7 @@ Object {
 exports[`Emphasis and strong emphasis foo *_*
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -10505,7 +10505,7 @@ Object {
 exports[`Emphasis and strong emphasis foo *_*
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -10529,7 +10529,7 @@ Object {
 exports[`Emphasis and strong emphasis foo _*_
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -10553,7 +10553,7 @@ Object {
 exports[`Emphasis and strong emphasis foo _*_
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -10577,7 +10577,7 @@ Object {
 exports[`Emphasis and strong emphasis foo _\\__
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -10601,7 +10601,7 @@ Object {
 exports[`Emphasis and strong emphasis foo _\\__
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -10625,7 +10625,7 @@ Object {
 exports[`Emphasis and strong emphasis foo __*__
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -10649,7 +10649,7 @@ Object {
 exports[`Emphasis and strong emphasis foo __*__
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -10673,7 +10673,7 @@ Object {
 exports[`Emphasis and strong emphasis foo __\\___
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -10697,7 +10697,7 @@ Object {
 exports[`Emphasis and strong emphasis foo __\\___
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -10721,7 +10721,7 @@ Object {
 exports[`Emphasis and strong emphasis foo ___
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -10738,7 +10738,7 @@ Object {
 exports[`Emphasis and strong emphasis foo ___
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -10755,7 +10755,7 @@ Object {
 exports[`Emphasis and strong emphasis foo _____
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -10772,7 +10772,7 @@ Object {
 exports[`Emphasis and strong emphasis foo _____
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -10789,7 +10789,7 @@ Object {
 exports[`Emphasis and strong emphasis foo**bar**
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -10813,7 +10813,7 @@ Object {
 exports[`Emphasis and strong emphasis foo**bar**
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -10837,7 +10837,7 @@ Object {
 exports[`Emphasis and strong emphasis foo*bar*
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -10861,7 +10861,7 @@ Object {
 exports[`Emphasis and strong emphasis foo*bar*
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -10885,7 +10885,7 @@ Object {
 exports[`Emphasis and strong emphasis foo__bar__
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -10902,7 +10902,7 @@ Object {
 exports[`Emphasis and strong emphasis foo__bar__
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -10919,7 +10919,7 @@ Object {
 exports[`Emphasis and strong emphasis foo_bar_
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -10936,7 +10936,7 @@ Object {
 exports[`Emphasis and strong emphasis foo_bar_
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -10953,7 +10953,7 @@ Object {
 exports[`Emphasis and strong emphasis foo-_(bar)_
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -10977,7 +10977,7 @@ Object {
 exports[`Emphasis and strong emphasis foo-_(bar)_
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -11001,7 +11001,7 @@ Object {
 exports[`Emphasis and strong emphasis foo-__(bar)__
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -11025,7 +11025,7 @@ Object {
 exports[`Emphasis and strong emphasis foo-__(bar)__
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -11049,7 +11049,7 @@ Object {
 exports[`Emphasis and strong emphasis пристаням__стремятся__
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -11066,7 +11066,7 @@ Object {
 exports[`Emphasis and strong emphasis пристаням__стремятся__
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -11083,7 +11083,7 @@ Object {
 exports[`Emphasis and strong emphasis пристаням_стремятся_
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -11100,7 +11100,7 @@ Object {
 exports[`Emphasis and strong emphasis пристаням_стремятся_
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -11117,7 +11117,7 @@ Object {
 exports[`Entity and numeric character references     f&ouml;f&ouml;
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -11135,7 +11135,7 @@ Object {
 exports[`Entity and numeric character references     f&ouml;f&ouml;
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -11153,7 +11153,7 @@ Object {
 exports[`Entity and numeric character references &#35; &#1234; &#992; &#98765432; &#0;
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -11170,7 +11170,7 @@ Object {
 exports[`Entity and numeric character references &#35; &#1234; &#992; &#98765432; &#0;
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -11187,7 +11187,7 @@ Object {
 exports[`Entity and numeric character references &#X22; &#XD06; &#xcab;
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -11204,7 +11204,7 @@ Object {
 exports[`Entity and numeric character references &#X22; &#XD06; &#xcab;
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -11221,7 +11221,7 @@ Object {
 exports[`Entity and numeric character references &MadeUpEntity;
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -11238,7 +11238,7 @@ Object {
 exports[`Entity and numeric character references &MadeUpEntity;
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -11255,7 +11255,7 @@ Object {
 exports[`Entity and numeric character references &copy
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -11272,7 +11272,7 @@ Object {
 exports[`Entity and numeric character references &copy
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -11290,7 +11290,7 @@ exports[`Entity and numeric character references &nbsp &x; &#; &#x;
 &ThisIsNotDefined; &hi?;
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -11309,7 +11309,7 @@ exports[`Entity and numeric character references &nbsp &x; &#; &#x;
 &ThisIsNotDefined; &hi?;
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -11329,7 +11329,7 @@ exports[`Entity and numeric character references &nbsp; &amp; &copy; &AElig; &Dc
 &ClockwiseContourIntegral; &ngE;
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -11350,7 +11350,7 @@ exports[`Entity and numeric character references &nbsp; &amp; &copy; &AElig; &Dc
 &ClockwiseContourIntegral; &ngE;
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -11369,7 +11369,7 @@ Object {
 exports[`Entity and numeric character references <a href="&ouml;&ouml;.html">
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -11387,7 +11387,7 @@ Object {
 exports[`Entity and numeric character references <a href="&ouml;&ouml;.html">
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -11407,7 +11407,7 @@ exports[`Entity and numeric character references [foo]
 [foo]: /f&ouml;&ouml; "f&ouml;&ouml;"
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -11435,7 +11435,7 @@ exports[`Entity and numeric character references [foo]
 [foo]: /f&ouml;&ouml; "f&ouml;&ouml;"
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -11461,7 +11461,7 @@ Object {
 exports[`Entity and numeric character references [foo](/f&ouml;&ouml; "f&ouml;&ouml;")
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -11487,7 +11487,7 @@ Object {
 exports[`Entity and numeric character references [foo](/f&ouml;&ouml; "f&ouml;&ouml;")
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -11515,7 +11515,7 @@ foo
 \`\`\`
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -11537,7 +11537,7 @@ foo
 \`\`\`
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -11557,7 +11557,7 @@ Object {
 exports[`Entity and numeric character references \`f&ouml;&ouml;\`
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -11580,7 +11580,7 @@ Object {
 exports[`Entity and numeric character references \`f&ouml;&ouml;\`
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -11605,7 +11605,7 @@ exports[`Fenced code blocks     \`\`\`
     \`\`\`
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -11627,7 +11627,7 @@ exports[`Fenced code blocks     \`\`\`
     \`\`\`
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -11651,7 +11651,7 @@ exports[`Fenced code blocks    \`\`\`
    \`\`\`
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -11677,7 +11677,7 @@ exports[`Fenced code blocks    \`\`\`
    \`\`\`
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -11701,7 +11701,7 @@ aaa
   \`\`\`
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -11723,7 +11723,7 @@ aaa
   \`\`\`
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -11747,7 +11747,7 @@ aaa
   \`\`\`
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -11773,7 +11773,7 @@ aaa
   \`\`\`
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -11798,7 +11798,7 @@ aaa
 \`\`\`
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -11822,7 +11822,7 @@ aaa
 \`\`\`
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -11846,7 +11846,7 @@ exports[`Fenced code blocks > \`\`\`
 bbb
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -11882,7 +11882,7 @@ exports[`Fenced code blocks > \`\`\`
 bbb
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -11917,7 +11917,7 @@ foo
 \`\`
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -11942,7 +11942,7 @@ foo
 \`\`
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -11968,7 +11968,7 @@ exports[`Fenced code blocks \`\`\`
 \`\`\`
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -11992,7 +11992,7 @@ exports[`Fenced code blocks \`\`\`
 \`\`\`
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -12013,7 +12013,7 @@ Object {
 exports[`Fenced code blocks \`\`\`
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -12030,7 +12030,7 @@ Object {
 exports[`Fenced code blocks \`\`\`
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -12050,7 +12050,7 @@ exports[`Fenced code blocks \`\`\`
 \`\`\`
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -12074,7 +12074,7 @@ exports[`Fenced code blocks \`\`\`
 \`\`\`
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -12096,7 +12096,7 @@ exports[`Fenced code blocks \`\`\`
 \`\`\`
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -12114,7 +12114,7 @@ exports[`Fenced code blocks \`\`\`
 \`\`\`
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -12133,7 +12133,7 @@ exports[`Fenced code blocks \`\`\`
 \`\`\`
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -12155,7 +12155,7 @@ exports[`Fenced code blocks \`\`\`
 \`\`\`
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -12177,7 +12177,7 @@ aaa
     \`\`\`
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -12200,7 +12200,7 @@ aaa
     \`\`\`
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -12223,7 +12223,7 @@ aaa
   \`\`\`
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -12245,7 +12245,7 @@ aaa
   \`\`\`
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -12268,7 +12268,7 @@ aaa
 \`\`\`
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -12292,7 +12292,7 @@ aaa
 \`\`\`
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -12314,7 +12314,7 @@ exports[`Fenced code blocks \`\`\` \`\`\`
 aaa
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -12338,7 +12338,7 @@ exports[`Fenced code blocks \`\`\` \`\`\`
 aaa
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -12362,7 +12362,7 @@ exports[`Fenced code blocks \`\`\` aa \`\`\`
 foo
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -12388,7 +12388,7 @@ exports[`Fenced code blocks \`\`\` aa \`\`\`
 foo
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -12416,7 +12416,7 @@ aaa
 \`\`\`\`\`\`
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -12440,7 +12440,7 @@ aaa
 \`\`\`\`\`\`
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -12462,7 +12462,7 @@ exports[`Fenced code blocks \`\`\`\`;
 \`\`\`\`
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -12480,7 +12480,7 @@ exports[`Fenced code blocks \`\`\`\`;
 \`\`\`\`
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -12500,7 +12500,7 @@ exports[`Fenced code blocks \`\`\`\`\`
 aaa
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -12525,7 +12525,7 @@ exports[`Fenced code blocks \`\`\`\`\`
 aaa
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -12551,7 +12551,7 @@ end
 \`\`\`
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -12577,7 +12577,7 @@ end
 \`\`\`
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -12602,7 +12602,7 @@ exports[`Fenced code blocks ~~~
 ~~~
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -12626,7 +12626,7 @@ exports[`Fenced code blocks ~~~
 ~~~
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -12650,7 +12650,7 @@ aaa
 ~~~
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -12674,7 +12674,7 @@ aaa
 ~~~
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -12698,7 +12698,7 @@ aaa
 ~~~~
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -12722,7 +12722,7 @@ aaa
 ~~~~
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -12747,7 +12747,7 @@ end
 ~~~~~~~
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -12773,7 +12773,7 @@ end
 ~~~~~~~
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -12797,7 +12797,7 @@ aaa
 ~~~ ~~
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -12820,7 +12820,7 @@ aaa
 ~~~ ~~
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -12845,7 +12845,7 @@ bar
 baz
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -12883,7 +12883,7 @@ bar
 baz
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -12922,7 +12922,7 @@ bar
 # baz
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -12965,7 +12965,7 @@ bar
 # baz
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -13005,7 +13005,7 @@ exports[`HTML blocks   <!-- foo -->
     <!-- foo -->
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -13033,7 +13033,7 @@ exports[`HTML blocks   <!-- foo -->
     <!-- foo -->
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -13061,7 +13061,7 @@ exports[`HTML blocks   <div>
     <div>
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -13089,7 +13089,7 @@ exports[`HTML blocks   <div>
     <div>
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -13117,7 +13117,7 @@ exports[`HTML blocks  <div>
          <foo><a>
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -13139,7 +13139,7 @@ exports[`HTML blocks  <div>
          <foo><a>
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -13171,7 +13171,7 @@ function matchwo(a,b)
 okay
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -13219,7 +13219,7 @@ function matchwo(a,b)
 okay
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -13259,7 +13259,7 @@ bar
 okay
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -13291,7 +13291,7 @@ bar
 okay
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -13320,7 +13320,7 @@ exports[`HTML blocks <!-- foo -->*bar*
 *baz*
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -13352,7 +13352,7 @@ exports[`HTML blocks <!-- foo -->*bar*
 *baz*
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -13383,7 +13383,7 @@ Object {
 exports[`HTML blocks <!DOCTYPE html>
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -13401,7 +13401,7 @@ Object {
 exports[`HTML blocks <!DOCTYPE html>
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -13420,7 +13420,7 @@ exports[`HTML blocks </div>
 *foo*
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -13440,7 +13440,7 @@ exports[`HTML blocks </div>
 *foo*
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -13460,7 +13460,7 @@ exports[`HTML blocks </ins>
 *bar*
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -13480,7 +13480,7 @@ exports[`HTML blocks </ins>
 *bar*
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -13504,7 +13504,7 @@ exports[`HTML blocks <?php
 okay
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -13538,7 +13538,7 @@ exports[`HTML blocks <?php
 okay
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -13571,7 +13571,7 @@ exports[`HTML blocks <DIV CLASS="foo">
 </DIV>
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -13614,7 +13614,7 @@ exports[`HTML blocks <DIV CLASS="foo">
 </DIV>
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -13655,7 +13655,7 @@ exports[`HTML blocks <Warning>
 </Warning>
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -13677,7 +13677,7 @@ exports[`HTML blocks <Warning>
 </Warning>
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -13699,7 +13699,7 @@ exports[`HTML blocks <a href="foo">
 </a>
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -13721,7 +13721,7 @@ exports[`HTML blocks <a href="foo">
 </a>
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -13745,7 +13745,7 @@ exports[`HTML blocks <del>
 </del>
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -13788,7 +13788,7 @@ exports[`HTML blocks <del>
 </del>
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -13829,7 +13829,7 @@ exports[`HTML blocks <del>
 </del>
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -13851,7 +13851,7 @@ exports[`HTML blocks <del>
 </del>
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -13871,7 +13871,7 @@ Object {
 exports[`HTML blocks <del>*foo*</del>
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -13908,7 +13908,7 @@ Object {
 exports[`HTML blocks <del>*foo*</del>
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -13946,7 +13946,7 @@ exports[`HTML blocks <div *???-&&&-<---
 *foo*
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -13966,7 +13966,7 @@ exports[`HTML blocks <div *???-&&&-<---
 *foo*
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -13986,7 +13986,7 @@ exports[`HTML blocks <div class
 foo
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -14006,7 +14006,7 @@ exports[`HTML blocks <div class
 foo
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -14027,7 +14027,7 @@ exports[`HTML blocks <div id="foo"
 </div>
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -14049,7 +14049,7 @@ exports[`HTML blocks <div id="foo"
 </div>
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -14070,7 +14070,7 @@ exports[`HTML blocks <div id="foo"
 *hi*
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -14090,7 +14090,7 @@ exports[`HTML blocks <div id="foo"
 *hi*
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -14111,7 +14111,7 @@ exports[`HTML blocks <div id="foo" class="bar
 </div>
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -14133,7 +14133,7 @@ exports[`HTML blocks <div id="foo" class="bar
 </div>
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -14157,7 +14157,7 @@ exports[`HTML blocks <div>
 </div>
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -14201,7 +14201,7 @@ exports[`HTML blocks <div>
 </div>
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -14243,7 +14243,7 @@ exports[`HTML blocks <div>
 </div>
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -14265,7 +14265,7 @@ exports[`HTML blocks <div>
 </div>
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -14288,7 +14288,7 @@ exports[`HTML blocks <div>
 *bar*
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -14323,7 +14323,7 @@ exports[`HTML blocks <div>
 *bar*
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -14358,7 +14358,7 @@ bar
 *foo*
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -14382,7 +14382,7 @@ bar
 *foo*
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -14406,7 +14406,7 @@ int x = 33;
 \`\`\`
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -14430,7 +14430,7 @@ int x = 33;
 \`\`\`
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -14451,7 +14451,7 @@ int x = 33;
 exports[`HTML blocks <div><a href="bar">*foo*</a></div>
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -14469,7 +14469,7 @@ Object {
 exports[`HTML blocks <div><a href="bar">*foo*</a></div>
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -14489,7 +14489,7 @@ exports[`HTML blocks <i class="foo">
 </i>
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -14511,7 +14511,7 @@ exports[`HTML blocks <i class="foo">
 </i>
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -14537,7 +14537,7 @@ main = print $ parseTags tags
 okay
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -14573,7 +14573,7 @@ main = print $ parseTags tags
 okay
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -14608,7 +14608,7 @@ document.getElementById("demo").innerHTML = "Hello JavaScript!";
 okay
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -14642,7 +14642,7 @@ document.getElementById("demo").innerHTML = "Hello JavaScript!";
 okay
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -14673,7 +14673,7 @@ foo
 </script>1. *bar*
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -14695,7 +14695,7 @@ foo
 </script>1. *bar*
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -14770,7 +14770,7 @@ p {color:blue;}
 okay
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -14806,7 +14806,7 @@ p {color:blue;}
 okay
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -14837,7 +14837,7 @@ exports[`HTML blocks <style>p{color:red;}</style>
 *foo*
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -14869,7 +14869,7 @@ exports[`HTML blocks <style>p{color:red;}</style>
 *foo*
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -14910,7 +14910,7 @@ exports[`HTML blocks <table>
 </table>
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -14972,7 +14972,7 @@ exports[`HTML blocks <table>
 </table>
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -15034,7 +15034,7 @@ Hi
 </table>
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -15096,7 +15096,7 @@ Hi
 </table>
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -15156,7 +15156,7 @@ exports[`HTML blocks <table>
 okay.
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -15195,7 +15195,7 @@ exports[`HTML blocks <table>
 okay.
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -15232,7 +15232,7 @@ _world_.
 </td></tr></table>
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -15288,7 +15288,7 @@ _world_.
 </td></tr></table>
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -15340,7 +15340,7 @@ foo
 </td></tr></table>
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -15362,7 +15362,7 @@ foo
 </td></tr></table>
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -15385,7 +15385,7 @@ exports[`HTML blocks > <div>
 bar
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -15420,7 +15420,7 @@ exports[`HTML blocks > <div>
 bar
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -15453,7 +15453,7 @@ exports[`HTML blocks - <div>
 - foo
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -15499,7 +15499,7 @@ exports[`HTML blocks - <div>
 - foo
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -15546,7 +15546,7 @@ exports[`HTML blocks Foo
 baz
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -15575,7 +15575,7 @@ exports[`HTML blocks Foo
 baz
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -15605,7 +15605,7 @@ bar
 </div>
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -15635,7 +15635,7 @@ bar
 </div>
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -15662,7 +15662,7 @@ bar
 exports[`Hard line breaks ### foo  
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -15681,7 +15681,7 @@ Object {
 exports[`Hard line breaks ### foo  
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -15700,7 +15700,7 @@ Object {
 exports[`Hard line breaks ### foo\\
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -15719,7 +15719,7 @@ Object {
 exports[`Hard line breaks ### foo\\
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -15739,7 +15739,7 @@ exports[`Hard line breaks *foo
 bar*
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -15769,7 +15769,7 @@ exports[`Hard line breaks *foo
 bar*
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -15799,7 +15799,7 @@ exports[`Hard line breaks *foo\\
 bar*
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -15829,7 +15829,7 @@ exports[`Hard line breaks *foo\\
 bar*
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -15859,7 +15859,7 @@ exports[`Hard line breaks <a href="foo
 bar">
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -15884,7 +15884,7 @@ exports[`Hard line breaks <a href="foo
 bar">
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -15909,7 +15909,7 @@ exports[`Hard line breaks <a href="foo\\
 bar">
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -15934,7 +15934,7 @@ exports[`Hard line breaks <a href="foo\\
 bar">
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -15959,7 +15959,7 @@ exports[`Hard line breaks \`code
 span\`
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -15983,7 +15983,7 @@ exports[`Hard line breaks \`code
 span\`
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -16007,7 +16007,7 @@ exports[`Hard line breaks \`code\\
 span\`
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -16031,7 +16031,7 @@ exports[`Hard line breaks \`code\\
 span\`
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -16055,7 +16055,7 @@ exports[`Hard line breaks foo
      bar
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -16079,7 +16079,7 @@ exports[`Hard line breaks foo
      bar
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -16102,7 +16102,7 @@ Object {
 exports[`Hard line breaks foo  
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -16119,7 +16119,7 @@ Object {
 exports[`Hard line breaks foo  
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -16137,7 +16137,7 @@ exports[`Hard line breaks foo
 baz
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -16161,7 +16161,7 @@ exports[`Hard line breaks foo
 baz
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -16185,7 +16185,7 @@ exports[`Hard line breaks foo
 baz
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -16209,7 +16209,7 @@ exports[`Hard line breaks foo
 baz
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -16233,7 +16233,7 @@ exports[`Hard line breaks foo\\
      bar
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -16257,7 +16257,7 @@ exports[`Hard line breaks foo\\
      bar
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -16280,7 +16280,7 @@ Object {
 exports[`Hard line breaks foo\\
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -16297,7 +16297,7 @@ Object {
 exports[`Hard line breaks foo\\
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -16315,7 +16315,7 @@ exports[`Hard line breaks foo\\
 baz
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -16339,7 +16339,7 @@ exports[`Hard line breaks foo\\
 baz
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -16364,7 +16364,7 @@ exports[`Images ![*foo* bar]
 [*foo* bar]: /url "title"
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -16391,7 +16391,7 @@ exports[`Images ![*foo* bar]
 [*foo* bar]: /url "title"
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -16418,7 +16418,7 @@ exports[`Images ![*foo* bar][]
 [*foo* bar]: /url "title"
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -16445,7 +16445,7 @@ exports[`Images ![*foo* bar][]
 [*foo* bar]: /url "title"
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -16472,7 +16472,7 @@ exports[`Images ![[foo]]
 [[foo]]: /url "title"
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -16498,7 +16498,7 @@ exports[`Images ![[foo]]
 [[foo]]: /url "title"
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -16522,7 +16522,7 @@ Object {
 exports[`Images ![](/url)
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -16546,7 +16546,7 @@ Object {
 exports[`Images ![](/url)
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -16572,7 +16572,7 @@ exports[`Images ![Foo]
 [foo]: /url "title"
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -16599,7 +16599,7 @@ exports[`Images ![Foo]
 [foo]: /url "title"
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -16626,7 +16626,7 @@ exports[`Images ![Foo][]
 [foo]: /url "title"
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -16653,7 +16653,7 @@ exports[`Images ![Foo][]
 [foo]: /url "title"
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -16678,7 +16678,7 @@ Object {
 exports[`Images ![foo ![bar](/url)](/url2)
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -16702,7 +16702,7 @@ Object {
 exports[`Images ![foo ![bar](/url)](/url2)
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -16728,7 +16728,7 @@ exports[`Images ![foo *bar*]
 [foo *bar*]: train.jpg "train & tracks"
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -16755,7 +16755,7 @@ exports[`Images ![foo *bar*]
 [foo *bar*]: train.jpg "train & tracks"
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -16782,7 +16782,7 @@ exports[`Images ![foo *bar*][]
 [foo *bar*]: train.jpg "train & tracks"
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -16809,7 +16809,7 @@ exports[`Images ![foo *bar*][]
 [foo *bar*]: train.jpg "train & tracks"
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -16836,7 +16836,7 @@ exports[`Images ![foo *bar*][foobar]
 [FOOBAR]: train.jpg "train & tracks"
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -16863,7 +16863,7 @@ exports[`Images ![foo *bar*][foobar]
 [FOOBAR]: train.jpg "train & tracks"
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -16888,7 +16888,7 @@ Object {
 exports[`Images ![foo [bar](/url)](/url2)
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -16912,7 +16912,7 @@ Object {
 exports[`Images ![foo [bar](/url)](/url2)
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -16938,7 +16938,7 @@ exports[`Images ![foo]
 [foo]: /url "title"
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -16965,7 +16965,7 @@ exports[`Images ![foo]
 [foo]: /url "title"
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -16993,7 +16993,7 @@ exports[`Images ![foo]
 [foo]: /url "title"
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -17023,7 +17023,7 @@ exports[`Images ![foo]
 [foo]: /url "title"
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -17050,7 +17050,7 @@ Object {
 exports[`Images ![foo](/url "title")
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -17075,7 +17075,7 @@ Object {
 exports[`Images ![foo](/url "title")
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -17100,7 +17100,7 @@ Object {
 exports[`Images ![foo](<url>)
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -17124,7 +17124,7 @@ Object {
 exports[`Images ![foo](<url>)
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -17148,7 +17148,7 @@ Object {
 exports[`Images ![foo](train.jpg)
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -17172,7 +17172,7 @@ Object {
 exports[`Images ![foo](train.jpg)
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -17198,7 +17198,7 @@ exports[`Images ![foo][]
 [foo]: /url "title"
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -17225,7 +17225,7 @@ exports[`Images ![foo][]
 [foo]: /url "title"
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -17252,7 +17252,7 @@ exports[`Images ![foo][bar]
 [BAR]: /url
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -17278,7 +17278,7 @@ exports[`Images ![foo][bar]
 [BAR]: /url
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -17304,7 +17304,7 @@ exports[`Images ![foo][bar]
 [bar]: /url
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -17330,7 +17330,7 @@ exports[`Images ![foo][bar]
 [bar]: /url
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -17356,7 +17356,7 @@ exports[`Images !\\[foo]
 [foo]: /url "title"
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -17375,7 +17375,7 @@ exports[`Images !\\[foo]
 [foo]: /url "title"
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -17394,7 +17394,7 @@ exports[`Images \\![foo]
 [foo]: /url "title"
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -17423,7 +17423,7 @@ exports[`Images \\![foo]
 [foo]: /url "title"
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -17450,7 +17450,7 @@ Object {
 exports[`Images My ![foo bar](/path/to/train.jpg  "title"   )
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -17476,7 +17476,7 @@ Object {
 exports[`Images My ![foo bar](/path/to/train.jpg  "title"   )
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -17506,7 +17506,7 @@ exports[`Indented code blocks
 
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -17528,7 +17528,7 @@ exports[`Indented code blocks
 
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -17547,7 +17547,7 @@ exports[`Indented code blocks         foo
     bar
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -17567,7 +17567,7 @@ exports[`Indented code blocks         foo
     bar
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -17589,7 +17589,7 @@ exports[`Indented code blocks     <a/>
     - one
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -17613,7 +17613,7 @@ exports[`Indented code blocks     <a/>
     - one
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -17635,7 +17635,7 @@ exports[`Indented code blocks     a simple
       indented code block
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -17655,7 +17655,7 @@ exports[`Indented code blocks     a simple
       indented code block
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -17680,7 +17680,7 @@ exports[`Indented code blocks     chunk1
     chunk3
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -17710,7 +17710,7 @@ exports[`Indented code blocks     chunk1
     chunk3
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -17736,7 +17736,7 @@ exports[`Indented code blocks     chunk1
       chunk2
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -17758,7 +17758,7 @@ exports[`Indented code blocks     chunk1
       chunk2
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -17779,7 +17779,7 @@ exports[`Indented code blocks     foo
 bar
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -17805,7 +17805,7 @@ exports[`Indented code blocks     foo
 bar
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -17830,7 +17830,7 @@ Object {
 exports[`Indented code blocks     foo  
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -17848,7 +17848,7 @@ Object {
 exports[`Indented code blocks     foo  
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -17868,7 +17868,7 @@ exports[`Indented code blocks   - foo
     bar
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -17908,7 +17908,7 @@ exports[`Indented code blocks   - foo
     bar
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -17951,7 +17951,7 @@ Heading
 ----
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -18005,7 +18005,7 @@ Heading
 ----
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -18056,7 +18056,7 @@ exports[`Indented code blocks 1.  foo
     - bar
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -18110,7 +18110,7 @@ exports[`Indented code blocks 1.  foo
     - bar
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -18164,7 +18164,7 @@ exports[`Indented code blocks Foo
 
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -18184,7 +18184,7 @@ exports[`Indented code blocks Foo
 
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -18202,7 +18202,7 @@ bar",
 exports[`Inlines \`hi\`lo\`
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -18226,7 +18226,7 @@ Object {
 exports[`Inlines \`hi\`lo\`
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -18252,7 +18252,7 @@ exports[`Link reference definitions     [foo]: /url "title"
 [foo]
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -18279,7 +18279,7 @@ exports[`Link reference definitions     [foo]: /url "title"
 [foo]
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -18308,7 +18308,7 @@ exports[`Link reference definitions    [foo]:
 [foo]
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -18338,7 +18338,7 @@ exports[`Link reference definitions    [foo]:
 [foo]
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -18366,7 +18366,7 @@ exports[`Link reference definitions # [Foo]
 > bar
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -18408,7 +18408,7 @@ exports[`Link reference definitions # [Foo]
 > bar
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -18451,7 +18451,7 @@ foo
 bar
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -18471,7 +18471,7 @@ foo
 bar
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -18490,7 +18490,7 @@ exports[`Link reference definitions [FOO]: /url
 [Foo]
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -18517,7 +18517,7 @@ exports[`Link reference definitions [FOO]: /url
 [Foo]
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -18546,7 +18546,7 @@ exports[`Link reference definitions [Foo bar]:
 [Foo bar]
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -18576,7 +18576,7 @@ exports[`Link reference definitions [Foo bar]:
 [Foo bar]
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -18604,7 +18604,7 @@ exports[`Link reference definitions [Foo*bar\\]]:my_(url) 'title (with parens)'
 [Foo*bar\\]]
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -18632,7 +18632,7 @@ exports[`Link reference definitions [Foo*bar\\]]:my_(url) 'title (with parens)'
 [Foo*bar\\]]
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -18660,7 +18660,7 @@ exports[`Link reference definitions [foo]
 > [foo]: /url
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -18692,7 +18692,7 @@ exports[`Link reference definitions [foo]
 > [foo]: /url
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -18725,7 +18725,7 @@ exports[`Link reference definitions [foo]
 [foo]: second
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -18753,7 +18753,7 @@ exports[`Link reference definitions [foo]
 [foo]: second
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -18780,7 +18780,7 @@ exports[`Link reference definitions [foo]
 [foo]: url
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -18807,7 +18807,7 @@ exports[`Link reference definitions [foo]
 [foo]: url
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -18834,7 +18834,7 @@ exports[`Link reference definitions [foo]:
 [foo]
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -18860,7 +18860,7 @@ exports[`Link reference definitions [foo]:
 [foo]
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -18887,7 +18887,7 @@ exports[`Link reference definitions [foo]:
 [foo]
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -18915,7 +18915,7 @@ exports[`Link reference definitions [foo]:
 [foo]
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -18947,7 +18947,7 @@ exports[`Link reference definitions [foo]: /foo-url "foo"
 [baz]
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -19003,7 +19003,7 @@ exports[`Link reference definitions [foo]: /foo-url "foo"
 [baz]
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -19052,7 +19052,7 @@ Object {
 exports[`Link reference definitions [foo]: /url
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [],
   "type": "root",
 }
@@ -19061,7 +19061,7 @@ Object {
 exports[`Link reference definitions [foo]: /url
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [],
   "type": "root",
 }
@@ -19071,7 +19071,7 @@ exports[`Link reference definitions [foo]: /url
 "title" ok
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -19089,7 +19089,7 @@ exports[`Link reference definitions [foo]: /url
 "title" ok
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -19108,7 +19108,7 @@ exports[`Link reference definitions [foo]: /url "title"
 [foo]
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -19136,7 +19136,7 @@ exports[`Link reference definitions [foo]: /url "title"
 [foo]
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -19162,7 +19162,7 @@ Object {
 exports[`Link reference definitions [foo]: /url "title" ok
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -19179,7 +19179,7 @@ Object {
 exports[`Link reference definitions [foo]: /url "title" ok
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -19202,7 +19202,7 @@ line2
 [foo]
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -19238,7 +19238,7 @@ line2
 [foo]
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -19272,7 +19272,7 @@ with blank line'
 [foo]
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -19307,7 +19307,7 @@ with blank line'
 [foo]
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -19340,7 +19340,7 @@ exports[`Link reference definitions [foo]: /url\\bar\\*baz "foo\\"bar\\baz"
 [foo]
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -19368,7 +19368,7 @@ exports[`Link reference definitions [foo]: /url\\bar\\*baz "foo\\"bar\\baz"
 [foo]
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -19396,7 +19396,7 @@ exports[`Link reference definitions [ΑΓΩ]: /φου
 [αγω]
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -19423,7 +19423,7 @@ exports[`Link reference definitions [ΑΓΩ]: /φου
 [αγω]
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -19452,7 +19452,7 @@ exports[`Link reference definitions \`\`\`
 [foo]
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -19483,7 +19483,7 @@ exports[`Link reference definitions \`\`\`
 [foo]
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -19513,7 +19513,7 @@ exports[`Link reference definitions Foo
 [bar]
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -19541,7 +19541,7 @@ exports[`Link reference definitions Foo
 [bar]
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -19614,7 +19614,7 @@ Object {
 exports[`Links *[foo*](/uri)
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -19640,7 +19640,7 @@ Object {
 exports[`Links *[foo*](/uri)
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -19668,7 +19668,7 @@ exports[`Links *[foo*][ref]
 [ref]: /uri
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -19696,7 +19696,7 @@ exports[`Links *[foo*][ref]
 [ref]: /uri
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -19722,7 +19722,7 @@ Object {
 exports[`Links *foo [bar* baz]
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -19746,7 +19746,7 @@ Object {
 exports[`Links *foo [bar* baz]
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -19774,7 +19774,7 @@ exports[`Links [
  ]: /uri
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -19804,7 +19804,7 @@ exports[`Links [
  ]: /uri
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -19830,7 +19830,7 @@ Object {
 exports[`Links [![moon](moon.jpg)](/uri)
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -19862,7 +19862,7 @@ Object {
 exports[`Links [![moon](moon.jpg)](/uri)
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -19896,7 +19896,7 @@ exports[`Links [![moon](moon.jpg)][ref]
 [ref]: /uri
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -19930,7 +19930,7 @@ exports[`Links [![moon](moon.jpg)][ref]
 [ref]: /uri
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -19964,7 +19964,7 @@ exports[`Links [*foo* bar]
 [*foo* bar]: /url "title"
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -19999,7 +19999,7 @@ exports[`Links [*foo* bar]
 [*foo* bar]: /url "title"
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -20034,7 +20034,7 @@ exports[`Links [*foo* bar][]
 [*foo* bar]: /url "title"
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -20069,7 +20069,7 @@ exports[`Links [*foo* bar][]
 [*foo* bar]: /url "title"
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -20104,7 +20104,7 @@ exports[`Links [[*foo* bar]]
 [*foo* bar]: /url "title"
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -20141,7 +20141,7 @@ exports[`Links [[*foo* bar]]
 [*foo* bar]: /url "title"
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -20178,7 +20178,7 @@ exports[`Links [[[foo]]]
 [[[foo]]]: /url
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -20204,7 +20204,7 @@ exports[`Links [[[foo]]]
 [[[foo]]]: /url
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -20230,7 +20230,7 @@ exports[`Links [[bar [foo]
 [foo]: /url
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -20258,7 +20258,7 @@ exports[`Links [[bar [foo]
 [foo]: /url
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -20286,7 +20286,7 @@ exports[`Links []
 []: /uri
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -20312,7 +20312,7 @@ exports[`Links []
 []: /uri
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -20339,7 +20339,7 @@ exports[`Links [Foo
 [Baz][Foo bar]
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -20367,7 +20367,7 @@ exports[`Links [Foo
 [Baz][Foo bar]
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -20394,7 +20394,7 @@ exports[`Links [Foo]
 [foo]: /url "title"
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -20422,7 +20422,7 @@ exports[`Links [Foo]
 [foo]: /url "title"
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -20450,7 +20450,7 @@ exports[`Links [Foo][]
 [foo]: /url "title"
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -20478,7 +20478,7 @@ exports[`Links [Foo][]
 [foo]: /url "title"
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -20506,7 +20506,7 @@ exports[`Links [bar\\\\]: /uri
 [bar\\\\]
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -20533,7 +20533,7 @@ exports[`Links [bar\\\\]: /uri
 [bar\\\\]
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -20560,7 +20560,7 @@ exports[`Links [bar][foo\\!]
 [foo!]: /url
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -20579,7 +20579,7 @@ exports[`Links [bar][foo\\!]
 [foo!]: /url
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -20596,7 +20596,7 @@ Object {
 exports[`Links [foo *[bar [baz](/uri)](/uri)*](/uri)
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -20631,7 +20631,7 @@ Object {
 exports[`Links [foo *[bar [baz](/uri)](/uri)*](/uri)
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -20668,7 +20668,7 @@ exports[`Links [foo *bar [baz][ref]*][ref]
 [ref]: /uri
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -20713,7 +20713,7 @@ exports[`Links [foo *bar [baz][ref]*][ref]
 [ref]: /uri
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -20756,7 +20756,7 @@ Object {
 exports[`Links [foo *bar](baz*)
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -20781,7 +20781,7 @@ Object {
 exports[`Links [foo *bar](baz*)
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -20808,7 +20808,7 @@ exports[`Links [foo *bar][ref]
 [ref]: /uri
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -20835,7 +20835,7 @@ exports[`Links [foo *bar][ref]
 [ref]: /uri
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -20860,7 +20860,7 @@ Object {
 exports[`Links [foo <bar attr="](baz)">
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -20884,7 +20884,7 @@ Object {
 exports[`Links [foo <bar attr="](baz)">
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -20910,7 +20910,7 @@ exports[`Links [foo <bar attr="][ref]">
 [ref]: /uri
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -20936,7 +20936,7 @@ exports[`Links [foo <bar attr="][ref]">
 [ref]: /uri
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -20960,7 +20960,7 @@ Object {
 exports[`Links [foo [bar](/uri)](/uri)
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -20987,7 +20987,7 @@ Object {
 exports[`Links [foo [bar](/uri)](/uri)
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -21016,7 +21016,7 @@ exports[`Links [foo [bar](/uri)][ref]
 [ref]: /uri
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -21054,7 +21054,7 @@ exports[`Links [foo [bar](/uri)][ref]
 [ref]: /uri
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -21092,7 +21092,7 @@ exports[`Links [foo*]: /url
 *[foo*]
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -21120,7 +21120,7 @@ exports[`Links [foo*]: /url
 *[foo*]
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -21146,7 +21146,7 @@ Object {
 exports[`Links [foo<http://example.com/?search=](uri)>
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -21172,7 +21172,7 @@ Object {
 exports[`Links [foo<http://example.com/?search=](uri)>
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -21200,7 +21200,7 @@ exports[`Links [foo<http://example.com/?search=][ref]>
 [ref]: /uri
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -21228,7 +21228,7 @@ exports[`Links [foo<http://example.com/?search=][ref]>
 [ref]: /uri
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -21256,7 +21256,7 @@ exports[`Links [foo]
 [foo]: /url "title"
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -21284,7 +21284,7 @@ exports[`Links [foo]
 [foo]: /url "title"
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -21313,7 +21313,7 @@ exports[`Links [foo]
 [bar]: /url "title"
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -21344,7 +21344,7 @@ exports[`Links [foo]
 [bar]: /url "title"
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -21375,7 +21375,7 @@ exports[`Links [foo]
 [foo]: /url "title"
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -21406,7 +21406,7 @@ exports[`Links [foo]
 [foo]: /url "title"
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -21436,7 +21436,7 @@ exports[`Links [foo] [bar]
 [bar]: /url "title"
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -21465,7 +21465,7 @@ exports[`Links [foo] [bar]
 [bar]: /url "title"
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -21494,7 +21494,7 @@ exports[`Links [foo] bar
 [foo]: /url
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -21522,7 +21522,7 @@ exports[`Links [foo] bar
 [foo]: /url
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -21550,7 +21550,7 @@ exports[`Links [foo]()
 [foo]: /url1
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -21577,7 +21577,7 @@ exports[`Links [foo]()
 [foo]: /url1
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -21604,7 +21604,7 @@ exports[`Links [foo](not a link)
 [foo]: /url1
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -21632,7 +21632,7 @@ exports[`Links [foo](not a link)
 [foo]: /url1
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -21662,7 +21662,7 @@ exports[`Links [foo]: /url1
 [bar][foo]
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -21691,7 +21691,7 @@ exports[`Links [foo]: /url1
 [bar][foo]
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -21718,7 +21718,7 @@ exports[`Links [foo][]
 [foo]: /url "title"
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -21746,7 +21746,7 @@ exports[`Links [foo][]
 [foo]: /url "title"
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -21774,7 +21774,7 @@ exports[`Links [foo][]
 [foo]: /url1
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -21801,7 +21801,7 @@ exports[`Links [foo][]
 [foo]: /url1
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -21828,7 +21828,7 @@ exports[`Links [foo][BaR]
 [bar]: /url "title"
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -21856,7 +21856,7 @@ exports[`Links [foo][BaR]
 [bar]: /url "title"
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -21884,7 +21884,7 @@ exports[`Links [foo][bar]
 [bar]: /url "title"
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -21912,7 +21912,7 @@ exports[`Links [foo][bar]
 [bar]: /url "title"
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -21941,7 +21941,7 @@ exports[`Links [foo][bar]
 [bar]: /url2
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -21969,7 +21969,7 @@ exports[`Links [foo][bar]
 [bar]: /url2
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -21996,7 +21996,7 @@ exports[`Links [foo][bar][baz]
 [baz]: /url
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -22024,7 +22024,7 @@ exports[`Links [foo][bar][baz]
 [baz]: /url
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -22053,7 +22053,7 @@ exports[`Links [foo][bar][baz]
 [bar]: /url2
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -22090,7 +22090,7 @@ exports[`Links [foo][bar][baz]
 [bar]: /url2
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -22127,7 +22127,7 @@ exports[`Links [foo][bar][baz]
 [foo]: /url2
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -22156,7 +22156,7 @@ exports[`Links [foo][bar][baz]
 [foo]: /url2
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -22184,7 +22184,7 @@ exports[`Links [foo][ref[]
 [ref[]: /uri
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -22210,7 +22210,7 @@ exports[`Links [foo][ref[]
 [ref[]: /uri
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -22236,7 +22236,7 @@ exports[`Links [foo][ref[bar]]
 [ref[bar]]: /uri
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -22262,7 +22262,7 @@ exports[`Links [foo][ref[bar]]
 [ref[bar]]: /uri
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -22288,7 +22288,7 @@ exports[`Links [foo][ref\\[]
 [ref\\[]: /uri
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -22315,7 +22315,7 @@ exports[`Links [foo][ref\\[]
 [ref\\[]: /uri
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -22340,7 +22340,7 @@ Object {
 exports[`Links [foo\`](/uri)\`
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -22364,7 +22364,7 @@ Object {
 exports[`Links [foo\`](/uri)\`
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -22390,7 +22390,7 @@ exports[`Links [foo\`][ref]\`
 [ref]: /uri
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -22416,7 +22416,7 @@ exports[`Links [foo\`][ref]\`
 [ref]: /uri
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -22440,7 +22440,7 @@ Object {
 exports[`Links [link *foo **bar** \`#\`*](/uri)
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -22487,7 +22487,7 @@ Object {
 exports[`Links [link *foo **bar** \`#\`*](/uri)
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -22536,7 +22536,7 @@ exports[`Links [link *foo **bar** \`#\`*][ref]
 [ref]: /uri
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -22585,7 +22585,7 @@ exports[`Links [link *foo **bar** \`#\`*][ref]
 [ref]: /uri
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -22632,7 +22632,7 @@ Object {
 exports[`Links [link [bar](/uri)
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -22658,7 +22658,7 @@ Object {
 exports[`Links [link [bar](/uri)
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -22684,7 +22684,7 @@ Object {
 exports[`Links [link [foo [bar]]](/uri)
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -22709,7 +22709,7 @@ Object {
 exports[`Links [link [foo [bar]]](/uri)
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -22736,7 +22736,7 @@ exports[`Links [link [foo [bar]]][ref]
 [ref]: /uri
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -22763,7 +22763,7 @@ exports[`Links [link [foo [bar]]][ref]
 [ref]: /uri
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -22788,7 +22788,7 @@ Object {
 exports[`Links [link \\[bar](/uri)
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -22813,7 +22813,7 @@ Object {
 exports[`Links [link \\[bar](/uri)
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -22840,7 +22840,7 @@ exports[`Links [link \\[bar][ref]
 [ref]: /uri
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -22867,7 +22867,7 @@ exports[`Links [link \\[bar][ref]
 [ref]: /uri
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -22892,7 +22892,7 @@ Object {
 exports[`Links [link] (/uri)
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -22909,7 +22909,7 @@ Object {
 exports[`Links [link] (/uri)
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -22926,7 +22926,7 @@ Object {
 exports[`Links [link] bar](/uri)
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -22943,7 +22943,7 @@ Object {
 exports[`Links [link] bar](/uri)
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -22961,7 +22961,7 @@ exports[`Links [link](   /uri
   "title"  )
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -22988,7 +22988,7 @@ exports[`Links [link](   /uri
   "title"  )
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -23014,7 +23014,7 @@ Object {
 exports[`Links [link]("title")
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -23039,7 +23039,7 @@ Object {
 exports[`Links [link]("title")
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -23068,7 +23068,7 @@ exports[`Links [link](#fragment)
 [link](http://example.com?foo=3#frag)
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -23127,7 +23127,7 @@ exports[`Links [link](#fragment)
 [link](http://example.com?foo=3#frag)
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -23182,7 +23182,7 @@ Object {
 exports[`Links [link]()
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -23207,7 +23207,7 @@ Object {
 exports[`Links [link]()
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -23232,7 +23232,7 @@ Object {
 exports[`Links [link](/my uri)
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -23249,7 +23249,7 @@ Object {
 exports[`Links [link](/my uri)
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -23266,7 +23266,7 @@ Object {
 exports[`Links [link](/uri "title")
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -23292,7 +23292,7 @@ Object {
 exports[`Links [link](/uri "title")
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -23318,7 +23318,7 @@ Object {
 exports[`Links [link](/uri)
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -23343,7 +23343,7 @@ Object {
 exports[`Links [link](/uri)
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -23368,7 +23368,7 @@ Object {
 exports[`Links [link](/url "title "and" title")
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -23385,7 +23385,7 @@ Object {
 exports[`Links [link](/url "title "and" title")
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -23402,7 +23402,7 @@ Object {
 exports[`Links [link](/url "title \\"&quot;")
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -23428,7 +23428,7 @@ Object {
 exports[`Links [link](/url "title \\"&quot;")
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -23456,7 +23456,7 @@ exports[`Links [link](/url "title")
 [link](/url (title))
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -23508,7 +23508,7 @@ exports[`Links [link](/url "title")
 [link](/url (title))
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -23558,7 +23558,7 @@ Object {
 exports[`Links [link](/url 'title "and" title')
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -23584,7 +23584,7 @@ Object {
 exports[`Links [link](/url 'title "and" title')
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -23610,7 +23610,7 @@ Object {
 exports[`Links [link](/url "title")
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -23635,7 +23635,7 @@ Object {
 exports[`Links [link](/url "title")
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -23660,7 +23660,7 @@ Object {
 exports[`Links [link](</my uri>)
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -23677,7 +23677,7 @@ Object {
 exports[`Links [link](</my uri>)
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -23694,7 +23694,7 @@ Object {
 exports[`Links [link](<>)
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -23719,7 +23719,7 @@ Object {
 exports[`Links [link](<>)
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -23745,7 +23745,7 @@ exports[`Links [link](<foo
 bar>)
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -23772,7 +23772,7 @@ exports[`Links [link](<foo
 bar>)
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -23798,7 +23798,7 @@ bar>",
 exports[`Links [link](<foo(and(bar)>)
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -23823,7 +23823,7 @@ Object {
 exports[`Links [link](<foo(and(bar)>)
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -23848,7 +23848,7 @@ Object {
 exports[`Links [link](\\(foo\\))
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -23873,7 +23873,7 @@ Object {
 exports[`Links [link](\\(foo\\))
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -23899,7 +23899,7 @@ exports[`Links [link](foo
 bar)
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -23918,7 +23918,7 @@ exports[`Links [link](foo
 bar)
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -23936,7 +23936,7 @@ bar)",
 exports[`Links [link](foo%20b&auml;)
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -23961,7 +23961,7 @@ Object {
 exports[`Links [link](foo%20b&auml;)
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -23986,7 +23986,7 @@ Object {
 exports[`Links [link](foo(and(bar)))
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -24011,7 +24011,7 @@ Object {
 exports[`Links [link](foo(and(bar)))
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -24036,7 +24036,7 @@ Object {
 exports[`Links [link](foo\\(and\\(bar\\))
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -24061,7 +24061,7 @@ Object {
 exports[`Links [link](foo\\(and\\(bar\\))
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -24086,7 +24086,7 @@ Object {
 exports[`Links [link](foo\\)\\:)
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -24111,7 +24111,7 @@ Object {
 exports[`Links [link](foo\\)\\:)
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -24136,7 +24136,7 @@ Object {
 exports[`Links [link](foo\\bar)
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -24161,7 +24161,7 @@ Object {
 exports[`Links [link](foo\\bar)
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -24188,7 +24188,7 @@ exports[`Links [Толпой][Толпой] is a Russian word.
 [ТОЛПОЙ]: /url
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -24216,7 +24216,7 @@ exports[`Links [Толпой][Толпой] is a Russian word.
 [ТОЛПОЙ]: /url
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -24244,7 +24244,7 @@ exports[`Links \\[foo]
 [foo]: /url "title"
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -24263,7 +24263,7 @@ exports[`Links \\[foo]
 [foo]: /url "title"
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -24285,7 +24285,7 @@ exports[`List items     1.  A paragraph
         > A block quote.
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -24313,7 +24313,7 @@ exports[`List items     1.  A paragraph
         > A block quote.
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -24340,7 +24340,7 @@ paragraph
     more code
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -24377,7 +24377,7 @@ paragraph
     more code
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -24412,7 +24412,7 @@ exports[`List items    > > 1.  one
 >>     two
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -24464,7 +24464,7 @@ exports[`List items    > > 1.  one
 >>     two
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -24519,7 +24519,7 @@ exports[`List items    1.  A paragraph
        > A block quote.
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -24577,7 +24577,7 @@ exports[`List items    1.  A paragraph
        > A block quote.
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -24632,7 +24632,7 @@ exports[`List items    foo
 bar
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -24658,7 +24658,7 @@ exports[`List items    foo
 bar
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -24687,7 +24687,7 @@ exports[`List items   1.  A paragraph
       > A block quote.
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -24745,7 +24745,7 @@ exports[`List items   1.  A paragraph
       > A block quote.
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -24799,7 +24799,7 @@ exports[`List items   1.  A paragraph
     with two lines.
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -24832,7 +24832,7 @@ exports[`List items   1.  A paragraph
     with two lines.
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -24869,7 +24869,7 @@ with two lines.
       > A block quote.
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -24927,7 +24927,7 @@ with two lines.
       > A block quote.
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -24982,7 +24982,7 @@ exports[`List items   10.  foo
            bar
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -25024,7 +25024,7 @@ exports[`List items   10.  foo
            bar
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -25066,7 +25066,7 @@ exports[`List items  -    one
       two
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -25106,7 +25106,7 @@ exports[`List items  -    one
       two
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -25146,7 +25146,7 @@ exports[`List items  -    one
      two
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -25187,7 +25187,7 @@ exports[`List items  -    one
      two
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -25231,7 +25231,7 @@ exports[`List items  1.  A paragraph
      > A block quote.
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -25289,7 +25289,7 @@ exports[`List items  1.  A paragraph
      > A block quote.
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -25342,7 +25342,7 @@ with two lines.",
 exports[`List items *
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -25365,7 +25365,7 @@ Object {
 exports[`List items *
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -25389,7 +25389,7 @@ exports[`List items > 1. > Blockquote
 > continued here.
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -25434,7 +25434,7 @@ exports[`List items > 1. > Blockquote
 > continued here.
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -25479,7 +25479,7 @@ exports[`List items > 1. > Blockquote
 continued here.
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -25524,7 +25524,7 @@ exports[`List items > 1. > Blockquote
 continued here.
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -25570,7 +25570,7 @@ exports[`List items >>- one
   >  > two
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -25622,7 +25622,7 @@ exports[`List items >>- one
   >  > two
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -25674,7 +25674,7 @@ exports[`List items -
   foo
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -25706,7 +25706,7 @@ exports[`List items -
   foo
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -25743,7 +25743,7 @@ exports[`List items -
       baz
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -25811,7 +25811,7 @@ exports[`List items -
       baz
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -25873,7 +25873,7 @@ exports[`List items -
   foo
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -25905,7 +25905,7 @@ exports[`List items -
   foo
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -25938,7 +25938,7 @@ exports[`List items -    foo
   bar
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -25978,7 +25978,7 @@ exports[`List items -    foo
   bar
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -26018,7 +26018,7 @@ exports[`List items -  foo
    bar
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -26058,7 +26058,7 @@ exports[`List items -  foo
    bar
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -26099,7 +26099,7 @@ exports[`List items - # Foo
   baz
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -26157,7 +26157,7 @@ exports[`List items - # Foo
   baz
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -26212,7 +26212,7 @@ Object {
 exports[`List items - - foo
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -26257,7 +26257,7 @@ Object {
 exports[`List items - - foo
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -26307,7 +26307,7 @@ exports[`List items - Foo
       baz
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -26354,7 +26354,7 @@ exports[`List items - Foo
       baz
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -26399,7 +26399,7 @@ exports[`List items - foo
   bar
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -26440,7 +26440,7 @@ exports[`List items - foo
   bar
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -26480,7 +26480,7 @@ exports[`List items - foo
       bar
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -26521,7 +26521,7 @@ exports[`List items - foo
       bar
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -26563,7 +26563,7 @@ exports[`List items - foo
       - boo
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -26660,7 +26660,7 @@ exports[`List items - foo
       - boo
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -26757,7 +26757,7 @@ exports[`List items - foo
    - boo
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -26830,7 +26830,7 @@ exports[`List items - foo
    - boo
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -26902,7 +26902,7 @@ exports[`List items - foo
 - bar
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -26953,7 +26953,7 @@ exports[`List items - foo
 - bar
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -27004,7 +27004,7 @@ exports[`List items - foo
 - bar
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -27055,7 +27055,7 @@ exports[`List items - foo
 - bar
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -27106,7 +27106,7 @@ exports[`List items - one
   two
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -27146,7 +27146,7 @@ exports[`List items - one
   two
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -27186,7 +27186,7 @@ exports[`List items - one
  two
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -27226,7 +27226,7 @@ exports[`List items - one
  two
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -27264,7 +27264,7 @@ Object {
 exports[`List items -1. not ok
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -27281,7 +27281,7 @@ Object {
 exports[`List items -1. not ok
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -27300,7 +27300,7 @@ exports[`List items -one
 2.two
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -27326,7 +27326,7 @@ exports[`List items -one
 2.two
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -27350,7 +27350,7 @@ Object {
 exports[`List items 0. ok
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -27382,7 +27382,7 @@ Object {
 exports[`List items 0. ok
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -27414,7 +27414,7 @@ Object {
 exports[`List items 003. ok
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -27446,7 +27446,7 @@ Object {
 exports[`List items 003. ok
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -27482,7 +27482,7 @@ exports[`List items 1.      indented code
        more code
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -27533,7 +27533,7 @@ exports[`List items 1.      indented code
        more code
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -27584,7 +27584,7 @@ exports[`List items 1.     indented code
        more code
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -27635,7 +27635,7 @@ exports[`List items 1.     indented code
        more code
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -27687,7 +27687,7 @@ exports[`List items 1.  A paragraph
     > A block quote.
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -27745,7 +27745,7 @@ exports[`List items 1.  A paragraph
     > A block quote.
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -27806,7 +27806,7 @@ exports[`List items 1.  foo
     > bam
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -27875,7 +27875,7 @@ exports[`List items 1.  foo
     > bam
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -27936,7 +27936,7 @@ Object {
 exports[`List items 1. - 2. foo
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -27996,7 +27996,7 @@ Object {
 exports[`List items 1. - 2. foo
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -28058,7 +28058,7 @@ exports[`List items 1. foo
 3. bar
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -28109,7 +28109,7 @@ exports[`List items 1. foo
 3. bar
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -28159,7 +28159,7 @@ exports[`List items 10) foo
     - bar
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -28213,7 +28213,7 @@ exports[`List items 10) foo
     - bar
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -28267,7 +28267,7 @@ exports[`List items 10) foo
    - bar
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -28321,7 +28321,7 @@ exports[`List items 10) foo
    - bar
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -28374,7 +28374,7 @@ Object {
 exports[`List items 123456789. ok
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -28406,7 +28406,7 @@ Object {
 exports[`List items 123456789. ok
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -28438,7 +28438,7 @@ Object {
 exports[`List items 1234567890. not ok
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -28455,7 +28455,7 @@ Object {
 exports[`List items 1234567890. not ok
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -28477,7 +28477,7 @@ with two lines.
 > A block quote.
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -28521,7 +28521,7 @@ with two lines.
 > A block quote.
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -28564,7 +28564,7 @@ foo
 1.
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -28594,7 +28594,7 @@ foo
 1.
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -28623,7 +28623,7 @@ exports[`Lists * a
 * c
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -28683,7 +28683,7 @@ exports[`Lists * a
 * c
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -28743,7 +28743,7 @@ exports[`Lists * a
 * c
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -28795,7 +28795,7 @@ exports[`Lists * a
 * c
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -28847,7 +28847,7 @@ exports[`Lists * foo
   baz
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -28909,7 +28909,7 @@ exports[`Lists * foo
   baz
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -28976,7 +28976,7 @@ exports[`Lists -   foo
     code
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -29051,7 +29051,7 @@ exports[`Lists -   foo
     code
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -29123,7 +29123,7 @@ exports[`Lists - a
 - d
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -29195,7 +29195,7 @@ exports[`Lists - a
 - d
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -29266,7 +29266,7 @@ exports[`Lists - a
 - d
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -29342,7 +29342,7 @@ exports[`Lists - a
 - d
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -29420,7 +29420,7 @@ exports[`Lists - a
   - f
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -29538,7 +29538,7 @@ exports[`Lists - a
   - f
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -29651,7 +29651,7 @@ exports[`Lists - a
   - b
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -29704,7 +29704,7 @@ exports[`Lists - a
   - b
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -29764,7 +29764,7 @@ exports[`Lists - a
 - i
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -29907,7 +29907,7 @@ exports[`Lists - a
 - i
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -30042,7 +30042,7 @@ Object {
 exports[`Lists - a
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -30073,7 +30073,7 @@ Object {
 exports[`Lists - a
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -30110,7 +30110,7 @@ exports[`Lists - a
 - c
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -30178,7 +30178,7 @@ exports[`Lists - a
 - c
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -30244,7 +30244,7 @@ exports[`Lists - a
 - d
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -30305,7 +30305,7 @@ exports[`Lists - a
 - d
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -30366,7 +30366,7 @@ exports[`Lists - a
 - d
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -30434,7 +30434,7 @@ exports[`Lists - a
 - d
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -30501,7 +30501,7 @@ exports[`Lists - a
 - c
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -30561,7 +30561,7 @@ exports[`Lists - a
 - c
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -30623,7 +30623,7 @@ exports[`Lists - foo
 - baz
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -30685,7 +30685,7 @@ exports[`Lists - foo
 - baz
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -30747,7 +30747,7 @@ exports[`Lists - foo
       bim
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -30832,7 +30832,7 @@ exports[`Lists - foo
       bim
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -30918,7 +30918,7 @@ exports[`Lists - foo
 - bim
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -31010,7 +31010,7 @@ exports[`Lists - foo
 - bim
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -31098,7 +31098,7 @@ exports[`Lists - foo
 + baz
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -31165,7 +31165,7 @@ exports[`Lists - foo
 + baz
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -31234,7 +31234,7 @@ exports[`Lists 1. \`\`\`
    bar
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -31279,7 +31279,7 @@ exports[`Lists 1. \`\`\`
    bar
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -31324,7 +31324,7 @@ exports[`Lists 1. a
     3. c
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -31385,7 +31385,7 @@ exports[`Lists 1. a
     3. c
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -31444,7 +31444,7 @@ exports[`Lists 1. foo
 3) baz
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -31512,7 +31512,7 @@ exports[`Lists 1. foo
 3) baz
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -31580,7 +31580,7 @@ exports[`Lists Foo
 - baz
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -31633,7 +31633,7 @@ exports[`Lists Foo
 - baz
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -31685,7 +31685,7 @@ exports[`Lists The number of windows in my house is
 1.  The number of doors is 6.
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -31724,7 +31724,7 @@ exports[`Lists The number of windows in my house is
 1.  The number of doors is 6.
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -31763,7 +31763,7 @@ exports[`Lists The number of windows in my house is
 14.  The number of doors is 6.
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -31782,7 +31782,7 @@ exports[`Lists The number of windows in my house is
 14.  The number of doors is 6.
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -31801,7 +31801,7 @@ exports[`Paragraphs     aaa
 bbb
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -31827,7 +31827,7 @@ exports[`Paragraphs     aaa
 bbb
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -31853,7 +31853,7 @@ exports[`Paragraphs    aaa
 bbb
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -31872,7 +31872,7 @@ exports[`Paragraphs    aaa
 bbb
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -31891,7 +31891,7 @@ exports[`Paragraphs   aaa
  bbb
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -31910,7 +31910,7 @@ exports[`Paragraphs   aaa
  bbb
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -31931,7 +31931,7 @@ exports[`Paragraphs aaa
 bbb
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -31958,7 +31958,7 @@ exports[`Paragraphs aaa
 bbb
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -31984,7 +31984,7 @@ exports[`Paragraphs aaa
 bbb
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -32010,7 +32010,7 @@ exports[`Paragraphs aaa
 bbb
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -32036,7 +32036,7 @@ exports[`Paragraphs aaa
                                        ccc
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -32057,7 +32057,7 @@ exports[`Paragraphs aaa
                                        ccc
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -32080,7 +32080,7 @@ ccc
 ddd
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -32110,7 +32110,7 @@ ccc
 ddd
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -32137,7 +32137,7 @@ exports[`Paragraphs aaa
 bbb     
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -32161,7 +32161,7 @@ exports[`Paragraphs aaa
 bbb     
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -32185,7 +32185,7 @@ exports[`Precedence - \`one
 - two\`
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -32230,7 +32230,7 @@ exports[`Precedence - \`one
 - two\`
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -32275,7 +32275,7 @@ exports[`Raw HTML < a><
 foo><bar/ >
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -32294,7 +32294,7 @@ exports[`Raw HTML < a><
 foo><bar/ >
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -32312,7 +32312,7 @@ foo><bar/ >",
 exports[`Raw HTML </a href="foo">
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -32329,7 +32329,7 @@ Object {
 exports[`Raw HTML </a href="foo">
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -32346,7 +32346,7 @@ Object {
 exports[`Raw HTML </a></foo >
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -32376,7 +32376,7 @@ Object {
 exports[`Raw HTML </a></foo >
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -32406,7 +32406,7 @@ Object {
 exports[`Raw HTML <33> <__>
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -32423,7 +32423,7 @@ Object {
 exports[`Raw HTML <33> <__>
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -32441,7 +32441,7 @@ exports[`Raw HTML <a  /><b2
 data="foo" >
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -32473,7 +32473,7 @@ exports[`Raw HTML <a  /><b2
 data="foo" >
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -32505,7 +32505,7 @@ exports[`Raw HTML <a foo="bar" bam = 'baz <em>"</em>'
 _boolean zoop:33=zoop:33 />
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -32530,7 +32530,7 @@ exports[`Raw HTML <a foo="bar" bam = 'baz <em>"</em>'
 _boolean zoop:33=zoop:33 />
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -32554,7 +32554,7 @@ _boolean zoop:33=zoop:33 />",
 exports[`Raw HTML <a h*#ref="hi">
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -32571,7 +32571,7 @@ Object {
 exports[`Raw HTML <a h*#ref="hi">
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -32588,7 +32588,7 @@ Object {
 exports[`Raw HTML <a href="\\"">
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -32605,7 +32605,7 @@ Object {
 exports[`Raw HTML <a href="\\"">
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -32622,7 +32622,7 @@ Object {
 exports[`Raw HTML <a href="hi'> <a href=hi'>
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -32639,7 +32639,7 @@ Object {
 exports[`Raw HTML <a href="hi'> <a href=hi'>
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -32656,7 +32656,7 @@ Object {
 exports[`Raw HTML <a href='bar'title=title>
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -32673,7 +32673,7 @@ Object {
 exports[`Raw HTML <a href='bar'title=title>
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -32690,7 +32690,7 @@ Object {
 exports[`Raw HTML <a/><b2/>
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -32720,7 +32720,7 @@ Object {
 exports[`Raw HTML <a/><b2/>
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -32750,7 +32750,7 @@ Object {
 exports[`Raw HTML <a><bab><c2c>
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -32787,7 +32787,7 @@ Object {
 exports[`Raw HTML <a><bab><c2c>
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -32824,7 +32824,7 @@ Object {
 exports[`Raw HTML Foo <responsive-image src="foo.jpg" />
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -32848,7 +32848,7 @@ Object {
 exports[`Raw HTML Foo <responsive-image src="foo.jpg" />
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -32872,7 +32872,7 @@ Object {
 exports[`Raw HTML foo <![CDATA[>&<]]>
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -32896,7 +32896,7 @@ Object {
 exports[`Raw HTML foo <![CDATA[>&<]]>
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -32920,7 +32920,7 @@ Object {
 exports[`Raw HTML foo <!-- not a comment -- two hyphens -->
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -32937,7 +32937,7 @@ Object {
 exports[`Raw HTML foo <!-- not a comment -- two hyphens -->
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -32955,7 +32955,7 @@ exports[`Raw HTML foo <!-- this is a
 comment - with hyphen -->
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -32981,7 +32981,7 @@ exports[`Raw HTML foo <!-- this is a
 comment - with hyphen -->
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -33008,7 +33008,7 @@ exports[`Raw HTML foo <!--> foo -->
 foo <!-- foo--->
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -33034,7 +33034,7 @@ exports[`Raw HTML foo <!--> foo -->
 foo <!-- foo--->
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -33058,7 +33058,7 @@ Object {
 exports[`Raw HTML foo <!ELEMENT br EMPTY>
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -33082,7 +33082,7 @@ Object {
 exports[`Raw HTML foo <!ELEMENT br EMPTY>
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -33106,7 +33106,7 @@ Object {
 exports[`Raw HTML foo <?php echo $a; ?>
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -33130,7 +33130,7 @@ Object {
 exports[`Raw HTML foo <?php echo $a; ?>
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -33154,7 +33154,7 @@ Object {
 exports[`Raw HTML foo <a href="&ouml;">
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -33178,7 +33178,7 @@ Object {
 exports[`Raw HTML foo <a href="&ouml;">
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -33202,7 +33202,7 @@ Object {
 exports[`Raw HTML foo <a href="\\*">
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -33226,7 +33226,7 @@ Object {
 exports[`Raw HTML foo <a href="\\*">
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -33251,7 +33251,7 @@ exports[`Setext headings
 ====
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -33269,7 +33269,7 @@ exports[`Setext headings
 ====
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -33290,7 +33290,7 @@ exports[`Setext headings     Foo
 ---
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -33320,7 +33320,7 @@ exports[`Setext headings     Foo
 ---
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -33347,7 +33347,7 @@ exports[`Setext headings     foo
 ---
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -33371,7 +33371,7 @@ exports[`Setext headings     foo
 ---
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -33401,7 +33401,7 @@ exports[`Setext headings    Foo
   ===
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -33445,7 +33445,7 @@ exports[`Setext headings    Foo
   ===
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -33483,7 +33483,7 @@ exports[`Setext headings > Foo
 ---
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -33512,7 +33512,7 @@ exports[`Setext headings > Foo
 ---
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -33541,7 +33541,7 @@ exports[`Setext headings > foo
 -----
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -33570,7 +33570,7 @@ exports[`Setext headings > foo
 -----
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -33600,7 +33600,7 @@ bar
 ===
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -33627,7 +33627,7 @@ bar
 ===
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -33653,7 +33653,7 @@ exports[`Setext headings \\> foo
 ------
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -33673,7 +33673,7 @@ exports[`Setext headings \\> foo
 ------
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -33698,7 +33698,7 @@ exports[`Setext headings \`Foo
 of dashes"/>
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -33746,7 +33746,7 @@ exports[`Setext headings \`Foo
 of dashes"/>
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -33789,7 +33789,7 @@ exports[`Setext headings - Foo
 ---
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -33826,7 +33826,7 @@ exports[`Setext headings - Foo
 ---
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -33863,7 +33863,7 @@ exports[`Setext headings - foo
 -----
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -33900,7 +33900,7 @@ exports[`Setext headings - foo
 -----
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -33937,7 +33937,7 @@ exports[`Setext headings ---
 ---
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -33958,7 +33958,7 @@ exports[`Setext headings ---
 ---
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -33983,7 +33983,7 @@ Bar
 Baz
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -34028,7 +34028,7 @@ Bar
 Baz
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -34072,7 +34072,7 @@ bar
 baz
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -34109,7 +34109,7 @@ bar
 baz
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -34143,7 +34143,7 @@ exports[`Setext headings Foo
     ---
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -34162,7 +34162,7 @@ exports[`Setext headings Foo
     ---
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -34181,7 +34181,7 @@ exports[`Setext headings Foo
    ----      
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -34201,7 +34201,7 @@ exports[`Setext headings Foo
    ----      
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -34224,7 +34224,7 @@ Foo
 --- -
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -34258,7 +34258,7 @@ Foo
 --- -
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -34292,7 +34292,7 @@ Foo
 =
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -34324,7 +34324,7 @@ Foo
 =
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -34354,7 +34354,7 @@ Bar
 ---
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -34376,7 +34376,7 @@ Bar
 ---
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -34401,7 +34401,7 @@ bar
 baz
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -34436,7 +34436,7 @@ bar
 baz
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -34469,7 +34469,7 @@ bar
 baz
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -34502,7 +34502,7 @@ bar
 baz
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -34535,7 +34535,7 @@ bar
 baz
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -34558,7 +34558,7 @@ bar
 baz
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -34579,7 +34579,7 @@ exports[`Setext headings Foo
 -----
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -34599,7 +34599,7 @@ exports[`Setext headings Foo
 -----
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -34620,7 +34620,7 @@ baz*
 ====
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -34649,7 +34649,7 @@ baz*
 ====
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -34680,7 +34680,7 @@ Foo *bar*
 ---------
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -34726,7 +34726,7 @@ Foo *bar*
 ---------
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -34769,7 +34769,7 @@ exports[`Setext headings Foo\\
 ----
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -34789,7 +34789,7 @@ exports[`Setext headings Foo\\
 ----
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -34809,7 +34809,7 @@ exports[`Soft line breaks foo
 baz
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -34828,7 +34828,7 @@ exports[`Soft line breaks foo
 baz
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -34847,7 +34847,7 @@ exports[`Soft line breaks foo
  baz
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -34866,7 +34866,7 @@ exports[`Soft line breaks foo
  baz
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -34885,7 +34885,7 @@ exports[`Tabs     a→a
     ὐ→a
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -34905,7 +34905,7 @@ exports[`Tabs     a→a
     ὐ→a
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -34925,7 +34925,7 @@ exports[`Tabs     foo
 →bar
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -34945,7 +34945,7 @@ exports[`Tabs     foo
 →bar
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -34966,7 +34966,7 @@ exports[`Tabs   - foo
 →bar
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -35006,7 +35006,7 @@ exports[`Tabs   - foo
 →bar
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -35044,7 +35044,7 @@ Object {
 exports[`Tabs   →foo→baz→→bim
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -35062,7 +35062,7 @@ Object {
 exports[`Tabs   →foo→baz→→bim
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -35082,7 +35082,7 @@ exports[`Tabs  - foo
 → - baz
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -35157,7 +35157,7 @@ exports[`Tabs  - foo
 → - baz
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -35230,7 +35230,7 @@ Object {
 exports[`Tabs #→Foo
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -35249,7 +35249,7 @@ Object {
 exports[`Tabs #→Foo
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -35268,7 +35268,7 @@ Object {
 exports[`Tabs *→*→*→
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -35283,7 +35283,7 @@ Object {
 exports[`Tabs *→*→*→
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -35298,7 +35298,7 @@ Object {
 exports[`Tabs >→→foo
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -35322,7 +35322,7 @@ Object {
 exports[`Tabs >→→foo
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -35348,7 +35348,7 @@ exports[`Tabs - foo
 →→bar
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -35389,7 +35389,7 @@ exports[`Tabs - foo
 →→bar
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -35428,7 +35428,7 @@ Object {
 exports[`Tabs -→→foo
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -35460,7 +35460,7 @@ Object {
 exports[`Tabs -→→foo
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -35492,7 +35492,7 @@ Object {
 exports[`Tabs →foo→baz→→bim
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -35510,7 +35510,7 @@ Object {
 exports[`Tabs →foo→baz→→bim
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -35528,7 +35528,7 @@ Object {
 exports[`Textual content Foo χρῆν
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -35545,7 +35545,7 @@ Object {
 exports[`Textual content Foo χρῆν
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -35562,7 +35562,7 @@ Object {
 exports[`Textual content Multiple     spaces
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -35579,7 +35579,7 @@ Object {
 exports[`Textual content Multiple     spaces
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -35596,7 +35596,7 @@ Object {
 exports[`Textual content hello $.;'there
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -35613,7 +35613,7 @@ Object {
 exports[`Textual content hello $.;'there
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -35630,7 +35630,7 @@ Object {
 exports[`Thematic breaks     ***
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -35648,7 +35648,7 @@ Object {
 exports[`Thematic breaks     ***
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -35666,7 +35666,7 @@ Object {
 exports[`Thematic breaks  **  * ** * ** * **
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -35681,7 +35681,7 @@ Object {
 exports[`Thematic breaks  **  * ** * ** * **
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -35698,7 +35698,7 @@ exports[`Thematic breaks  ***
    ***
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -35725,7 +35725,7 @@ exports[`Thematic breaks  ***
    ***
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -35750,7 +35750,7 @@ Object {
 exports[`Thematic breaks  *-*
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -35773,7 +35773,7 @@ Object {
 exports[`Thematic breaks  *-*
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -35796,7 +35796,7 @@ Object {
 exports[`Thematic breaks  - - -
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -35811,7 +35811,7 @@ Object {
 exports[`Thematic breaks  - - -
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -35828,7 +35828,7 @@ exports[`Thematic breaks * Foo
 * Bar
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -35887,7 +35887,7 @@ exports[`Thematic breaks * Foo
 * Bar
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -35946,7 +35946,7 @@ exports[`Thematic breaks ***
 ___
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -35973,7 +35973,7 @@ exports[`Thematic breaks ***
 ___
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -35998,7 +35998,7 @@ Object {
 exports[`Thematic breaks +++
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -36015,7 +36015,7 @@ Object {
 exports[`Thematic breaks +++
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -36032,7 +36032,7 @@ Object {
 exports[`Thematic breaks ===
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -36049,7 +36049,7 @@ Object {
 exports[`Thematic breaks ===
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -36070,7 +36070,7 @@ a------
 ---a---
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -36105,7 +36105,7 @@ a------
 ---a---
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -36136,7 +36136,7 @@ Object {
 exports[`Thematic breaks _____________________________________
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -36151,7 +36151,7 @@ Object {
 exports[`Thematic breaks _____________________________________
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -36166,7 +36166,7 @@ Object {
 exports[`Thematic breaks -     -      -      -
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -36181,7 +36181,7 @@ Object {
 exports[`Thematic breaks -     -      -      -
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -36196,7 +36196,7 @@ Object {
 exports[`Thematic breaks - - - -    
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -36211,7 +36211,7 @@ Object {
 exports[`Thematic breaks - - - -    
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -36227,7 +36227,7 @@ exports[`Thematic breaks - Foo
 - * * *
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -36270,7 +36270,7 @@ exports[`Thematic breaks - Foo
 - * * *
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -36314,7 +36314,7 @@ exports[`Thematic breaks - foo
 - bar
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -36373,7 +36373,7 @@ exports[`Thematic breaks - foo
 - bar
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -36432,7 +36432,7 @@ exports[`Thematic breaks --
 __
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -36453,7 +36453,7 @@ exports[`Thematic breaks --
 __
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -36473,7 +36473,7 @@ exports[`Thematic breaks Foo
     ***
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -36492,7 +36492,7 @@ exports[`Thematic breaks Foo
     ***
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -36512,7 +36512,7 @@ exports[`Thematic breaks Foo
 bar
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -36543,7 +36543,7 @@ exports[`Thematic breaks Foo
 bar
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {},
@@ -36574,7 +36574,7 @@ exports[`Thematic breaks Foo
 bar
  1`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {
@@ -36602,7 +36602,7 @@ exports[`Thematic breaks Foo
 bar
  2`] = `
 Object {
-  "attributes": undefined,
+  "attributes": Object {},
   "children": Array [
     Object {
       "attributes": Object {

--- a/packages/@atjson/renderer-commonmark/test/commonmark-spec-test.ts
+++ b/packages/@atjson/renderer-commonmark/test/commonmark-spec-test.ts
@@ -3,7 +3,7 @@
  */
 import Document from '@atjson/document';
 import { HIR } from '@atjson/hir';
-import CommonMarkRenderer from '@atjson/renderer-commonmark';
+import CommonMarkRenderer from '../src/index';
 import CommonMarkSource from '@atjson/source-commonmark';
 import * as MarkdownIt from 'markdown-it';
 import * as spec from 'commonmark-spec';

--- a/packages/@atjson/renderer-commonmark/test/commonmark-test.ts
+++ b/packages/@atjson/renderer-commonmark/test/commonmark-test.ts
@@ -1,5 +1,5 @@
 import Document from '@atjson/document';
-import CommonMarkRenderer from '@atjson/renderer-commonmark';
+import CommonMarkRenderer from '../src/index';
 import schema from '@atjson/schema';
 
 describe('commonmark', () => {
@@ -16,6 +16,35 @@ describe('commonmark', () => {
 
     let renderer = new CommonMarkRenderer();
     expect(renderer.render(document)).toBe('Some text that is both **bold *and*** *italic* plus something after.');
+  });
+
+  it('sub-documents', () => {
+    let document = new Document({
+      content: '\uFFFC',
+      contentType: 'text/atjson',
+      annotations: [{ 
+        type: 'image',
+        start: 0,
+        end: 1,
+        attributes: {
+          url: 'http://commonmark.org/images/markdown-mark.png',
+          description: new Document({
+            content: 'Hello!',
+            contentType: 'text/atjson',
+            annotations: [{
+              type: 'bold',
+              start: 0,
+              end: 5
+            }],
+            schema
+          })
+        }
+      }],
+      schema
+    });
+
+    let renderer = new CommonMarkRenderer();
+    expect(renderer.render(document)).toBe('![**Hello**\\!](http://commonmark.org/images/markdown-mark.png)');
   });
 
   it('a plain text document with virtual paragraphs', () => {

--- a/packages/@atjson/source-html/test/source-html-test.ts
+++ b/packages/@atjson/source-html/test/source-html-test.ts
@@ -9,7 +9,7 @@ describe('@atjson/source-html', () => {
 
     expect(hir).toEqual({
       type: 'root',
-      attributes: undefined,
+      attributes: {},
       children: [{
         type: '-html-pre',
         attributes: {},
@@ -34,7 +34,7 @@ describe('@atjson/source-html', () => {
     let hir = new HIR(doc).toJSON();
     expect(hir).toEqual({
       type: 'root',
-      attributes: undefined,
+      attributes: {},
       children: [{
         type: '-html-p',
         attributes: {},
@@ -51,7 +51,7 @@ describe('@atjson/source-html', () => {
 
     expect(hir).toEqual({
       type: 'root',
-      attributes: undefined,
+      attributes: {},
       children: [{
         type: '-html-a',
         attributes: {
@@ -67,7 +67,7 @@ describe('@atjson/source-html', () => {
     let hir = new HIR(doc).toJSON();
     expect(hir).toEqual({
       type: 'root',
-      attributes: undefined,
+      attributes: {},
       children: [{
         type: '-html-img',
         attributes: {
@@ -83,7 +83,7 @@ describe('@atjson/source-html', () => {
     let hir = new HIR(doc).toJSON();
     expect(hir).toEqual({
       type: 'root',
-      attributes: undefined,
+      attributes: {},
       children: [{
         type: '-html-h2',
         attributes: {},
@@ -105,7 +105,7 @@ describe('@atjson/source-html', () => {
     let hir = new HIR(doc).toJSON();
     expect(hir).toEqual({
       type: 'root',
-      attributes: undefined,
+      attributes: {},
       children: [{
         type: '-html-p',
         attributes: {},
@@ -127,7 +127,7 @@ describe('@atjson/source-html', () => {
     let hir = new HIR(doc).toJSON();
     expect(hir).toEqual({
       type: 'root',
-      attributes: undefined,
+      attributes: {},
       children: [{
         type: '-html-p',
         attributes: {},
@@ -146,7 +146,7 @@ describe('@atjson/source-html', () => {
     let hir = new HIR(doc).toJSON();
     expect(hir).toEqual({
       type: 'root',
-      attributes: undefined,
+      attributes: {},
       children: ['<>']
     });
   });
@@ -156,7 +156,7 @@ describe('@atjson/source-html', () => {
     let hir = new HIR(doc).toJSON();
     expect(hir).toEqual({
       type: 'root',
-      attributes: undefined,
+      attributes: {},
       children: [{
         type: '-html-a',
         attributes {
@@ -173,7 +173,7 @@ describe('@atjson/source-html', () => {
       let hir = new HIR(doc.toCommonSchema()).toJSON();
       expect(hir).toEqual({
         type: 'root',
-        attributes: undefined,
+        attributes: {},
         children: ['This ', {
           type: 'bold',
           attributes: {},
@@ -191,7 +191,7 @@ describe('@atjson/source-html', () => {
       let hir = new HIR(doc.toCommonSchema()).toJSON();
       expect(hir).toEqual({
         type: 'root',
-        attributes: undefined,
+        attributes: {},
         children: ['This ', {
           type: 'italic',
           attributes: {},
@@ -209,7 +209,7 @@ describe('@atjson/source-html', () => {
       let hir = new HIR(doc.toCommonSchema()).toJSON();
       expect(hir).toEqual({
         type: 'root',
-        attributes: undefined,
+        attributes: {},
         children: [{
           type: 'heading',
           attributes: { level: 1 },
@@ -243,7 +243,7 @@ describe('@atjson/source-html', () => {
       let hir = new HIR(doc.toCommonSchema()).toJSON();
       expect(hir).toEqual({
         type: 'root',
-        attributes: undefined,
+        attributes: {},
         children: [{
           type: 'paragraph',
           attributes: {},
@@ -261,7 +261,7 @@ describe('@atjson/source-html', () => {
       let hir = new HIR(doc.toCommonSchema()).toJSON();
       expect(hir).toEqual({
         type: 'root',
-        attributes: undefined,
+        attributes: {},
         children: ['This ', {
           type: 'link',
           attributes: {
@@ -277,7 +277,7 @@ describe('@atjson/source-html', () => {
       let hir = new HIR(doc.toCommonSchema()).toJSON();
       expect(hir).toEqual({
         type: 'root',
-        attributes: undefined,
+        attributes: {},
         children: ['Horizontal ', {
           type: 'horizontal-rule',
           attributes: {},
@@ -291,7 +291,7 @@ describe('@atjson/source-html', () => {
       let hir = new HIR(doc.toCommonSchema()).toJSON();
       expect(hir).toEqual({
         type: 'root',
-        attributes: undefined,
+        attributes: {},
         children: [{
           type: 'image',
           attributes: {
@@ -309,7 +309,7 @@ describe('@atjson/source-html', () => {
       let hir = new HIR(doc.toCommonSchema()).toJSON();
       expect(hir).toEqual({
         type: 'root',
-        attributes: undefined,
+        attributes: {},
         children: [{
           type: 'blockquote',
           attributes: {},
@@ -323,7 +323,7 @@ describe('@atjson/source-html', () => {
       let hir = new HIR(doc.toCommonSchema()).toJSON();
       expect(hir).toEqual({
         type: 'root',
-        attributes: undefined,
+        attributes: {},
         children: [{
           type: 'list',
           attributes: {


### PR DESCRIPTION
This feature allows for better serialization of our hierarchical intermediate representation as well as some better developer ergonomics.

So, before, to render a sub-document:

```ts
import CommonMarkRenderer, { Annotation } from '@atjson/renderer-commonmark';

export default class extends CommonMarkRenderer {
  *figure(node: Annotation): Iterable<any> {
     return `![node.description](node.url)|||${this.render(node.caption)}|||`
  }
}
```

After, this becomes:

```ts
import CommonMarkRenderer, { Annotation } from '@atjson/renderer-commonmark';

export default class extends CommonMarkRenderer {
  *figure(node: Annotation): Iterable<any> {
     return `![node.description](node.url)|||${node.caption}|||`
  }
}
```