### PR TITLE
Fix empty paragraphs created by narrow no-break space

### DIFF
--- a/packages/@atjson/renderer-commonmark/src/index.ts
+++ b/packages/@atjson/renderer-commonmark/src/index.ts
@@ -141,7 +141,7 @@ export default class CommonmarkRenderer {
     if (this.state.isPreformatted) {
       return text;
     }
-    return escapePunctuation(text).replace(/\u00A0/gu, '&nbsp;');
+    return escapePunctuation(text).replace(/\u00A0/gu, '&nbsp;').replace(/\u202F/gu, '&#8239;');
   }
 
   /**

--- a/packages/@atjson/renderer-commonmark/src/index.ts
+++ b/packages/@atjson/renderer-commonmark/src/index.ts
@@ -141,7 +141,7 @@ export default class CommonmarkRenderer {
     if (this.state.isPreformatted) {
       return text;
     }
-    return escapePunctuation(text).replace(/\u00A0/gu, '&nbsp;').replace(/\u202F/gu, '&#8239;');
+    return escapePunctuation(text).replace(/\u00A0/gu, '&nbsp;');
   }
 
   /**

--- a/packages/@atjson/renderer-commonmark/test/commonmark-test.ts
+++ b/packages/@atjson/renderer-commonmark/test/commonmark-test.ts
@@ -301,7 +301,7 @@ After all the lists
 
   test('non-breaking spaces don\'t recieve formatting', () => {
     let document = new Document({
-      content: '\u00A0\ntext\n',
+      content: '\u00A0\ntext\n\u202F',
       annotations: [{
         type: 'bold', start: 0, end: 7
       }, {
@@ -317,7 +317,7 @@ After all the lists
     });
 
     let renderer = new CommonMarkRenderer();
-    expect(renderer.render(document)).toBe('&nbsp;\n\n**text**\n\n');
+    expect(renderer.render(document)).toBe('&nbsp;\n\n**text**\n\n&#8239;');
   });
 
   test('line feed characters don\'t recieve formatting', () => {

--- a/packages/@atjson/renderer-commonmark/test/commonmark-test.ts
+++ b/packages/@atjson/renderer-commonmark/test/commonmark-test.ts
@@ -317,7 +317,7 @@ After all the lists
     });
 
     let renderer = new CommonMarkRenderer();
-    expect(renderer.render(document)).toBe('&nbsp;\n\n**text**\n\n&#8239;');
+    expect(renderer.render(document)).toBe('&nbsp;\n\n**text**\n\n\u202F');
   });
 
   test('line feed characters don\'t recieve formatting', () => {

--- a/packages/@atjson/source-commonmark/src/index.ts
+++ b/packages/@atjson/source-commonmark/src/index.ts
@@ -130,11 +130,12 @@ class Parser {
       if (node.name === 'text') {
         this.content += node.value;
       } else if (node.open) {
+        // Markdown-It strips out all unicode whitespace characters.
         if (node.name === 'paragraph' && node.children.length === 0) {
           node.children.push({
             name: 'text',
             parent: node,
-            value: '\u00A0',
+            value: '\u202F',
             children: []
           });
         } else if (node.name === 'image' && node.open) {
@@ -213,11 +214,6 @@ export default class CommonMarkSource extends Document {
       schema: markdownSchema as Schema
     });
 
-    // Markdown-It strips out all unicode whitespace characters.
-    // Instead of varying between narrow non-breaking space and
-    // non-breaking spaces, we use U+00A0 (No-Break Space)
-    // for consistency
-    markdown = markdown.replace(/\u202F/gu, '\u00A0');
     let md = this.markdownParser();
     let parser = new Parser(md.parse(markdown, { linkify: false }), this.contentHandlers());
 

--- a/packages/@atjson/source-commonmark/src/index.ts
+++ b/packages/@atjson/source-commonmark/src/index.ts
@@ -130,15 +130,13 @@ class Parser {
       if (node.name === 'text') {
         this.content += node.value;
       } else if (node.open) {
-        // Markdown-it strips non-breaking spaces from paragraphs;
-        // we need to re-insert them :(
         if (node.name === 'paragraph' && node.children.length === 0) {
-          node.children = [{
+          node.children.push({
             name: 'text',
             parent: node,
             value: '\u00A0',
             children: []
-          }];
+          });
         } else if (node.name === 'image' && node.open) {
           let token = node.open;
           token.attrs = token.attrs || [];
@@ -215,6 +213,11 @@ export default class CommonMarkSource extends Document {
       schema: markdownSchema as Schema
     });
 
+    // Markdown-It strips out all unicode whitespace characters.
+    // Instead of varying between narrow non-breaking space and
+    // non-breaking spaces, we use U+00A0 (No-Break Space)
+    // for consistency
+    markdown = markdown.replace(/\u202F/gu, '\u00A0');
     let md = this.markdownParser();
     let parser = new Parser(md.parse(markdown, { linkify: false }), this.contentHandlers());
 

--- a/packages/@atjson/source-commonmark/test/commonmark-test.ts
+++ b/packages/@atjson/source-commonmark/test/commonmark-test.ts
@@ -40,7 +40,7 @@ describe('whitespace', () => {
       });
     });
 
-    test('unicode characters are retained', () => {
+    test('empty paragraphs are created using narrow no-break unicode characters', () => {
       let doc = new CommonMarkSource('1\n\n\u202F\n\n\u00A0\n\n2');
       let hir = new HIR(doc);
       expect(hir.toJSON()).toEqual({
@@ -53,11 +53,11 @@ describe('whitespace', () => {
         }, {
           type: 'paragraph',
           attributes: {},
-          children: ['\u00A0']
+          children: ['\u202F']
         }, {
           type: 'paragraph',
           attributes: {},
-          children: ['\u00A0']
+          children: ['\u202F']
         }, {
           type: 'paragraph',
           attributes: {},

--- a/packages/@atjson/source-commonmark/test/commonmark-test.ts
+++ b/packages/@atjson/source-commonmark/test/commonmark-test.ts
@@ -13,25 +13,57 @@ describe('whitespace', () => {
     expect(render(doc)).toBe('1\n2\n\n');
   });
 
-  test('non-breaking space unicode characters are converted to fixed-space annotations', () => {
-    let doc = new CommonMarkSource('1\n\n\u202F\n\n2');
-    let hir = new HIR(doc);
-    expect(hir.toJSON()).toEqual({
-      type: 'root',
-      attributes: {},
-      children: [{
-        type: 'paragraph',
+  describe('non-breaking spaces', () => {
+    test('html entities are converted to unicode characters', () => {
+      let doc = new CommonMarkSource('1\n\n&#8239;\n\n&nbsp;\n\n2');
+      let hir = new HIR(doc);
+      expect(hir.toJSON()).toEqual({
+        type: 'root',
         attributes: {},
-        children: ['1']
-      }, {
-        type: 'paragraph',
+        children: [{
+          type: 'paragraph',
+          attributes: {},
+          children: ['1']
+        }, {
+          type: 'paragraph',
+          attributes: {},
+          children: ['\u202F']
+        }, {
+          type: 'paragraph',
+          attributes: {},
+          children: ['\u00A0']
+        }, {
+          type: 'paragraph',
+          attributes: {},
+          children: ['2']
+        }]
+      });
+    });
+
+    test('unicode characters are retained', () => {
+      let doc = new CommonMarkSource('1\n\n\u202F\n\n\u00A0\n\n2');
+      let hir = new HIR(doc);
+      expect(hir.toJSON()).toEqual({
+        type: 'root',
         attributes: {},
-        children: ['\u00A0']
-      }, {
-        type: 'paragraph',
-        attributes: {},
-        children: ['2']
-      }]
+        children: [{
+          type: 'paragraph',
+          attributes: {},
+          children: ['1']
+        }, {
+          type: 'paragraph',
+          attributes: {},
+          children: ['\u00A0']
+        }, {
+          type: 'paragraph',
+          attributes: {},
+          children: ['\u00A0']
+        }, {
+          type: 'paragraph',
+          attributes: {},
+          children: ['2']
+        }]
+      });
     });
   });
 });


### PR DESCRIPTION
Narrow no-break spaces `U+202F` results in a blank paragraph from Markdown-It. Some of our brands use this to generate extra spacing between paragraphs.