### PR TITLE
Fix leading whitespace and tabs turning into code blocks

### DIFF
--- a/packages/@atjson/renderer-commonmark/package.json
+++ b/packages/@atjson/renderer-commonmark/package.json
@@ -16,6 +16,7 @@
     "access": "public"
   },
   "devDependencies": {
+    "@atjson/schema": "^0.7.16",
     "@atjson/source-commonmark": "^0.8.2",
     "commonmark-spec": "^0.28.0",
     "markdown-it": "^8.4.1"

--- a/packages/@atjson/renderer-commonmark/src/index.ts
+++ b/packages/@atjson/renderer-commonmark/src/index.ts
@@ -433,6 +433,15 @@ export default class CommonmarkRenderer {
    */
   *'paragraph'(): Iterable<any> {
     let text = yield;
+
+    // Remove leading and trailing newlines from paragraphs
+    // with text in them.
+    // This ensures that paragraphs preceded with tabs or spaces
+    // will not turn into code blocks
+    if (!text.match(/^\s+$/g)) {
+      text = text.replace(/^\s+/g, '').replace(/\s+$/g, '');
+    }
+
     if (this.state.tight) {
       return text + '\n';
     }

--- a/packages/@atjson/renderer-commonmark/test/commonmark-test.ts
+++ b/packages/@atjson/renderer-commonmark/test/commonmark-test.ts
@@ -1,6 +1,7 @@
 import Document from '@atjson/document';
-import CommonMarkRenderer from '../src/index';
 import schema from '@atjson/schema';
+import CommonMarkSource from '@atjson/source-commonmark';
+import CommonMarkRenderer from '../src/index';
 
 describe('commonmark', () => {
   it('raw atjson document', () => {
@@ -339,5 +340,24 @@ After all the lists
 
     let renderer = new CommonMarkRenderer();
     expect(renderer.render(document)).toBe('\u000b\n\n**text**\n\n');
+  });
+
+  test('tabs and leading / trailing spaces are stripped from output', () => {
+    let document = new Document({
+      content: '\tHello \n    This is my text',
+      annotations: [{
+        type: 'paragraph', start: 0, end: 8
+      }, {
+        type: 'paragraph', start: 8, end: 27
+      }],
+      schema
+    });
+
+    let renderer = new CommonMarkRenderer();
+    let markdown = renderer.render(document);
+
+    expect(renderer.render(document)).toBe('Hello\n\nThis is my text\n\n');
+    // Make sure we're not generating code in the round-trip
+    expect(markdown).toEqual(renderer.render(new CommonMarkSource(markdown).toCommonSchema()));
   });
 });


### PR DESCRIPTION
Leading whitespace from Google Docs, for example, was turning paragraphs into code blocks 😭 

This removes leading and trailing (non-significant) whitespace from paragraphs.