### PR TITLE
Unknown Annotations

### DIFF
--- a/packages/@atjson/document/src/annotation.ts
+++ b/packages/@atjson/document/src/annotation.ts
@@ -1,9 +1,25 @@
+
 import { Attributes, toJSON, unprefix } from './attributes';
 import Change, { AdjacentBoundaryBehaviour, Deletion, Insertion } from './change';
 
 export default abstract class Annotation {
   static vendorPrefix: string;
   static type: string;
+
+  static hydrate<T extends Annotation>(
+    this: {
+      vendorPrefix: string;
+      new(attributes: { start: number, end: number, attributes: Attributes }): T;
+    },
+    attrs: { start: number, end: number, attributes: Attributes }
+  ) {
+    return new this({
+      start: attrs.start,
+      end: attrs.end,
+      attributes: unprefix(this.vendorPrefix, attrs.attributes) as Attributes
+    });
+  }
+
   readonly type: string;
   abstract rank: number;
   start: number;
@@ -15,7 +31,8 @@ export default abstract class Annotation {
     this.type = AnnotationClass.type;
     this.start = attrs.start;
     this.end = attrs.end;
-    this.attributes = unprefix(AnnotationClass.vendorPrefix, attrs.attributes) as Attributes;
+
+    this.attributes = attrs.attributes;
   }
 
   /**

--- a/packages/@atjson/document/src/annotations/block.ts
+++ b/packages/@atjson/document/src/annotations/block.ts
@@ -1,4 +1,4 @@
-import Annotation from './annotation';
+import Annotation from '../annotation';
 
 export default abstract class BlockAnnotation extends Annotation {
   get rank() {

--- a/packages/@atjson/document/src/annotations/index.ts
+++ b/packages/@atjson/document/src/annotations/index.ts
@@ -1,0 +1,5 @@
+export { default as Block } from './block';
+export { default as Inline } from './inline';
+export { default as Object } from './object';
+export { default as Parse } from './parse';
+export { default as Unknown } from './unknown';

--- a/packages/@atjson/document/src/annotations/inline.ts
+++ b/packages/@atjson/document/src/annotations/inline.ts
@@ -1,4 +1,4 @@
-import Annotation from './annotation';
+import Annotation from '../annotation';
 
 export default abstract class InlineAnnotation extends Annotation {
   get rank() {

--- a/packages/@atjson/document/src/annotations/object.ts
+++ b/packages/@atjson/document/src/annotations/object.ts
@@ -1,4 +1,4 @@
-import Annotation from './annotation';
+import Annotation from '../annotation';
 
 export default abstract class ObjectAnnotation extends Annotation {
   get rank() {

--- a/packages/@atjson/document/src/annotations/parse.ts
+++ b/packages/@atjson/document/src/annotations/parse.ts
@@ -1,4 +1,4 @@
-import Annotation from './annotation';
+import Annotation from '../annotation';
 
 export default class ParseAnnotation extends Annotation {
   static vendorPrefix = 'atjson';

--- a/packages/@atjson/document/src/annotations/unknown.ts
+++ b/packages/@atjson/document/src/annotations/unknown.ts
@@ -4,7 +4,7 @@ import { Attributes } from '../attributes';
 export default class UnknownAnnotation extends Annotation {
   static vendorPrefix = 'atjson';
   static type = 'unknown';
-  attributes!: {
+  attributes: {
     type: string;
     attributes: Attributes;
   };

--- a/packages/@atjson/document/src/annotations/unknown.ts
+++ b/packages/@atjson/document/src/annotations/unknown.ts
@@ -1,0 +1,24 @@
+import Annotation from '../annotation';
+import { Attributes } from '../attributes';
+
+export default class UnknownAnnotation extends Annotation {
+  static vendorPrefix = 'atjson';
+  static type = 'unknown';
+  attributes!: {
+    type: string;
+    attributes: Attributes;
+  };
+
+  get rank() {
+    return Number.MAX_SAFE_INTEGER;
+  }
+
+  toJSON() {
+    return {
+      start: this.start,
+      end: this.end,
+      type: this.attributes.type,
+      attributes: this.attributes.attributes
+    };
+  }
+}

--- a/packages/@atjson/document/test/atjson-insert-test.ts
+++ b/packages/@atjson/document/test/atjson-insert-test.ts
@@ -1,4 +1,4 @@
-import { AdjacentBoundaryBehaviour } from '../src';
+import { AdjacentBoundaryBehaviour, UnknownAnnotation } from '../src';
 import TestSource, { Bold, Italic } from './test-source';
 
 describe('Document.insertText', () => {
@@ -19,20 +19,35 @@ describe('Document.insertText', () => {
         start: 1,
         end: 3,
         attributes: {}
+      }, {
+        type: '-test-link',
+        start: 1,
+        end: 2,
+        attributes: {
+          '-test-uri': 'https://example.com'
+        }
       }]
     });
 
     atjson.insertText(0, 'zzz');
     expect(atjson.content).toBe('zzzabcd');
 
-    let [bold] = atjson.annotations;
+    let [bold, unknown] = atjson.annotations;
     expect(bold).toBeInstanceOf(Bold);
-    expect(bold.toJSON()).toEqual({
+    expect(unknown).toBeInstanceOf(UnknownAnnotation);
+    expect(atjson.annotations.map(a => a.toJSON())).toEqual([{
       type: '-test-bold',
       start: 4,
       end: 6,
       attributes: {}
-    });
+    }, {
+      type: '-test-link',
+      start: 4,
+      end: 5,
+      attributes: {
+        '-test-uri': 'https://example.com'
+      }
+    }]);
   });
 
   test('insert text after an annotation doesn\'t affect it', () => {
@@ -43,19 +58,34 @@ describe('Document.insertText', () => {
         start: 0,
         end: 2,
         attributes: {}
+      }, {
+        type: '-test-color',
+        start: 0,
+        end: 2,
+        attributes: {
+          '-test-color': 'blue'
+        }
       }]
     });
     atjson.insertText(3, 'zzz');
     expect(atjson.content).toBe('abczzzd');
 
-    let [italic] = atjson.annotations;
+    let [italic, unknown] = atjson.annotations;
     expect(italic).toBeInstanceOf(Italic);
-    expect(italic.toJSON()).toEqual({
+    expect(unknown).toBeInstanceOf(UnknownAnnotation);
+    expect(atjson.annotations.map(a => a.toJSON())).toEqual([{
       type: '-test-italic',
       start: 0,
       end: 2,
       attributes: {}
-    });
+    }, {
+      type: '-test-color',
+      start: 0,
+      end: 2,
+      attributes: {
+        '-test-color': 'blue'
+      }
+    }]);
   });
 
   test('insert text inside an annotation adjusts the endpoint', () => {
@@ -66,19 +96,30 @@ describe('Document.insertText', () => {
         start: 1,
         end: 3,
         attributes: {}
+      }, {
+        type: '-test-underline',
+        start: 1,
+        end: 3,
+        attributes: {}
       }]
     });
     atjson.insertText(2, 'xyz');
     expect(atjson.content).toBe('abxyzcd');
 
-    let [bold] = atjson.annotations;
+    let [bold, unknown] = atjson.annotations;
     expect(bold).toBeInstanceOf(Bold);
-    expect(bold.toJSON()).toEqual({
+    expect(unknown).toBeInstanceOf(UnknownAnnotation);
+    expect(atjson.annotations.map(a => a.toJSON())).toEqual([{
       type: '-test-bold',
       start: 1,
       end: 6,
       attributes: {}
-    });
+    }, {
+      type: '-test-underline',
+      start: 1,
+      end: 6,
+      attributes: {}
+    }]);
   });
 
   test('insert text at the left boundary of an annotation', () => {
@@ -89,12 +130,22 @@ describe('Document.insertText', () => {
         start: 0,
         end: 2,
         attributes: {}
+      }, {
+        type: '-test-strikethrough',
+        start: 0,
+        end: 2,
+        attributes: {}
       }]
     });
     atjson.insertText(0, 'zzz');
     expect(atjson.content).toBe('zzzabcd');
     expect(atjson.annotations.map(a => a.toJSON())).toEqual([{
       type: '-test-italic',
+      start: 3,
+      end: 5,
+      attributes: {}
+    }, {
+      type: '-test-strikethrough',
       start: 3,
       end: 5,
       attributes: {}
@@ -109,12 +160,22 @@ describe('Document.insertText', () => {
         start: 0,
         end: 2,
         attributes: {}
+      }, {
+        type: '-test-underline',
+        start: 0,
+        end: 2,
+        attributes: {}
       }]
     });
     atjson.insertText(2, 'zzz');
     expect(atjson.content).toBe('abzzzcd');
     expect(atjson.annotations.map(a => a.toJSON())).toEqual([{
       type: '-test-italic',
+      start: 0,
+      end: 5,
+      attributes: {}
+    }, {
+      type: '-test-underline',
       start: 0,
       end: 5,
       attributes: {}
@@ -134,6 +195,16 @@ describe('Document.insertText', () => {
         start: 1,
         end: 2,
         attributes: {}
+      }, {
+        type: '-test-superscript',
+        start: 0,
+        end: 1,
+        attributes: {}
+      }, {
+        type: '-test-subscript',
+        start: 1,
+        end: 2,
+        attributes: {}
       }]
     });
 
@@ -147,6 +218,16 @@ describe('Document.insertText', () => {
       attributes: {}
     }, {
       type: '-test-bold',
+      start: 2,
+      end: 3,
+      attributes: {}
+    }, {
+      type: '-test-superscript',
+      start: 0,
+      end: 2,
+      attributes: {}
+    }, {
+      type: '-test-subscript',
       start: 2,
       end: 3,
       attributes: {}
@@ -181,6 +262,11 @@ describe('Document.insertText', () => {
         start: 0,
         end: 2,
         attributes: {}
+      }, {
+        type: '-test-underline',
+        start: 0,
+        end: 2,
+        attributes: {}
       }]
     });
 
@@ -188,6 +274,11 @@ describe('Document.insertText', () => {
     expect(atjson.content).toBe('abzzzcd');
     expect(atjson.annotations.map(a => a.toJSON())).toEqual([{
       type: '-test-italic',
+      start: 0,
+      end: 2,
+      attributes: {}
+    }, {
+      type: '-test-underline',
       start: 0,
       end: 2,
       attributes: {}
@@ -234,12 +325,30 @@ describe('Document.insertText', () => {
         start: 0,
         end: 2,
         attributes: {}
+      }, {
+        type: '-test-emoji',
+        start: 0,
+        end: 2,
+        attributes: {
+          '-test-emoji': '❤️'
+        }
       }]
     });
 
     atjson.insertText(2, 'zzz');
     expect(atjson.content).toBe('abzzzcd');
-    expect(atjson.annotations[0].start).toBe(1);
-    expect(atjson.annotations[0].end).toBe(3);
+    expect(atjson.annotations.map(a => a.toJSON())).toEqual([{
+      type: '-test-manual',
+      start: 1,
+      end: 3,
+      attributes: {}
+    }, {
+      type: '-test-emoji',
+      start: 0,
+      end: 5,
+      attributes: {
+        '-test-emoji': '❤️'
+      }
+    }]);
   });
 });

--- a/packages/@atjson/document/test/atjson-test.ts
+++ b/packages/@atjson/document/test/atjson-test.ts
@@ -33,6 +33,11 @@ describe('new Document', () => {
         start: 0,
         end: 13,
         attributes: {}
+      }, {
+        type: '-test-underline',
+        start: 0,
+        end: 13,
+        attributes: {}
       }]
     });
 
@@ -54,6 +59,11 @@ describe('new Document', () => {
           start: 0,
           end: 12,
           attributes: {}
+        }, {
+          type: '-test-underline',
+          start: 0,
+          end: 12,
+          attributes: {}
         }]
       });
 
@@ -68,6 +78,11 @@ describe('new Document', () => {
           attributes: {}
         }, {
           type: '-test-italic',
+          start: 0,
+          end: 13,
+          attributes: {}
+        }, {
+          type: '-test-underline',
           start: 0,
           end: 13,
           attributes: {}

--- a/packages/@atjson/document/test/query-test.ts
+++ b/packages/@atjson/document/test/query-test.ts
@@ -1,74 +1,85 @@
-import Document from '@atjson/document';
+import { AnnotationJSON } from '../src';
+import TestSource from './test-source';
 
 describe.skip('Document.where', () => {
   it('runs queries against existing annotations', () => {
-    let doc = new Document({
+    let doc = new TestSource({
       content: 'Hello',
       annotations: [{
-        type: 'strong',
+        type: '-test-strong',
         start: 0,
-        end: 5
+        end: 5,
+        attributes: {}
       }, {
-        type: 'em',
+        type: '-test-emphasis',
         start: 0,
-        end: 5
+        end: 5,
+        attributes: {}
       }]
     });
 
-    doc.where({ type: 'strong' }).set({ type: 'bold' });
-    doc.where({ type: 'em' }).set({ type: 'italic' });
+    doc.where({ type: '-test-strong' }).set({ type: '-test-bold' });
+    doc.where({ type: '-test-em' }).set({ type: '-test-italic' });
     expect(doc.content).toBe('Hello');
-    expect(doc.annotations).toEqual([{
-      type: 'bold',
+
+    expect(doc.annotations.map(a => a.toJSON())).toEqual([{
+      type: '-test-bold',
       start: 0,
-      end: 5
+      end: 5,
+      attributes: {}
     }, {
-      type: 'italic',
+      type: '-test-italic',
       start: 0,
-      end: 5
+      end: 5,
+      attributes: {}
     }]);
   });
 
   it('runs queries against new annotations', () => {
-    let doc = new Document({
+    let doc = new TestSource({
       content: 'Hello',
       annotations: []
     });
 
-    doc.where({ type: 'strong' }).set({ type: 'bold' });
-    doc.where({ type: 'em' }).set({ type: 'italic' });
+    doc.where({ type: '-test-strong' }).set({ type: '-test-bold' });
+    doc.where({ type: '-test-emphasis' }).set({ type: '-test-italic' });
     doc.addAnnotations({
-      type: 'strong',
+      type: '-test-strong',
       start: 0,
-      end: 5
+      end: 5,
+      attributes: {}
     }, {
-      type: 'em',
+      type: '-test-emphasis',
       start: 0,
-      end: 5
+      end: 5,
+      attributes: {}
     });
     expect(doc.content).toBe('Hello');
-    expect(doc.annotations).toEqual([{
-      type: 'bold',
+    expect(doc.annotations.map(a => a.toJSON())).toEqual([{
+      type: '-test-bold',
       start: 0,
-      end: 5
+      end: 5,
+      attributes: {}
     }, {
-      type: 'italic',
+      type: '-test-italic',
       start: 0,
-      end: 5
+      end: 5,
+      attributes: {}
     }]);
   });
 
   it('set', () => {
-    let doc = new Document({
+    let doc = new TestSource({
       content: 'Hello',
       annotations: []
     });
 
-    doc.where({ type: 'h1' }).set({ type: 'heading', attributes: { level: 1 } });
+    doc.where({ type: '-test-h1' }).set({ type: '-test-heading', attributes: { level: 1 } });
     doc.addAnnotations({
       type: 'h1',
       start: 0,
-      end: 5
+      end: 5,
+      attributes: {}
     });
     expect(doc.content).toBe('Hello');
     expect(doc.annotations).toEqual([{
@@ -82,41 +93,41 @@ describe.skip('Document.where', () => {
   });
 
   it('unset', () => {
-    let doc = new Document({
+    let doc = new TestSource({
       content: '\uFFFC\uFFFC',
       annotations: [{
-        type: 'embed',
+        type: '-test-social',
         attributes: {
-          type: 'instagram',
-          url: 'https://www.instagram.com/p/BeW0pqZDUuK/'
+          '-test-type': 'instagram',
+          '-test-uri': 'https://www.instagram.com/p/BeW0pqZDUuK/'
         },
         start: 0,
         end: 1
       }]
     });
 
-    doc.where({ type: 'embed', attributes: { type: 'instagram' } }).set({ type: 'instagram' }).unset('attributes.type');
+    doc.where({ type: '-test-social', attributes: { '-test-type': 'instagram' } }).set({ type: '-test-instagram' }).unset('attributes.-test-type');
     doc.addAnnotations({
-      type: 'embed',
+      type: '-test-social',
       attributes: {
-        type: 'instagram',
-        url: 'https://www.instagram.com/p/BdyySYBDvpm/'
+        '-test-type': 'instagram',
+        '-test-uri': 'https://www.instagram.com/p/BdyySYBDvpm/'
       },
       start: 1,
       end: 2
     });
     expect(doc.content).toBe('\uFFFC\uFFFC');
-    expect(doc.annotations).toEqual([{
-      type: 'instagram',
+    expect(doc.annotations.map(a => a.toJSON())).toEqual([{
+      type: '-test-instagram',
       attributes: {
-        url: 'https://www.instagram.com/p/BeW0pqZDUuK/'
+        '-test-uri': 'https://www.instagram.com/p/BeW0pqZDUuK/'
       },
       start: 0,
       end: 1
     }, {
-      type: 'instagram',
+      type: '-test-instagram',
       attributes: {
-        url: 'https://www.instagram.com/p/BdyySYBDvpm/'
+        '-test-uri': 'https://www.instagram.com/p/BdyySYBDvpm/'
       },
       start: 1,
       end: 2
@@ -124,7 +135,7 @@ describe.skip('Document.where', () => {
   });
 
   it('rename', () => {
-    let doc = new Document({
+    let doc = new TestSource({
       content: 'Conde Nast',
       annotations: [{
         type: 'a',
@@ -136,67 +147,27 @@ describe.skip('Document.where', () => {
       }]
     });
 
-    doc.where({ type: 'a' }).set({ type: 'link' }).rename({ attributes: { href: 'url' } });
+    doc.where({ type: '-test-a' }).set({ type: '-test-link' }).rename({ attributes: { '-test-href': '-test-url' } });
     doc.addAnnotations({
-      type: 'a',
+      type: '-test-a',
       attributes: {
-        href: 'https://condenast.com'
+        '-test-href': 'https://condenast.com'
       },
       start: 6,
       end: 10
     });
     expect(doc.content).toBe('Conde Nast');
-    expect(doc.annotations).toEqual([{
-      type: 'link',
+    expect(doc.annotations.map(a => a.toJSON())).toEqual([{
+      type: '-test-link',
       attributes: {
-        url: 'https://example.com'
+        '-test-url': 'https://example.com'
       },
       start: 0,
       end: 5
     }, {
-      type: 'link',
+      type: '-test-link',
       attributes: {
-        url: 'https://condenast.com'
-      },
-      start: 6,
-      end: 10
-    }]);
-  });
-
-  it('map', () => {
-    let doc = new Document({
-      content: 'Conde Nast',
-      annotations: [{
-        type: 'a',
-        attributes: {
-          href: 'https://example.com'
-        },
-        start: 0,
-        end: 5
-      }]
-    });
-
-    doc.where({ type: 'a' }).set({ type: 'link' }).map({ attributes: { href: 'url' } });
-    doc.addAnnotations({
-      type: 'a',
-      attributes: {
-        href: 'https://condenast.com'
-      },
-      start: 6,
-      end: 10
-    });
-    expect(doc.content).toBe('Conde Nast');
-    expect(doc.annotations).toEqual([{
-      type: 'link',
-      attributes: {
-        url: 'https://example.com'
-      },
-      start: 0,
-      end: 5
-    }, {
-      type: 'link',
-      attributes: {
-        url: 'https://condenast.com'
+        '-test-url': 'https://condenast.com'
       },
       start: 6,
       end: 10
@@ -204,51 +175,48 @@ describe.skip('Document.where', () => {
   });
 
   it('map with function', () => {
-    let doc = new Document({
+    let doc = new TestSource({
       content: 'Conde Nast',
       annotations: [{
-        type: 'a',
+        type: '-test-a',
         attributes: {
-          href: 'https://example.com'
+          '-test-href': 'http://example.com'
         },
         start: 0,
         end: 5
       }]
     });
 
-    doc.where({ type: 'a' }).map((annotation: Annotation) => {
+    doc.where({ type: '-test-a' }).map((annotation: AnnotationJSON) => {
       return {
-        type: 'link',
+        type: '-test-link',
         start: annotation.start,
         end: annotation.end,
         attributes: {
-          url: annotation.attributes.href,
-          openInNewTab: true
+          '-test-url': annotation.attributes['-test-href'].replace('http://', 'https://')
         }
       };
     });
     doc.addAnnotations({
-      type: 'a',
+      type: '-test-a',
       attributes: {
-        href: 'https://condenast.com'
+        '-test-href': 'http://condenast.com'
       },
       start: 6,
       end: 10
     });
     expect(doc.content).toBe('Conde Nast');
     expect(doc.annotations).toEqual([{
-      type: 'link',
+      type: '-test-link',
       attributes: {
-        url: 'https://example.com',
-        openInNewTab: true
+        '-test-url': 'https://example.com'
       },
       start: 0,
       end: 5
     }, {
-      type: 'link',
+      type: '-test-link',
       attributes: {
-        url: 'https://condenast.com',
-        openInNewTab: true
+        '-test-url': 'https://condenast.com'
       },
       start: 6,
       end: 10
@@ -256,82 +224,84 @@ describe.skip('Document.where', () => {
   });
 
   it('remove', () => {
-    let doc = new Document({
+    let doc = new TestSource({
       content: 'function () {}',
       annotations: [{
-        type: 'code',
+        type: '-test-code',
         start: 0,
-        end: 14
+        end: 14,
+        attributes: {}
       }]
     });
 
-    doc.where({ type: 'code' }).remove();
+    doc.where({ type: '-test-code' }).remove();
     doc.addAnnotations({
-      type: 'code',
+      type: '-test-code',
       start: 0,
-      end: 14
+      end: 14,
+      attributes: {}
     });
     expect(doc.content).toBe('function () {}');
     expect(doc.annotations).toEqual([]);
   });
 
   it('annotation expansion', () => {
-    let doc = new Document({
+    let doc = new TestSource({
       content: 'string.trim();\nstring.strip',
       annotations: [{
-        type: 'code',
+        type: '-test-code',
         start: 0,
         end: 14,
         attributes: {
-          class: 'language-js',
-          language: 'js'
+          '-test-class': 'language-js',
+          '-test-language': 'js'
         }
       }]
     });
 
-    doc.where({ type: 'code' }).map((annotation: Annotation) => {
+    doc.where({ type: 'code' }).map((annotation: AnnotationJSON) => {
       return [{
-        type: 'pre',
+        type: '-test-pre',
         start: annotation.start,
         end: annotation.end,
         attributes: annotation.attributes
       }, {
-        type: 'code',
+        type: '-test-code',
         start: annotation.start,
         end: annotation.end,
         attributes: {}
       }];
-    }).unset('attributes.class');
+    }).unset('attributes.-test-class');
 
     doc.addAnnotations({
-      type: 'code',
+      type: '-test-code',
       start: 16,
       end: 28,
       attributes: {
-        class: 'language-rb',
-        language: 'rb'
+        '-test-class': 'language-rb',
+        '-test-language': 'rb'
       }
     });
 
     expect(doc.content).toBe('string.trim();\nstring.strip');
     expect(doc.annotations).toEqual([{
-      type: 'pre',
+      type: '-test-pre',
       start: 0,
       end: 14,
       attributes: {
-        language: 'js'
+        '-test-language': 'js'
       }
     }, {
-      type: 'code',
+      type: '-test-code',
       start: 0,
       end: 14,
       attributes: {}
     }, {
-      type: 'pre',
+      type: '-test-pre',
       start: 16,
       end: 28,
       attributes: {
-        language: 'rb'
+        '-test-language': 'rb'
       }
     }, {
       type: 'code',
@@ -342,29 +312,31 @@ describe.skip('Document.where', () => {
   });
 
   it('sliced documents inherit queries', () => {
-    let doc = new Document({
+    let doc = new TestSource({
       content: 'This is ~my caption~\nNext paragraph',
       annotations: [{
         type: 'photo',
         start: 0,
-        end: 20
+        end: 20,
+        attributes: {}
       }]
     });
 
-    doc.where({ type: 'em' }).set({ type: 'italic' });
+    doc.where({ type: '-test-em' }).set({ type: '-test-italic' });
     let caption = doc.slice(0, 20);
     caption.addAnnotations({
-      type: 'em',
+      type: '-test-em',
       start: 0,
-      end: 4
+      end: 4,
+      attributes: {}
     });
     expect(caption.content).toBe('This is ~my caption~');
     expect(doc.annotations).toEqual([{
-      type: 'photo',
+      type: '-test-photo',
       start: 0,
       end: 20
     }, {
-      type: 'italic',
+      type: '-test-italic',
       start: 0,
       end: 4
     }]);


### PR DESCRIPTION
This adds formal support for unknown annotations.

Unknown Annotations have a particular way of being created; they stuff their `type` and `attributes` into the `attributes`. This means all data is retained for these annotations, while they appear as a homogenous blob. When rendered, these annotations will get categorized into a single bucket of `unknown`, so they can be rendered for debugging purposes in a document.

For an example, if we import the following HTML document into AtJSON,

```html
<p>Hello, <em>world</em>!</p>
```

The document created would be a bunch of Unknown Annotations:

```json
{
  "contentType": "application/vnd.atjson+html",
  "content": "<p>Hello, <em>world</em>!</p>",
  "schema": [],
  "annotations": [{
    "type": "-atjson-unknown",
    "start": 0,
    "end": 29,
    "attributes": {
      "type": "-html-p",
      "attributes": {}
    }
  }, {
    "type": "-atjson-unknown",
    "start": 11,
    "end": 25,
    "attributes": {
      "type": "-html-em",
      "attributes": {}
    }
  }, {
    "type": "-atjson-parse-token",
    "start": 0,
    "end": 4,
    "attributes": {}
  }, {
    "type": "-atjson-parse-token",
    "start": 11,
    "end": 15,
    "attributes": {}
  }, {
    "type": "-atjson-parse-token",
    "start": 20,
    "end": 25,
    "attributes": {}
  }, {
    "type": "-atjson-parse-token",
    "start": 26,
    "end": 30,
    "attributes": {}
  }]
}
```