### PR TITLE
Fix querying to work with Annotation classes

### DIFF
--- a/packages/@atjson/document/src/attributes.ts
+++ b/packages/@atjson/document/src/attributes.ts
@@ -17,7 +17,7 @@ export function unprefix(vendorPrefix: string, attribute: Attribute): Attribute 
     return null;
   } else if (typeof attribute === 'object') {
     return Object.keys(attribute).reduce((attrs: Attributes, key: string) => {
-      let value = attrs[key];
+      let value = attribute[key];
       if (key.indexOf(`-${vendorPrefix}-`) === 0 && value !== undefined) {
         attrs[key.slice(`-${vendorPrefix}-`.length)] = unprefix(vendorPrefix, value);
       }
@@ -42,7 +42,7 @@ export function toJSON(vendorPrefix: string, attribute: Attribute): JSON {
     return Object.keys(attribute).reduce((copy: JSONObject, key: string) => {
       let value = attribute[key];
       if (value !== undefined) {
-        copy[key] = toJSON(vendorPrefix, value);
+        copy[`-${vendorPrefix}-${key}`] = toJSON(vendorPrefix, value);
       }
       return copy;
     }, {});

--- a/packages/@atjson/document/src/index.ts
+++ b/packages/@atjson/document/src/index.ts
@@ -28,6 +28,8 @@ export {
 
 export type Schema<T extends Annotation> = T[];
 
+export type Schema<T extends Annotation> = T[];
+
 export default class AtJSON {
   static contentType: string;
   static schema: Schema<any>;

--- a/packages/@atjson/document/src/index.ts
+++ b/packages/@atjson/document/src/index.ts
@@ -95,11 +95,14 @@ export default class AtJSON {
     }
   }
 
-  replaceAnnotation(annotation: Annotation, ...newAnnotations: Annotation[]): void {
+  replaceAnnotation(annotation: Annotation, ...newAnnotations: AnnotationJSON[]): Annotation[] {
     let index = this.annotations.indexOf(annotation);
     if (index > -1) {
-      this.annotations.splice(index, 1, ...newAnnotations);
+      let annotations = newAnnotations.map(json => this.createAnnotation(json));
+      this.annotations.splice(index, 1, ...annotations);
+      return annotations;
     }
+    return [];
   }
 
   insertText(start: number, text: string, behaviour: AdjacentBoundaryBehaviour = AdjacentBoundaryBehaviour.default) {

--- a/packages/@atjson/document/test/atjson-test.ts
+++ b/packages/@atjson/document/test/atjson-test.ts
@@ -22,7 +22,7 @@ describe('new Document', () => {
 
   describe('slice', () => {
     let document = new TestSource({
-      content: 'Hello, world!',
+      content: 'Hello, world!\n\uFFFC',
       annotations: [{
         type: '-test-bold',
         start: 0,
@@ -38,15 +38,21 @@ describe('new Document', () => {
         start: 0,
         end: 13,
         attributes: {}
+      }, {
+        type: '-test-instagram',
+        start: 14,
+        end: 15,
+        attributes: {
+          '-test-uri': 'https://www.instagram.com/p/BeW0pqZDUuK/'
+        }
       }]
     });
 
     test('source documents are unaltered', () => {
-      let doc = document.slice(1, 13);
-      expect(doc.content).toBe('ello, world!');
+      let doc = document.slice(1, 15);
 
       expect(doc.toJSON()).toEqual({
-        content: 'ello, world!',
+        content: 'ello, world!\n\uFFFC',
         contentType: 'application/vnd.atjson+test',
         schema: ['-test-bold', '-test-instagram', '-test-italic', '-test-manual'],
         annotations: [{
@@ -64,11 +70,18 @@ describe('new Document', () => {
           start: 0,
           end: 12,
           attributes: {}
+        }, {
+          type: '-test-instagram',
+          start: 13,
+          end: 14,
+          attributes: {
+            '-test-uri': 'https://www.instagram.com/p/BeW0pqZDUuK/'
+          }
         }]
       });
 
       expect(document.toJSON()).toEqual({
-        content: 'Hello, world!',
+        content: 'Hello, world!\n\uFFFC',
         contentType: 'application/vnd.atjson+test',
         schema: ['-test-bold', '-test-instagram', '-test-italic', '-test-manual'],
         annotations: [{
@@ -86,6 +99,13 @@ describe('new Document', () => {
           start: 0,
           end: 13,
           attributes: {}
+        }, {
+          type: '-test-instagram',
+          start: 14,
+          end: 15,
+          attributes: {
+            '-test-uri': 'https://www.instagram.com/p/BeW0pqZDUuK/'
+          }
         }]
       });
     });

--- a/packages/@atjson/document/test/query-test.ts
+++ b/packages/@atjson/document/test/query-test.ts
@@ -1,7 +1,7 @@
 import { AnnotationJSON } from '../src';
 import TestSource from './test-source';
 
-describe.skip('Document.where', () => {
+describe('Document.where', () => {
   it('runs queries against existing annotations', () => {
     let doc = new TestSource({
       content: 'Hello',
@@ -11,7 +11,7 @@ describe.skip('Document.where', () => {
         end: 5,
         attributes: {}
       }, {
-        type: '-test-emphasis',
+        type: '-test-em',
         start: 0,
         end: 5,
         attributes: {}
@@ -74,18 +74,18 @@ describe.skip('Document.where', () => {
       annotations: []
     });
 
-    doc.where({ type: '-test-h1' }).set({ type: '-test-heading', attributes: { level: 1 } });
+    doc.where({ type: '-test-h1' }).set({ type: '-test-heading', attributes: { '-test-level': 1 } });
     doc.addAnnotations({
-      type: 'h1',
+      type: '-test-h1',
       start: 0,
       end: 5,
       attributes: {}
     });
     expect(doc.content).toBe('Hello');
-    expect(doc.annotations).toEqual([{
-      type: 'heading',
+    expect(doc.annotations.map(a => a.toJSON())).toEqual([{
+      type: '-test-heading',
       attributes: {
-        level: 1
+        '-test-level': 1
       },
       start: 0,
       end: 5
@@ -138,9 +138,9 @@ describe.skip('Document.where', () => {
     let doc = new TestSource({
       content: 'Conde Nast',
       annotations: [{
-        type: 'a',
+        type: '-test-a',
         attributes: {
-          href: 'https://example.com'
+          '-test-href': 'https://example.com'
         },
         start: 0,
         end: 5
@@ -188,12 +188,13 @@ describe.skip('Document.where', () => {
     });
 
     doc.where({ type: '-test-a' }).map((annotation: AnnotationJSON) => {
+      let href = annotation.attributes['-test-href'] as string;
       return {
         type: '-test-link',
         start: annotation.start,
         end: annotation.end,
         attributes: {
-          '-test-url': annotation.attributes['-test-href'].replace('http://', 'https://')
+          '-test-url': href.replace('http://', 'https://')
         }
       };
     });
@@ -206,7 +207,7 @@ describe.skip('Document.where', () => {
       end: 10
     });
     expect(doc.content).toBe('Conde Nast');
-    expect(doc.annotations).toEqual([{
+    expect(doc.annotations.map(a => a.toJSON())).toEqual([{
       type: '-test-link',
       attributes: {
         '-test-url': 'https://example.com'
@@ -259,7 +260,7 @@ describe.skip('Document.where', () => {
       }]
     });
 
-    doc.where({ type: 'code' }).map((annotation: AnnotationJSON) => {
+    doc.where({ type: '-test-code' }).map((annotation: AnnotationJSON) => {
       return [{
         type: '-test-pre',
         start: annotation.start,
@@ -284,7 +285,7 @@ describe.skip('Document.where', () => {
     });
 
     expect(doc.content).toBe('string.trim();\nstring.strip');
-    expect(doc.annotations).toEqual([{
+    expect(doc.annotations.map(a => a.toJSON())).toEqual([{
       type: '-test-pre',
       start: 0,
       end: 14,
@@ -304,7 +305,7 @@ describe.skip('Document.where', () => {
         '-test-language': 'rb'
       }
     }, {
-      type: 'code',
+      type: '-test-code',
       start: 16,
       end: 28,
       attributes: {}
@@ -315,7 +316,7 @@ describe.skip('Document.where', () => {
     let doc = new TestSource({
       content: 'This is ~my caption~\nNext paragraph',
       annotations: [{
-        type: 'photo',
+        type: '-test-photo',
         start: 0,
         end: 20,
         attributes: {}
@@ -331,14 +332,16 @@ describe.skip('Document.where', () => {
       attributes: {}
     });
     expect(caption.content).toBe('This is ~my caption~');
-    expect(doc.annotations).toEqual([{
+    expect(caption.annotations.map(a => a.toJSON())).toEqual([{
       type: '-test-photo',
       start: 0,
-      end: 20
+      end: 20,
+      attributes: {}
     }, {
       type: '-test-italic',
       start: 0,
-      end: 4
+      end: 4,
+      attributes: {}
     }]);
   });
 });


### PR DESCRIPTION
This PR makes the `where` syntax work again (and the tests!)

A couple of things here:

☝️ There's a bugfix here for annotations that weren't being unprefixed and cloned correctly. (I was using the collection object in the reducer instead of the original attributes object)
✌️ All annotations will undergo a structured clone when being sent through our query language.

Unfortunately, this removes the feature of having a sub-documents in annotations, but that will have to be fixed soon 😢 
