### PR TITLE
🎨 Fix rendering API to handle annotation classes

### DIFF
--- a/packages/@atjson/renderer-hir/src/index.ts
+++ b/packages/@atjson/renderer-hir/src/index.ts
@@ -34,20 +34,51 @@ function flatten(array: any[]): any[] {
   return flattenedArray;
 }
 
-function compile(renderer: Renderer, node: HIRNode): any {
-  let annotation: AnyAnnotation = node.annotation;
+function compile(renderer: Renderer, node: HIRNode, parent?: AnyAnnotation, index?: number): any {
+  let annotation: AnyAnnotation = node.annotation.clone();
+  let children = node.children();
+
+  // Add metadata to annotations for formats that require context
+  // when rendering
+  annotation.parent = parent || null;
+  annotation.previous = null;
+  annotation.next = null;
+
+  if (parent && index != null && index > 0) {
+    annotation.previous = parent.children[index - 1];
+    if (annotation.previous == null ||
+        typeof annotation.previous === 'string') {
+      annotation.previous = null;
+    }
+  }
+
+  if (parent && index != null && index < parent.children.length) {
+    annotation.next = parent.children[index + 1];
+    if (annotation.next == null ||
+        typeof annotation.next === 'string') {
+      annotation.next = null;
+    }
+  }
+
+  annotation.children = children.map(childNode => {
+    if (childNode.annotation instanceof TextAnnotation) {
+      return childNode.annotation.attributes.text;
+    } else {
+      return childNode.annotation;
+    }
+  });
+
   let generator = renderer.renderAnnotation(annotation);
   let result = generator.next();
   if (result.done) {
     return result.value;
   }
 
-  let children = node.children();
-  return generator.next(flatten(children.map((childNode: HIRNode) => {
+  return generator.next(flatten(children.map((childNode: HIRNode, idx: number) => {
     if (childNode.annotation instanceof TextAnnotation) {
       return renderer.text(childNode.annotation.attributes.text);
     } else {
-      return compile(renderer, childNode);
+      return compile(renderer, childNode, annotation, idx);
     }
   }))).value;
 }

--- a/packages/@atjson/renderer-hir/test/renderer-hir-test.ts
+++ b/packages/@atjson/renderer-hir/test/renderer-hir-test.ts
@@ -1,24 +1,39 @@
-import Document from '@atjson/document';
+import Document, { AnyAnnotation, InlineAnnotation } from '@atjson/document';
 import { HIR, HIRNode } from '@atjson/hir';
-import HIRRenderer, { escapeHTML } from '@atjson/renderer-hir';
+import HIRRenderer, { escapeHTML } from '../src/index';
 
-describe('@atjson/renderer-hir', function () {
-  it('defines an abstract rendering interface', function () {
-    let atjson = new Document({
+class Bold extends InlineAnnotation {
+  static vendorPrefix = 'test';
+  static type = 'bold';
+}
+
+class Italic extends InlineAnnotation {
+  static vendorPrefix = 'test';
+  static type = 'italic';
+}
+
+class TestSource extends Document {
+  static contentType = 'application/vnd.atjson+test';
+  static schema = [Bold, Italic];
+}
+
+describe('@atjson/renderer-hir', () => {
+  it('defines an abstract rendering interface', () => {
+    let atjson = new TestSource({
       content: 'This is bold and italic text',
       annotations: [{
-        type: 'bold', start: 8, end: 17
+        type: '-test-bold', start: 8, end: 17, attributes: {}
       }, {
-        type: 'italic', start: 12, end: 23
+        type: '-test-italic', start: 12, end: 23, attributes: {}
       }]
     });
 
     let root = new HIR(atjson).rootNode;
     let callStack = [
-      root,
-      root.children()[1],
-      root.children()[1].children()[1],
-      root.children()[2]
+      root.annotation,
+      root.children()[1].annotation,
+      root.children()[1].children()[1].annotation,
+      root.children()[2].annotation
     ];
 
     let textBuilder: string[] = [
@@ -29,7 +44,7 @@ describe('@atjson/renderer-hir', function () {
     ];
 
     class ConcreteRenderer extends HIRRenderer {
-      *renderAnnotation(annotation: HIRNode): IterableIterator<string> {
+      *renderAnnotation(annotation: AnyAnnotation): IterableIterator<any> {
         expect(annotation).toEqual(callStack.shift());
 
         let text: string[] = yield;
@@ -42,16 +57,17 @@ describe('@atjson/renderer-hir', function () {
     renderer.render(atjson);
   });
 
-  it('escapes HTML entities in text', function () {
-    let atjson = new Document({
-      content: `This <html-element with="param" and-another='param'> should render as plain text`
+  it('escapes HTML entities in text', () => {
+    let atjson = new TestSource({
+      content: `This <html-element with="param" and-another='param'> should render as plain text`,
+      annotations: []
     });
 
     class ConcreteRenderer extends HIRRenderer {
-      renderText(text: string): string {
+      text(text: string): string {
         return escapeHTML(text);
       }
-      *renderAnnotation(annotation: HIRNode): IterableIterator<string> {
+      *renderAnnotation(annotation: AnyAnnotation): IterableIterator<any> {
         let text: string[] = yield;
         return text.join('');
       }


### PR DESCRIPTION
This PR changes the rendering API so annotation classes can be reused in the render hooks.

Previously, when an annotation was rendered, it would be called with the attributes, that stripped all type information:

```ts
import Renderer from '@atjson/renderer-hir';
import { HIRNode } from '@atjson/hir';

export default class TestRenderer extends Renderer {
  *image(attrs: any): IterableIterator<any> {
    return `![${attrs.description}](${attrs.src})`;
  }
}
```

Now, classes can be reused:

```ts
import { ObjectAnnotation } from '@atjson/document';
import Renderer from '@atjson/renderer-hir';

class Image extends ObjectAnnotation {
  static vendorPrefix = 'test';
  static type = 'image';
  attributes!: {
    description: string;
    src: string;
  };
}

export default class TestRenderer extends Renderer {
  *image(image: Image): IterableIterator<any> {
    return `![${image.attributes.description}](${image.attributes.src})`;
  }
}
```

In addition! There is now metadata associated on annotations passed to renderers for tricky rendering scenarios like markdown, which will hopefully remove the need for fully-custom renderers! ✨  (For context, this is currently being done [here](https://github.com/CondeNast-Copilot/atjson/blob/latest/packages/%40atjson/renderer-commonmark/src/index.ts#L70) and used for ambiguous nesting of [bold](https://github.com/CondeNast-Copilot/atjson/blob/latest/packages/%40atjson/renderer-commonmark/src/index.ts#L157-L161) and [italic](https://github.com/CondeNast-Copilot/atjson/blob/latest/packages/%40atjson/renderer-commonmark/src/index.ts#L157-L161) and [adjacent lists of the same type](https://github.com/CondeNast-Copilot/atjson/blob/latest/packages/%40atjson/renderer-commonmark/src/index.ts#L392-L397))