### PR TITLE
🛀 @atjson/document: Change default class name from AtJSON to Document.

### DIFF
--- a/packages/@atjson/document/src/index.ts
+++ b/packages/@atjson/document/src/index.ts
@@ -6,7 +6,7 @@ const OBJECT_REPLACEMENT = '\uFFFC';
 
 export { Annotation, Schema, Display };
 
-export default class AtJSON {
+export default class Document {
 
   content: string;
   contentType?: string;
@@ -221,8 +221,8 @@ export default class AtJSON {
    * document. All queries are inherited from the parent
    * document.
    */
-  slice(start: number, end: number): AtJSON {
-    let doc = new AtJSON({
+  slice(start: number, end: number): Document {
+    let doc = new Document({
       content: this.content,
       contentType: this.contentType,
       annotations: this.annotations,


### PR DESCRIPTION
It seems that wherever this package is [imported](https://github.com/CondeNast-Copilot/atjson/blob/130233e43868ead7045e0d69caebecfdc15bfb8c/packages/%40atjson/editor/src/index.ts#L2), it's being referred to as `Document`.

The TypeScript compiler, however, will reveal it as type `AtJSON`, which IMHO is confusing.

This PR changes the class name to `Document`.

Also, consider changing the name to `AtJSONDocument` to be extra explicit...