### PR TITLE
source-commonmark: Explicitly declare Document as toCommonSchema() return type.

### DIFF
--- a/packages/@atjson/renderer-react/test/react-renderer-test.tsx
+++ b/packages/@atjson/renderer-react/test/react-renderer-test.tsx
@@ -121,4 +121,4 @@ describe('ReactRenderer', function () {
     });
 
   }());
-}
+});

--- a/packages/@atjson/source-commonmark/src/index.ts
+++ b/packages/@atjson/source-commonmark/src/index.ts
@@ -229,7 +229,7 @@ export default class CommonMarkSource extends Document {
     return {};
   }
 
-  toCommonSchema() {
+  toCommonSchema(): Document {
     let doc = new Document({
       content: this.content,
       contentType: 'text/atjson',

--- a/packages/@atjson/source-html/test/source-html-test.ts
+++ b/packages/@atjson/source-html/test/source-html-test.ts
@@ -159,7 +159,7 @@ describe('@atjson/source-html', () => {
       attributes: {},
       children: [{
         type: '-html-a',
-        attributes {
+        attributes: {
           href: 'https://en.wiktionary.org/wiki/日本人'
         },
         children: []


### PR DESCRIPTION
Small syntax fixes in packages/@atjson/renderer-react/test/react-renderer-test.tsx and packages/@atjson/source-html/test/source-html-test.ts