### PR TITLE
Publish npm version v0.8.5.

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "lerna": "2.2.0",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "packages": [
     "packages/@atjson/*"
   ],

--- a/packages/@atjson/renderer-commonmark/package.json
+++ b/packages/@atjson/renderer-commonmark/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atjson/renderer-commonmark",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "description": "A brand new TypeScript library.",
   "main": "dist/commonjs/index.js",
   "module": "dist/modules/index.js",
@@ -17,7 +17,7 @@
   },
   "devDependencies": {
     "@atjson/schema": "^0.8.4",
-    "@atjson/source-commonmark": "^0.8.4",
+    "@atjson/source-commonmark": "^0.8.5",
     "commonmark-spec": "^0.28.0",
     "markdown-it": "^8.4.1"
   },

--- a/packages/@atjson/renderer-plain-text/package.json
+++ b/packages/@atjson/renderer-plain-text/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atjson/renderer-plain-text",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "description": "A brand new TypeScript library.",
   "main": "dist/commonjs/index.js",
   "module": "dist/modules/index.js",
@@ -18,7 +18,7 @@
   "devDependencies": {
     "@atjson/document": "^0.8.4",
     "@atjson/hir": "^0.8.4",
-    "@atjson/source-html": "^0.8.4"
+    "@atjson/source-html": "^0.8.5"
   },
   "dependencies": {
     "@atjson/renderer-hir": "^0.8.4"

--- a/packages/@atjson/renderer-react/package.json
+++ b/packages/@atjson/renderer-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atjson/renderer-react",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "description": "A brand new TypeScript library.",
   "main": "dist/commonjs/index.js",
   "module": "dist/modules/index.js",

--- a/packages/@atjson/source-commonmark/package.json
+++ b/packages/@atjson/source-commonmark/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atjson/source-commonmark",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "description": "Create AtJSON documents from CommonMark.",
   "main": "dist/commonjs/index.js",
   "module": "dist/modules/index.js",
@@ -24,7 +24,7 @@
   "dependencies": {
     "@atjson/document": "^0.8.4",
     "@atjson/schema": "^0.8.4",
-    "@atjson/source-html": "^0.8.4",
+    "@atjson/source-html": "^0.8.5",
     "@types/entities": "^1.1.0",
     "@types/markdown-it": "^0.0.4",
     "entities": "^1.1.1",

--- a/packages/@atjson/source-html/package.json
+++ b/packages/@atjson/source-html/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atjson/source-html",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "description": "Create AtJSON documents from HTML source",
   "main": "dist/commonjs/index.js",
   "module": "dist/modules/index.js",


### PR DESCRIPTION
The `npm publish` has already occurred; but, when npm Git tagged the version and tried to push, the _protected branch hook declined_ prevented it.