### PR TITLE
Pin all internal package dependencies

### DIFF
--- a/packages/@atjson/editor/package.json
+++ b/packages/@atjson/editor/package.json
@@ -20,8 +20,8 @@
     "last 2 Chrome versions"
   ],
   "dependencies": {
-    "@atjson/document": "^0.8.4",
-    "@atjson/hir": "^0.8.4"
+    "@atjson/document": "0.8.4",
+    "@atjson/hir": "0.8.4"
   },
   "devDependencies": {
     "parcel-bundler": "^1.6.2",

--- a/packages/@atjson/hir/package.json
+++ b/packages/@atjson/hir/package.json
@@ -21,6 +21,6 @@
     "access": "public"
   },
   "dependencies": {
-    "@atjson/document": "^0.8.4"
+    "@atjson/document": "0.8.4"
   }
 }

--- a/packages/@atjson/renderer-commonmark/package.json
+++ b/packages/@atjson/renderer-commonmark/package.json
@@ -16,13 +16,13 @@
     "access": "public"
   },
   "devDependencies": {
-    "@atjson/schema": "^0.8.4",
-    "@atjson/source-commonmark": "^0.8.5",
+    "@atjson/schema": "0.8.4",
+    "@atjson/source-commonmark": "0.8.5",
     "commonmark-spec": "^0.28.0",
     "markdown-it": "^8.4.1"
   },
   "dependencies": {
-    "@atjson/document": "^0.8.4",
-    "@atjson/hir": "^0.8.4"
+    "@atjson/document": "0.8.4",
+    "@atjson/hir": "0.8.4"
   }
 }

--- a/packages/@atjson/renderer-graphviz/package.json
+++ b/packages/@atjson/renderer-graphviz/package.json
@@ -16,7 +16,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@atjson/document": "^0.8.4",
-    "@atjson/hir": "^0.8.4"
+    "@atjson/document": "0.8.4",
+    "@atjson/hir": "0.8.4"
   }
 }

--- a/packages/@atjson/renderer-hir/package.json
+++ b/packages/@atjson/renderer-hir/package.json
@@ -16,7 +16,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@atjson/document": "^0.8.4",
-    "@atjson/hir": "^0.8.4"
+    "@atjson/document": "0.8.4",
+    "@atjson/hir": "0.8.4"
   }
 }

--- a/packages/@atjson/renderer-plain-text/package.json
+++ b/packages/@atjson/renderer-plain-text/package.json
@@ -16,11 +16,11 @@
     "access": "public"
   },
   "devDependencies": {
-    "@atjson/document": "^0.8.4",
-    "@atjson/hir": "^0.8.4",
-    "@atjson/source-html": "^0.8.5"
+    "@atjson/document": "0.8.4",
+    "@atjson/hir": "0.8.4",
+    "@atjson/source-html": "0.8.5"
   },
   "dependencies": {
-    "@atjson/renderer-hir": "^0.8.4"
+    "@atjson/renderer-hir": "0.8.4"
   }
 }

--- a/packages/@atjson/renderer-react/package.json
+++ b/packages/@atjson/renderer-react/package.json
@@ -16,14 +16,14 @@
     "access": "public"
   },
   "devDependencies": {
-    "@atjson/document": "^0.8.4",
-    "@atjson/hir": "^0.8.4",
+    "@atjson/document": "0.8.4",
+    "@atjson/hir": "0.8.4",
     "@types/react": "^16.0.36",
     "@types/react-dom": "^16.0.3",
     "react-dom": "^16.2.0"
   },
   "dependencies": {
-    "@atjson/renderer-hir": "^0.8.4",
+    "@atjson/renderer-hir": "0.8.4",
     "react": "^16.2.0"
   }
 }

--- a/packages/@atjson/schema/package.json
+++ b/packages/@atjson/schema/package.json
@@ -16,6 +16,6 @@
     "access": "public"
   },
   "dependencies": {
-    "@atjson/document": "^0.8.4"
+    "@atjson/document": "0.8.4"
   }
 }

--- a/packages/@atjson/source-commonmark/package.json
+++ b/packages/@atjson/source-commonmark/package.json
@@ -16,15 +16,15 @@
     "access": "public"
   },
   "devDependencies": {
-    "@atjson/hir": "^0.8.4",
-    "@atjson/renderer-hir": "^0.8.4",
+    "@atjson/hir": "0.8.4",
+    "@atjson/renderer-hir": "0.8.4",
     "commonmark": "^0.28.1",
     "commonmark-spec": "^0.28.0"
   },
   "dependencies": {
-    "@atjson/document": "^0.8.4",
-    "@atjson/schema": "^0.8.4",
-    "@atjson/source-html": "^0.8.5",
+    "@atjson/document": "0.8.4",
+    "@atjson/schema": "0.8.4",
+    "@atjson/source-html": "0.8.5",
     "@types/entities": "^1.1.0",
     "@types/markdown-it": "^0.0.4",
     "entities": "^1.1.1",

--- a/packages/@atjson/source-gdocs-paste/package.json
+++ b/packages/@atjson/source-gdocs-paste/package.json
@@ -16,7 +16,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@atjson/document": "^0.8.4",
-    "@atjson/schema": "^0.8.4"
+    "@atjson/document": "0.8.4",
+    "@atjson/schema": "0.8.4"
   }
 }

--- a/packages/@atjson/source-html/package.json
+++ b/packages/@atjson/source-html/package.json
@@ -16,13 +16,13 @@
     "access": "public"
   },
   "devDependencies": {
-    "@atjson/hir": "^0.8.4",
-    "@atjson/renderer-hir": "^0.8.4",
+    "@atjson/hir": "0.8.4",
+    "@atjson/renderer-hir": "0.8.4",
     "@types/node": "^9.6.5"
   },
   "dependencies": {
-    "@atjson/document": "^0.8.4",
-    "@atjson/schema": "^0.8.4",
+    "@atjson/document": "0.8.4",
+    "@atjson/schema": "0.8.4",
     "parse5": "^4.0.0"
   }
 }


### PR DESCRIPTION
Pinning dependencies will prevent subsequent installs of the same package from installing newer (possibly incompatible) minor versions of dependencies.

We ran into this problem deploying atjson as a dependency-of-a-dependency where our application received a newer version of an atjson dependency than expected when we built and deployed our application, causing rendering to fail on a couple of documents.