### PR TITLE
✨  allow a HIR to be passed to a renderer

### DIFF
--- a/packages/@atjson/renderer-commonmark/src/index.ts
+++ b/packages/@atjson/renderer-commonmark/src/index.ts
@@ -448,8 +448,14 @@ export default class CommonmarkRenderer {
     return text + '\n\n';
   }
 
-  render(document: Document): string {
-    let graph = new HIR(document);
+  render(document: Document | HIR): string {
+    let graph;
+    if (document instanceof HIR) {
+      graph = document;
+    } else {
+      graph = new HIR(document);
+    }
+
     return render(this, hirNodeToMarkdownNode(graph.rootNode, null), -1);
   }
 }

--- a/packages/@atjson/renderer-hir/src/index.ts
+++ b/packages/@atjson/renderer-hir/src/index.ts
@@ -65,7 +65,10 @@ export default class Renderer {
     return text;
   }
 
-  render(document: Document) {
+  render(document: Document | HIR) {
+    if (document instanceof HIR) {
+      return compile(this, document.rootNode);
+    }
     return compile(this, new HIR(document).rootNode);
   }
 }


### PR DESCRIPTION
This allows sub-documents to be rendererd using different renderers instead of itself.

We have some mixed result formats that we're using this for and need to render to a different output format.