### PR TITLE
Define Nested Querying

### DIFF
--- a/packages/@atjson/document/src/query.ts
+++ b/packages/@atjson/document/src/query.ts
@@ -132,6 +132,12 @@ export default class AnnotationCollection {
     this.annotations = annotations;
   }
 
+  *[Symbol.iterator](): IterableIterator<JoinableAnnotation> {
+    for (let annotation of this.annotations) {
+      yield annotation;
+    }
+  }
+
   where(filter: StrictMatch | FilterFunction): AnnotationCollection {
     let filterFn = this.getFilterFunction(filter);
     let annotations = this.annotations.filter(filterFn);

--- a/packages/@atjson/document/src/query.ts
+++ b/packages/@atjson/document/src/query.ts
@@ -264,7 +264,7 @@ export default class AnnotationCollection {
 
       if (joinAnnotations.length > 0) {
         let result;
-        if (leftAnnotation instanceof AnnotationJoin && leftName !== 'string') {
+        if (leftAnnotation instanceof AnnotationJoin && typeof leftName !== 'string') {
           // If we're joining on an unnamed already-joined collection, just reuse it.
           result = leftAnnotation;
         } else if (typeof leftName === 'string') {

--- a/packages/@atjson/document/test/query-test.ts
+++ b/packages/@atjson/document/test/query-test.ts
@@ -29,47 +29,17 @@ describe('Document.where', () => {
     }]);
   });
 
-  it('runs queries against new annotations', () => {
-    let doc = new Document({
-      content: 'Hello',
-      annotations: []
-    });
-
-    doc.where({ type: 'strong' }).set({ type: 'bold' });
-    doc.where({ type: 'em' }).set({ type: 'italic' });
-    doc.addAnnotations({
-      type: 'strong',
-      start: 0,
-      end: 5
-    }, {
-      type: 'em',
-      start: 0,
-      end: 5
-    });
-    expect(doc.content).toBe('Hello');
-    expect(doc.annotations).toEqual([{
-      type: 'bold',
-      start: 0,
-      end: 5
-    }, {
-      type: 'italic',
-      start: 0,
-      end: 5
-    }]);
-  });
-
   it('set', () => {
     let doc = new Document({
       content: 'Hello',
-      annotations: []
+      annotations: [{
+        type: 'h1',
+        start: 0,
+        end: 5
+      }]
     });
 
     doc.where({ type: 'h1' }).set({ type: 'heading', attributes: { level: 1 } });
-    doc.addAnnotations({
-      type: 'h1',
-      start: 0,
-      end: 5
-    });
     expect(doc.content).toBe('Hello');
     expect(doc.annotations).toEqual([{
       type: 'heading',
@@ -92,19 +62,19 @@ describe('Document.where', () => {
         },
         start: 0,
         end: 1
+      },
+      {
+        type: 'embed',
+        attributes: {
+          type: 'instagram',
+          url: 'https://www.instagram.com/p/BdyySYBDvpm/'
+        },
+        start: 1,
+        end: 2
       }]
     });
 
     doc.where({ type: 'embed', attributes: { type: 'instagram' } }).set({ type: 'instagram' }).unset('attributes.type');
-    doc.addAnnotations({
-      type: 'embed',
-      attributes: {
-        type: 'instagram',
-        url: 'https://www.instagram.com/p/BdyySYBDvpm/'
-      },
-      start: 1,
-      end: 2
-    });
     expect(doc.content).toBe('\uFFFC\uFFFC');
     expect(doc.annotations).toEqual([{
       type: 'instagram',
@@ -133,18 +103,19 @@ describe('Document.where', () => {
         },
         start: 0,
         end: 5
+      },
+      {
+        type: 'a',
+        attributes: {
+          href: 'https://condenast.com'
+        },
+        start: 6,
+        end: 10
       }]
     });
 
     doc.where({ type: 'a' }).set({ type: 'link' }).rename({ attributes: { href: 'url' } });
-    doc.addAnnotations({
-      type: 'a',
-      attributes: {
-        href: 'https://condenast.com'
-      },
-      start: 6,
-      end: 10
-    });
+    doc.addAnnotations();
     expect(doc.content).toBe('Conde Nast');
     expect(doc.annotations).toEqual([{
       type: 'link',
@@ -163,7 +134,7 @@ describe('Document.where', () => {
     }]);
   });
 
-  it('map', () => {
+  it('map with a patch mapping', () => {
     let doc = new Document({
       content: 'Conde Nast',
       annotations: [{
@@ -173,18 +144,18 @@ describe('Document.where', () => {
         },
         start: 0,
         end: 5
+      },
+      {
+        type: 'a',
+        attributes: {
+          href: 'https://condenast.com'
+        },
+        start: 6,
+        end: 10
       }]
     });
 
     doc.where({ type: 'a' }).set({ type: 'link' }).map({ attributes: { href: 'url' } });
-    doc.addAnnotations({
-      type: 'a',
-      attributes: {
-        href: 'https://condenast.com'
-      },
-      start: 6,
-      end: 10
-    });
     expect(doc.content).toBe('Conde Nast');
     expect(doc.annotations).toEqual([{
       type: 'link',
@@ -213,10 +184,18 @@ describe('Document.where', () => {
         },
         start: 0,
         end: 5
+      },
+      {
+        type: 'a',
+        attributes: {
+          href: 'https://condenast.com'
+        },
+        start: 6,
+        end: 10
       }]
     });
 
-    doc.where({ type: 'a' }).map((annotation: Annotation) => {
+    doc.where({ type: 'a' }).map(annotation => {
       return {
         type: 'link',
         start: annotation.start,
@@ -226,14 +205,6 @@ describe('Document.where', () => {
           openInNewTab: true
         }
       };
-    });
-    doc.addAnnotations({
-      type: 'a',
-      attributes: {
-        href: 'https://condenast.com'
-      },
-      start: 6,
-      end: 10
     });
     expect(doc.content).toBe('Conde Nast');
     expect(doc.annotations).toEqual([{
@@ -262,15 +233,15 @@ describe('Document.where', () => {
         type: 'code',
         start: 0,
         end: 14
+      },
+      {
+        type: 'code',
+        start: 0,
+        end: 14
       }]
     });
 
     doc.where({ type: 'code' }).remove();
-    doc.addAnnotations({
-      type: 'code',
-      start: 0,
-      end: 14
-    });
     expect(doc.content).toBe('function () {}');
     expect(doc.annotations).toEqual([]);
   });
@@ -286,10 +257,19 @@ describe('Document.where', () => {
           class: 'language-js',
           language: 'js'
         }
+      },
+      {
+        type: 'code',
+        start: 16,
+        end: 28,
+        attributes: {
+          class: 'language-rb',
+          language: 'rb'
+        }
       }]
     });
 
-    doc.where({ type: 'code' }).map((annotation: Annotation) => {
+    doc.where({ type: 'code' }).map(annotation => {
       return [{
         type: 'pre',
         start: annotation.start,
@@ -302,16 +282,6 @@ describe('Document.where', () => {
         attributes: {}
       }];
     }).unset('attributes.class');
-
-    doc.addAnnotations({
-      type: 'code',
-      start: 16,
-      end: 28,
-      attributes: {
-        class: 'language-rb',
-        language: 'rb'
-      }
-    });
 
     expect(doc.content).toBe('string.trim();\nstring.strip');
     expect(doc.annotations).toEqual([{
@@ -341,32 +311,239 @@ describe('Document.where', () => {
     }]);
   });
 
-  it('sliced documents inherit queries', () => {
-    let doc = new Document({
-      content: 'This is ~my caption~\nNext paragraph',
-      annotations: [{
-        type: 'photo',
-        start: 0,
-        end: 20
-      }]
+  describe('AnnotationCollection.join', () => {
+
+    let doc;
+
+    beforeEach(() => {
+      doc = new Document({
+        content: 'string.trim();\nstring.strip\nextra',
+        annotations: [{
+          type: 'code',
+          start: 0,
+          end: 14,
+          attributes: {
+            class: 'language-js',
+            language: 'js'
+          }
+        },
+        {
+          type: 'pre',
+          start: 0,
+          end: 14,
+          attributes: { }
+        },
+        {
+          type: 'pre',
+          start: 16,
+          end: 28,
+          attributes: { }
+        },
+        {
+          type: 'code',
+          start: 30,
+          end: 35
+        }]
+      });
     });
 
-    doc.where({ type: 'em' }).set({ type: 'italic' });
-    let caption = doc.slice(0, 20);
-    caption.addAnnotations({
-      type: 'em',
-      start: 0,
-      end: 4
+    describe('simple join', () => {
+
+      let code;
+      let pre;
+      let preAndCode;
+
+      beforeEach(() => {
+        code = doc.where({ type: 'code' }).as('code');
+        pre = doc.where({ type: 'pre' }).as('pre');
+
+        preAndCode = code.join(pre, (l, r) => l.start === r.start && l.end === r.end);
+      });
+
+      it('should construct an AnnotationJoin', () => {
+
+        expect(preAndCode.annotations[0]).toEqual({
+          code: {
+            type: 'code',
+            start: 0,
+            end: 14,
+            attributes: {
+              class: 'language-js',
+              language: 'js'
+            }
+          },
+          pre: [
+            { type: 'pre', start: 0, end: 14, attributes: {} }
+          ]
+        });
+      });
+
+      describe('transform', () => {
+
+        beforeEach(() => {
+          preAndCode.map(join => {
+            doc.removeAnnotation(join.pre[0]);
+
+            let newAttributes = Object.assign(join.code.attributes, {
+              textStyle: 'pre'
+            });
+            let newCode = Object.assign(join.code, {attributes: newAttributes});
+
+            doc.replaceAnnotation(join.code, newCode);
+            doc.deleteText({start: 2, end: 4});
+
+            return {
+              update: [[join.code, newCode]],
+              remove: [join.pre[0]]
+            };
+          });
+        });
+
+        it('successfully transforms the document', () => {
+          expect(doc.annotations.filter(x => x.type === 'pre')).toEqual(
+            [{ type: 'pre', start: 14, end: 26, attributes: {} }]
+          );
+        });
+
+        it('updates the annotations on the AnnotationCollection', () => {
+          expect(preAndCode.annotations).toEqual([
+            {
+              type: 'code',
+              start: 0,
+              end: 12,
+              attributes: {
+                class: 'language-js',
+                language: 'js',
+                textStyle: 'pre'
+              }
+            }
+          ]);
+        });
+      });
     });
-    expect(caption.content).toBe('This is ~my caption~');
-    expect(doc.annotations).toEqual([{
-      type: 'photo',
-      start: 0,
-      end: 20
-    }, {
-      type: 'italic',
-      start: 0,
-      end: 4
-    }]);
+
+    describe('complex (three-way) join', () => {
+      let pre;
+      let code;
+      let locale;
+      let allJoin;
+
+      beforeEach(() => {
+        doc.addAnnotations({
+          type: 'locale',
+          start: 0,
+          end: 14,
+          attributes: { locale: 'en-us' }
+        }, {
+          type: 'pre',
+          start: 0,
+          end: 14,
+          attributes: { style: 'color: red' }
+        });
+
+        code = doc.where({ type: 'code' }).as('code');
+        pre = doc.where({ type: 'pre' }).as('pre');
+        locale = doc.where({ type: 'locale' }).as('locale');
+
+        allJoin = code.join(pre, (l, r) => l.start === r.start && l.end === r.end)
+                      .join(locale, (l, r) => l.code.start === r.start && l.code.end === r.end);
+      });
+
+      it('constructs a valid join', () => {
+        expect(allJoin.annotations).toEqual([{
+          code: {
+            type: 'code',
+            start: 0,
+            end: 14,
+            attributes: {
+              class: 'language-js',
+              language: 'js'
+            }
+          },
+          pre: [{
+            type: 'pre',
+            start: 0,
+            end: 14,
+            attributes: { }
+          }, {
+            type: 'pre',
+            start: 0,
+            end: 14,
+            attributes: { style: 'color: red' }
+          }],
+          locale: [{
+            type: 'locale',
+            start: 0,
+            end: 14,
+            attributes: { locale: 'en-us' }
+          }]
+        }]);
+      });
+
+      describe('transform', () => {
+        beforeEach(() => {
+          allJoin.map(join => {
+
+            doc.insertText(0, 'Hello!\n');
+
+            let removeAnnotations = [];
+            let newAttributes = {};
+            join.pre.forEach(x => {
+              Object.assign(newAttributes, x.attributes);
+              doc.removeAnnotation(x);
+              removeAnnotations.push(x);
+            });
+            newAttributes = Object.assign(newAttributes, { locale: join.locale[0].attributes.locale });
+            removeAnnotations.push(join.locale[0]);
+            doc.removeAnnotation(join.locale[0]);
+
+            let newCode = Object.assign(join.code, {
+              attributes: Object.assign(join.code.attributes, newAttributes)
+            });
+            doc.replaceAnnotation(join.code, newCode);
+
+            return {
+              update: [[join.code, newCode]],
+              remove: removeAnnotations
+            };
+          });
+        });
+
+        it('does the transform right', () => {
+          expect(allJoin.annotations).toEqual([
+            {
+              type: 'code',
+              start: 7,
+              end: 21,
+              attributes: {
+                locale: 'en-us',
+                style: 'color: red',
+                class: 'language-js',
+                language: 'js'
+              }
+            }
+          ]);
+        });
+
+        it('updates the document', () => {
+          expect(doc.annotations).toEqual([
+            {
+              type: 'code', start: 7, end: 21, attributes: {
+                class: 'language-js',
+                language: 'js',
+                locale: 'en-us',
+                style: 'color: red'
+              }
+            },
+            {
+              type: 'pre', start: 23, end: 35, attributes: {}
+            },
+            {
+              type: 'code', start: 37, end: 42
+            }
+          ]);
+        });
+      });
+    });
   });
 });

--- a/packages/@atjson/document/test/query-test.ts
+++ b/packages/@atjson/document/test/query-test.ts
@@ -381,7 +381,7 @@ describe('Document.where', () => {
       describe('transform', () => {
 
         beforeEach(() => {
-          preAndCode.map(join => {
+          preAndCode.transform(join => {
             doc.removeAnnotation(join.pre[0]);
 
             let newAttributes = Object.assign(join.code.attributes, {
@@ -482,7 +482,7 @@ describe('Document.where', () => {
 
       describe('transform', () => {
         beforeEach(() => {
-          allJoin.map(join => {
+          allJoin.transform(join => {
 
             doc.insertText(0, 'Hello!\n');
 

--- a/packages/@atjson/source-html/src/index.ts
+++ b/packages/@atjson/source-html/src/index.ts
@@ -167,6 +167,6 @@ export default class HTMLSource extends Document {
   }
 
   toCommonSchema(): Document {
-    return new HTMLSchemaTranslator(this);
+    return new HTMLSchemaTranslator(this).translate();
   }
 }

--- a/packages/@atjson/source-html/src/translator.ts
+++ b/packages/@atjson/source-html/src/translator.ts
@@ -1,4 +1,4 @@
-import Document, { Annotation, JoinableAnnotation, Schema } from '@atjson/document';
+import Document, { Annotation, Schema } from '@atjson/document';
 import schema from '@atjson/schema';
 
 export default class HTMLSchemaTranslator {
@@ -35,8 +35,7 @@ export default class HTMLSchemaTranslator {
     doc.where({ type: '-html-ul' }).set({ type: 'list', attributes: { type: 'bulleted' } });
     doc.where({ type: '-html-ol' }).set({ type: 'list', attributes: { type: 'numbered' } })
       .rename({ attributes: { starts: 'startsAt' } })
-      .map((list: JoinableAnnotation): Annotation | null => {
-        list = list as Annotation;
+      .map((list: Annotation) => {
         if (list.attributes !== undefined) {
           if (list.attributes && list.attributes.startsAt) {
             list.attributes.startsAt = parseInt(list.attributes.startsAt, 10);

--- a/packages/@atjson/source-html/src/translator.ts
+++ b/packages/@atjson/source-html/src/translator.ts
@@ -1,45 +1,60 @@
-import Document, { Annotation, Schema } from '@atjson/document';
+import Document, { Annotation, JoinableAnnotation, Schema } from '@atjson/document';
 import schema from '@atjson/schema';
 
-export default class HTMLSchemaTranslator extends Document {
+export default class HTMLSchemaTranslator {
+
+  document: Document;
+
   constructor(document: Document) {
-    super({
+    this.document = new Document({
       content: document.content,
       contentType: 'text/atjson',
       annotations: [...document.annotations],
       schema: schema as Schema
     });
+  }
 
-    this.where({ type: '-html-a' }).set({ type: 'link' }).rename({ attributes: { href: 'url' } });
+  translate() {
+    let doc = this.document;
 
-    this.where({ type: '-html-blockquote' }).set({ type: 'blockquote' });
+    doc.where({ type: '-html-a' }).set({ type: 'link' }).rename({ attributes: { href: 'url' } });
 
-    this.where({ type: '-html-h1' }).set({ type: 'heading', attributes: { level: 1 } });
-    this.where({ type: '-html-h2' }).set({ type: 'heading', attributes: { level: 2 } });
-    this.where({ type: '-html-h3' }).set({ type: 'heading', attributes: { level: 3 } });
-    this.where({ type: '-html-h4' }).set({ type: 'heading', attributes: { level: 4 } });
-    this.where({ type: '-html-h5' }).set({ type: 'heading', attributes: { level: 5 } });
-    this.where({ type: '-html-h6' }).set({ type: 'heading', attributes: { level: 6 } });
+    doc.where({ type: '-html-blockquote' }).set({ type: 'blockquote' });
 
-    this.where({ type: '-html-p' }).set({ type: 'paragraph' });
-    this.where({ type: '-html-br' }).set({ type: 'line-break' });
-    this.where({ type: '-html-hr' }).set({ type: 'horizontal-rule' });
+    doc.where({ type: '-html-h1' }).set({ type: 'heading', attributes: { level: 1 } });
+    doc.where({ type: '-html-h2' }).set({ type: 'heading', attributes: { level: 2 } });
+    doc.where({ type: '-html-h3' }).set({ type: 'heading', attributes: { level: 3 } });
+    doc.where({ type: '-html-h4' }).set({ type: 'heading', attributes: { level: 4 } });
+    doc.where({ type: '-html-h5' }).set({ type: 'heading', attributes: { level: 5 } });
+    doc.where({ type: '-html-h6' }).set({ type: 'heading', attributes: { level: 6 } });
 
-    this.where({ type: '-html-ul' }).set({ type: 'list', attributes: { type: 'bulleted' } });
-    this.where({ type: '-html-ol' }).set({ type: 'list', attributes: { type: 'numbered' } })
-      .rename({ attributes: { starts: 'startsAt' } }).map((list: Annotation) => {
-        if (list.attributes && list.attributes.startsAt) {
-          list.attributes.startsAt = parseInt(list.attributes.startsAt, 10);
+    doc.where({ type: '-html-p' }).set({ type: 'paragraph' });
+    doc.where({ type: '-html-br' }).set({ type: 'line-break' });
+    doc.where({ type: '-html-hr' }).set({ type: 'horizontal-rule' });
+
+    doc.where({ type: '-html-ul' }).set({ type: 'list', attributes: { type: 'bulleted' } });
+    doc.where({ type: '-html-ol' }).set({ type: 'list', attributes: { type: 'numbered' } })
+      .rename({ attributes: { starts: 'startsAt' } })
+      .map((list: JoinableAnnotation): Annotation | null => {
+        list = list as Annotation;
+        if (list.attributes !== undefined) {
+          if (list.attributes && list.attributes.startsAt) {
+            list.attributes.startsAt = parseInt(list.attributes.startsAt, 10);
+          }
+          return list;
+        } else {
+          return null;
         }
-        return list;
       });
-    this.where({ type: '-html-li' }).set({ type: 'list-item' });
+    doc.where({ type: '-html-li' }).set({ type: 'list-item' });
 
-    this.where({ type: '-html-em' }).set({ type: 'italic' });
-    this.where({ type: '-html-i' }).set({ type: 'italic' });
-    this.where({ type: '-html-strong' }).set({ type: 'bold' });
-    this.where({ type: '-html-b' }).set({ type: 'bold' });
+    doc.where({ type: '-html-em' }).set({ type: 'italic' });
+    doc.where({ type: '-html-i' }).set({ type: 'italic' });
+    doc.where({ type: '-html-strong' }).set({ type: 'bold' });
+    doc.where({ type: '-html-b' }).set({ type: 'bold' });
 
-    this.where({ type: '-html-img' }).set({ type: 'image'}).rename({ attributes: { src: 'url', alt: 'description' } });
+    doc.where({ type: '-html-img' }).set({ type: 'image'}).rename({ attributes: { src: 'url', alt: 'description' } });
+
+    return doc;
   }
 }


### PR DESCRIPTION
There are some changes that will cause some typescript headaches (see the source-html translator) if you've used raw `map`s in the brand mappers, but otherwise this should be transparent and compatible.

We'll need to write up some documentation, but for now it's probably best to look at the examples in the `query-test.js` file in the `document` package.

I also have the intent to move to having Transforms use a proxy to mutate the document to avoid having to duplicate the effort of maintaining annotation lists, but it got to be too much (the `TransformResult` interface can't do it as-is because text changes and ordering matter, and it doesn't account for those, so it's relegated for the moment to handling changes to the AnnotationCollection for chaining purposes).

Please let me know if the ergonomics are okay, and if there's anything obvious that we can do to improve them!

I don't want to spend too much more time on this in the short term, partially because I want to stop blocking work, and partially because I think this is a fairly big problem space and it might be good to get some early examples of use / problems before doing too much more.

Thanks!