### PR TITLE
Remove common punctuation from escaped chars

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "lerna": "3.0.0-rc.0",
+  "lerna": "3.2.1",
   "version": "independent",
   "packages": [
     "packages/@atjson/*"

--- a/packages/@atjson/renderer-commonmark/src/index.ts
+++ b/packages/@atjson/renderer-commonmark/src/index.ts
@@ -25,11 +25,13 @@ export type CodeStyle = 'block' | 'inline' | 'fence';
 
 // http://spec.commonmark.org/0.28/#backslash-escapes
 function escapePunctuation(text: string) {
-  return text.replace(/([#$%'"!()*+,=?@\\\[\]\^_`{|}~-])/g, '\\$1')
+  return text.replace(/([#!*+=\\\[\]\^_`{|}~])/g, '\\$1')
              .replace(/(\d+)\./g, '$1\\.')
              .replace(/&/g, '&amp;')
              .replace(/</g, '&lt;')
-             .replace(/>/g, '&gt;');
+             .replace(/>/g, '&gt;')
+             .replace(/(^[\s]*)-/g, '$1\\-') // `  - list item`
+             .replace(/(\r\n|\r|\n)([\s]*)-/g, '$1$2\\-'); // `- list item\n - list item`
 }
 
 function escapeAttribute(text: string) {

--- a/packages/@atjson/renderer-commonmark/test/commonmark-test.ts
+++ b/packages/@atjson/renderer-commonmark/test/commonmark-test.ts
@@ -23,7 +23,7 @@ describe('commonmark', () => {
     let document = new Document({
       content: '\uFFFC',
       contentType: 'text/atjson',
-      annotations: [{ 
+      annotations: [{
         type: 'image',
         start: 0,
         end: 1,
@@ -325,7 +325,7 @@ After all the lists
     });
 
     let renderer = new CommonMarkRenderer();
-    expect(renderer.render(document)).toBe('**bold**_\\, then italic_\n\n_italic_**\\, then bold**\n\n');
+    expect(renderer.render(document)).toBe('**bold**_, then italic_\n\n_italic_**, then bold**\n\n');
   });
 
   test('empty format strings are removed', () => {


### PR DESCRIPTION
Because we support rendering to markdown, we had been escaping special characters used by markdown in case the text itself might contain a markdown sequence. We had been doing this rather aggressively, escaping many common punctuation characters, and instead we can be more targeted with the escaped sequences: for example, looking for `-` where it would indicate a list rather than in all occurrences. 

- Don't escape common punctuation chars: `(),'"?@-$%`
- Also updates lerna version in lerna.json to match version in package.json