### PR TITLE
🛀 Add non-emitting tsconfig.json to document/test.

### DIFF
--- a/packages/@atjson/document/test/atjson-insert-test.ts
+++ b/packages/@atjson/document/test/atjson-insert-test.ts
@@ -1,4 +1,4 @@
-import Document from '@atjson/document';
+import Document from '../src/';
 
 describe('Document.insertText', () => {
   it('insert text adds text to the content attribute', () => {

--- a/packages/@atjson/document/test/atjson-test.ts
+++ b/packages/@atjson/document/test/atjson-test.ts
@@ -1,4 +1,4 @@
-import Document from '@atjson/document';
+import Document from '../src/';
 
 describe('new Document', () => {
   it('constructor accepts a string', () => {

--- a/packages/@atjson/document/test/query-test.ts
+++ b/packages/@atjson/document/test/query-test.ts
@@ -1,4 +1,5 @@
-import Document from '@atjson/document';
+import Document, { Annotation } from '../src/';
+import AnnotationCollection from '../src/query';
 
 describe('Document.where', () => {
   it('runs queries against existing annotations', () => {
@@ -201,7 +202,7 @@ describe('Document.where', () => {
         start: annotation.start,
         end: annotation.end,
         attributes: {
-          url: annotation.attributes.href,
+          url: annotation.attributes ? annotation.attributes.href : '',
           openInNewTab: true
         }
       };
@@ -312,8 +313,7 @@ describe('Document.where', () => {
   });
 
   describe('AnnotationCollection.join', () => {
-
-    let doc;
+    let doc: Document;
 
     beforeEach(() => {
       doc = new Document({
@@ -351,7 +351,7 @@ describe('Document.where', () => {
 
       let code;
       let pre;
-      let preAndCode;
+      let preAndCode: AnnotationCollection;
 
       beforeEach(() => {
         code = doc.where({ type: 'code' }).as('code');
@@ -390,7 +390,7 @@ describe('Document.where', () => {
             let newCode = Object.assign(join.code, {attributes: newAttributes});
 
             doc.replaceAnnotation(join.code, newCode);
-            doc.deleteText({start: 2, end: 4});
+            doc.deleteText({start: 2, end: 4} as Annotation);
 
             return {
               update: [[join.code, newCode]],
@@ -426,7 +426,7 @@ describe('Document.where', () => {
       let pre;
       let code;
       let locale;
-      let allJoin;
+      let allJoin: AnnotationCollection;
 
       beforeEach(() => {
         doc.addAnnotations({
@@ -486,9 +486,9 @@ describe('Document.where', () => {
 
             doc.insertText(0, 'Hello!\n');
 
-            let removeAnnotations = [];
+            let removeAnnotations: Annotation[] = [];
             let newAttributes = {};
-            join.pre.forEach(x => {
+            join.pre.forEach((x: Annotation) => {
               Object.assign(newAttributes, x.attributes);
               doc.removeAnnotation(x);
               removeAnnotations.push(x);

--- a/packages/@atjson/document/test/tsconfig.json
+++ b/packages/@atjson/document/test/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": [
+    "**/*"
+  ]
+}


### PR DESCRIPTION
This sets a TypeScript compilation context for `ts` files in `test/` allowing VSCode (among other editors) to surface TypeScript errors.

I've addressed the more straightforward TypeScripts errors; there are a number of errors related to accessing properties on the parameter passed to `AnnotationCollection.transform`:
```
test/query-test.ts:360:49 - error TS2339: Property 'start' does not exist on type 'JoinableAnnotation'.
  Property 'start' does not exist on type 'AnnotationJoin'.

360         preAndCode = code.join(pre, (l, r) => l.start === r.start && l.end === r.end);
```
