### PR TITLE
🛀 Add non-emitting tsconfig.json to editor/test.

### DIFF
--- a/packages/@atjson/editor/test/tsconfig.json
+++ b/packages/@atjson/editor/test/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": [
+    "**/*"
+  ]
+}


### PR DESCRIPTION
This sets a TypeScript compilation context for `ts` files in `test/` allowing VSCode (among other editors) to surface TypeScript errors.