### PR TITLE
📦 Pin @types/node to 10.11.0.

### DIFF
--- a/packages/@atjson/source-html/package.json
+++ b/packages/@atjson/source-html/package.json
@@ -18,7 +18,7 @@
   "devDependencies": {
     "@atjson/hir": "0.8.10",
     "@atjson/renderer-hir": "0.9.3",
-    "@types/node": "^10.9.4"
+    "@types/node": "10.11.0"
   },
   "dependencies": {
     "@atjson/document": "0.8.6",


### PR DESCRIPTION
Looks like [it](https://github.com/DefinitelyTyped/DefinitelyTyped/issues/29228) will be [addressed](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/29230) soon, but if it's not soon enough, here's a band-aid.