### PR TITLE
🔍 make `id` optional, using `uuid` when not provided

### DIFF
--- a/packages/@atjson/document/package.json
+++ b/packages/@atjson/document/package.json
@@ -14,5 +14,9 @@
   "license": "Apache-2.0",
   "publishConfig": {
     "access": "public"
+  },
+  "dependencies": {
+    "@types/uuid": "^3.4.4",
+    "uuid": "^3.3.2"
   }
 }

--- a/packages/@atjson/document/src/annotation.ts
+++ b/packages/@atjson/document/src/annotation.ts
@@ -1,3 +1,4 @@
+import { v4 as uuid } from 'uuid';
 import { toJSON, unprefix } from './attributes';
 import Change, { AdjacentBoundaryBehaviour, Deletion, Insertion } from './change';
 import Document from './index';
@@ -8,8 +9,8 @@ export interface AnnotationConstructor {
   vendorPrefix: string;
   type: string;
   subdocuments: { [key: string]: typeof Document };
-  new(attributes: { id: string, start: number, end: number, attributes: NonNullable<any> }): Annotation;
-  hydrate(attrs: { id: string, start: number, end: number, attributes: JSON }): Annotation;
+  new(attributes: { id?: string, start: number, end: number, attributes: NonNullable<any> }): Annotation;
+  hydrate(attrs: { id?: string, start: number, end: number, attributes: JSON }): Annotation;
 }
 
 export default abstract class Annotation {
@@ -19,7 +20,7 @@ export default abstract class Annotation {
 
   static hydrate(
     this: AnnotationConstructor,
-    attrs: { id: string, start: number, end: number, attributes: JSON }
+    attrs: { id?: string, start: number, end: number, attributes: JSON }
   ) {
     return new this({
       id: attrs.id,
@@ -36,10 +37,10 @@ export default abstract class Annotation {
   end: number;
   attributes: NonNullable<any>;
 
-  constructor(attrs: { id: string, start: number, end: number, attributes: NonNullable<any> }) {
+  constructor(attrs: { id?: string, start: number, end: number, attributes: NonNullable<any> }) {
     let AnnotationClass = this.constructor as AnnotationConstructor;
     this.type = AnnotationClass.type;
-    this.id = attrs.id;
+    this.id = attrs.id || uuid();
     this.start = attrs.start;
     this.end = attrs.end;
 

--- a/packages/@atjson/document/src/index.ts
+++ b/packages/@atjson/document/src/index.ts
@@ -6,7 +6,7 @@ import Join from './join';
 import JSON from './json';
 
 export interface AnnotationJSON {
-  id: string;
+  id?: string;
   type: string;
   start: number;
   end: number;

--- a/packages/@atjson/hir/src/hir-node.ts
+++ b/packages/@atjson/hir/src/hir-node.ts
@@ -134,7 +134,6 @@ export default class HIRNode {
     if (text.length === 1 && this.end - this.start === 1 && text === '\uFFFC') return;
 
     let node = new HIRNode(new Text({
-      id: uuid(),
       start: this.start,
       end: this.end,
       attributes: { text }

--- a/packages/@atjson/hir/src/hir.ts
+++ b/packages/@atjson/hir/src/hir.ts
@@ -1,5 +1,4 @@
 import Document, { Annotation, JSON } from '@atjson/document';
-import { v4 as uuid } from 'uuid';
 import { Root } from './annotations';
 import HIRNode from './hir-node';
 
@@ -18,7 +17,6 @@ export default class HIR {
       });
 
     this.rootNode = new HIRNode(new Root({
-      id: uuid(),
       start: 0,
       end: document.content.length,
       attributes: {}

--- a/packages/@atjson/source-commonmark/package.json
+++ b/packages/@atjson/source-commonmark/package.json
@@ -20,10 +20,8 @@
     "@atjson/offset-annotations": "file:../offset-annotations",
     "@types/entities": "^1.1.0",
     "@types/markdown-it": "^0.0.4",
-    "@types/uuid": "^3.4.4",
     "entities": "^1.1.1",
-    "markdown-it": "^8.4.1",
-    "uuid": "^3.3.2"
+    "markdown-it": "^8.4.1"
   },
   "devDependencies": {
     "@atjson/source-html": "file:../source-html"

--- a/packages/@atjson/source-commonmark/src/index.ts
+++ b/packages/@atjson/source-commonmark/src/index.ts
@@ -2,7 +2,6 @@ import Document, { AnnotationJSON } from '@atjson/document';
 import OffsetSource from '@atjson/offset-annotations';
 import * as entities from 'entities';
 import * as MarkdownIt from 'markdown-it';
-import { v4 as uuid } from 'uuid';
 import { Blockquote, BulletList, CodeBlock, CodeInline, Emphasis, Fence, HTMLBlock, HTMLInline, Hardbreak, Heading, HorizontalRule, Image, Link, ListItem, OrderedList, Paragraph, Strong } from './annotations';
 
 export * from './annotations';
@@ -166,7 +165,6 @@ class Parser {
     let start = this.content.length;
     this.content += '\uFFFC';
     this.annotations.push({
-      id: uuid(),
       type: '-atjson-parse-token',
       start,
       end: start + 1,
@@ -191,7 +189,6 @@ class Parser {
       Object.assign(attributes, this.handlers[name](open));
     }
     this.annotations.push({
-      id: uuid(),
       type: '-atjson-parse-token',
       start: end - 1,
       end,
@@ -199,7 +196,6 @@ class Parser {
         '-atjson-reason': `${name}_close`
       }
     }, {
-      id: uuid(),
       type: `-commonmark-${name}`,
       start,
       end,

--- a/packages/@atjson/source-gdocs-paste/package.json
+++ b/packages/@atjson/source-gdocs-paste/package.json
@@ -17,8 +17,6 @@
   },
   "dependencies": {
     "@atjson/document": "file:../document",
-    "@atjson/offset-annotations": "file:../offset-annotations",
-    "@types/uuid": "^3.4.4",
-    "uuid": "^3.3.2"
+    "@atjson/offset-annotations": "file:../offset-annotations"
   }
 }

--- a/packages/@atjson/source-gdocs-paste/src/horizontal-rule.ts
+++ b/packages/@atjson/source-gdocs-paste/src/horizontal-rule.ts
@@ -1,5 +1,4 @@
 import { AnnotationJSON } from '@atjson/document';
-import { v4 as uuid } from 'uuid';
 import { GDocsStyleSlice } from './types';
 
 export default function extractHorizontalRule(styles: GDocsStyleSlice[]): AnnotationJSON[] {
@@ -11,7 +10,6 @@ export default function extractHorizontalRule(styles: GDocsStyleSlice[]): Annota
     if (style === null) continue;
 
     annotations.push({
-      id: uuid(),
       type: '-gdocs-horizontal_rule',
       start: i,
       end: i + 1,

--- a/packages/@atjson/source-gdocs-paste/src/link-styles.ts
+++ b/packages/@atjson/source-gdocs-paste/src/link-styles.ts
@@ -1,5 +1,4 @@
 import { AnnotationJSON } from '@atjson/document';
-import { v4 as uuid } from 'uuid';
 import { GDocsStyleSlice } from './types';
 
 export default function extractLinkStyles(linkStyles: GDocsStyleSlice[]): AnnotationJSON[] {
@@ -24,7 +23,6 @@ export default function extractLinkStyles(linkStyles: GDocsStyleSlice[]): Annota
     // If the linkStyles[i] entry is not null, then we have a new link starting here.
     if (link.lnks_link !== null) {
       currentLink = {
-        id: uuid(),
         type: '-gdocs-lnks_link',
         start: i,
         end: -1,

--- a/packages/@atjson/source-gdocs-paste/src/list-styles.ts
+++ b/packages/@atjson/source-gdocs-paste/src/list-styles.ts
@@ -1,5 +1,4 @@
 import { AnnotationJSON } from '@atjson/document';
-import { v4 as uuid } from 'uuid';
 import { GDocsEntityMap, GDocsStyleSlice } from './types';
 
 export default function extractListStyles(lists: GDocsStyleSlice[], entityMap: GDocsEntityMap): AnnotationJSON[] {
@@ -18,7 +17,6 @@ export default function extractListStyles(lists: GDocsStyleSlice[], entityMap: G
 
     if (!listAnnotations[list.ls_id]) {
       listAnnotations[list.ls_id] = {
-        id: uuid(),
         type: '-gdocs-list',
         start: lastParagraphStart,
         end: i,
@@ -34,7 +32,6 @@ export default function extractListStyles(lists: GDocsStyleSlice[], entityMap: G
     }
 
     listItems.push({
-      id: uuid(),
       type: '-gdocs-list_item',
       start: lastParagraphStart,
       end: i,

--- a/packages/@atjson/source-gdocs-paste/src/paragraph-styles.ts
+++ b/packages/@atjson/source-gdocs-paste/src/paragraph-styles.ts
@@ -1,5 +1,4 @@
 import { AnnotationJSON } from '@atjson/document';
-import { v4 as uuid } from 'uuid';
 import { GDocsStyleSlice } from './types';
 
 /*
@@ -44,7 +43,6 @@ export default function extractParagraphStyles(styles: GDocsStyleSlice[]): Annot
 
     if (style.ps_hd !== 0) {
       annotations.push({
-        id: uuid(),
         type: '-gdocs-ps_hd',
         start: lastParagraphStart,
         end: i,

--- a/packages/@atjson/source-gdocs-paste/src/text-styles.ts
+++ b/packages/@atjson/source-gdocs-paste/src/text-styles.ts
@@ -1,5 +1,4 @@
 import { AnnotationJSON } from '@atjson/document';
-import { v4 as uuid } from 'uuid';
 import { GDocsStyleSlice } from './types';
 
 interface ParseState {
@@ -18,7 +17,6 @@ export default function extractTextStyles(styles: GDocsStyleSlice[]): Annotation
     // Handle subscript and superscript
     if (style.ts_va !== 'nor' && !state.ts_va) {
       state.ts_va = {
-        id: uuid(),
         type: '-gdocs-ts_va',
         attributes: {
           '-gdocs-va': style.ts_va
@@ -35,7 +33,6 @@ export default function extractTextStyles(styles: GDocsStyleSlice[]): Annotation
     for (let styleType of ['ts_bd', 'ts_it', 'ts_un', 'ts_st']) {
       if (style[styleType] === true && !state[styleType]) {
         state[styleType] = {
-          id: uuid(),
           type: '-gdocs-' + styleType,
           start: i,
           end: -1,

--- a/packages/@atjson/source-html/package.json
+++ b/packages/@atjson/source-html/package.json
@@ -18,8 +18,6 @@
   "dependencies": {
     "@atjson/document": "file:../document",
     "@atjson/offset-annotations": "file:../offset-annotations",
-    "@types/uuid": "^3.4.4",
-    "parse5": "^4.0.0",
-    "uuid": "^3.3.2"
+    "parse5": "^4.0.0"
   }
 }

--- a/packages/@atjson/source-html/src/index.ts
+++ b/packages/@atjson/source-html/src/index.ts
@@ -1,6 +1,5 @@
 import Document, { AnnotationJSON } from '@atjson/document';
 import * as parse5 from 'parse5/lib';
-import { v4 as uuid } from 'uuid';
 import {
   Anchor,
   Blockquote,
@@ -112,7 +111,6 @@ class Parser {
     let { startOffset: start, endOffset: end } = location[which];
     let reason = which === 'startTag' ? `<${node.tagName}>` : `</${node.tagName}>`;
     this.annotations.push({
-      id: uuid(),
       type: '-atjson-parse-token',
       attributes: { '-atjson-reason': reason },
       start: start - this.offset,
@@ -137,7 +135,6 @@ class Parser {
       yield;
 
       this.annotations.push({
-        id: uuid(),
         type: `-html-${tagName}`,
         attributes: getAttributes(node),
         start,
@@ -152,7 +149,6 @@ class Parser {
       yield;
 
       this.annotations.push({
-        id: uuid(),
         type: `-html-${tagName}`,
         attributes: getAttributes(node),
         start,
@@ -165,13 +161,11 @@ class Parser {
 
       this.content += this.html.slice(location.startOffset, location.endOffset);
       this.annotations.push({
-        id: uuid(),
         type: '-atjson-parse-token',
         attributes: { '-atjson-reason': `<${tagName}/>` },
         start,
         end
       }, {
-        id: uuid(),
         type: `-html-${tagName}`,
         attributes: getAttributes(node),
         start,


### PR DESCRIPTION
This eases a constraint, making code that generates lots of annotations smaller by not asking the annotation creator to bring their own ids.

`id` can be overridden, which allows annotations to be saved to a database with a different uuid than one provided by the node `uuid` module.