### PR TITLE
✨🔮 allow Annotation classes or AnnotationJSON to all Document methods

### DIFF
--- a/packages/@atjson/document/src/annotations/index.ts
+++ b/packages/@atjson/document/src/annotations/index.ts
@@ -1,5 +1,5 @@
-export { default as Block } from './block';
-export { default as Inline } from './inline';
-export { default as Object } from './object';
-export { default as Parse } from './parse';
-export { default as Unknown } from './unknown';
+export { default as BlockAnnotation } from './block';
+export { default as InlineAnnotation } from './inline';
+export { default as ObjectAnnotation } from './object';
+export { default as ParseAnnotation } from './parse';
+export { default as UnknownAnnotation } from './unknown';

--- a/packages/@atjson/document/test/atjson-insert-test.ts
+++ b/packages/@atjson/document/test/atjson-insert-test.ts
@@ -14,13 +14,12 @@ describe('Document.insertText', () => {
   test('insert text before an annotation moves it forward', () => {
     let atjson = new TestSource({
       content: 'abcd',
-      annotations: [{
+      annotations: [new Bold({
         id: '1',
-        type: '-test-bold',
         start: 1,
         end: 3,
         attributes: {}
-      }, {
+      }), {
         id: '2',
         type: '-test-link',
         start: 1,
@@ -57,13 +56,12 @@ describe('Document.insertText', () => {
   test('insert text after an annotation doesn\'t affect it', () => {
     let atjson = new TestSource({
       content: 'abcd',
-      annotations: [{
+      annotations: [new Italic({
         id: '1',
-        type: '-test-italic',
         start: 0,
         end: 2,
         attributes: {}
-      }, {
+      }), {
         id: '2',
         type: '-test-color',
         start: 0,
@@ -99,13 +97,12 @@ describe('Document.insertText', () => {
   test('insert text inside an annotation adjusts the endpoint', () => {
     let atjson = new TestSource({
       content: 'abcd',
-      annotations: [{
+      annotations: [new Bold({
         id: '1',
-        type: '-test-bold',
         start: 1,
         end: 3,
         attributes: {}
-      }, {
+      }), {
         id: '2',
         type: '-test-underline',
         start: 1,

--- a/packages/@atjson/document/test/atjson-test.ts
+++ b/packages/@atjson/document/test/atjson-test.ts
@@ -11,26 +11,22 @@ describe('new Document', () => {
   test('constructor will set annotations', () => {
     expect(new TestSource({
       content: 'Hello World.',
-      annotations: [{
-        id: '1',
-        type: '-test-bold',
+      annotations: [new Bold({
         start: 0,
         end: 2,
         attributes: {}
-      }]
+      })]
     })).toBeDefined();
   });
 
   test('clone', () => {
     let document = new TestSource({
       content: 'Hello World.',
-      annotations: [{
-        id: '1',
-        type: '-test-bold',
+      annotations: [new Bold({
         start: 0,
         end: 2,
         attributes: {}
-      }]
+      })]
     });
     let clone = document.clone();
     let [bold] = document.annotations;


### PR DESCRIPTION
This opens up the potential for stricter typing with annotation creation, as well as tidying up some code (especially if the annotation is known when being created)

When adding an annotation that is not in the document schema, the annotation will be cast into an `UnknownAnnotation`, which means that the annotation will be added, but not rendered (under normal circumstances)