### PR TITLE
🐛 Close any open annotations from Google Docs paste

### DIFF
--- a/packages/@atjson/document/src/annotation.ts
+++ b/packages/@atjson/document/src/annotation.ts
@@ -47,6 +47,11 @@ export default abstract class Annotation {
     this.attributes = attrs.attributes || {};
   }
 
+  isAlignedWith(annotation: Annotation) {
+    return this.start === annotation.start &&
+           this.end === annotation.end;
+  }
+
   /**
    * nb. Currently, changes are applied directly to the document.
    *     In the future, we want to return a set of changes that

--- a/packages/@atjson/source-gdocs-paste/README.md
+++ b/packages/@atjson/source-gdocs-paste/README.md
@@ -1,6 +1,22 @@
 # @atjson/source-gdocs-paste
 
-Create AtJSON documents from Google Docs annotation paste buffers.
+The Google Docs paste source provides turns Google Docs pastes into an AtJSON document. AtJSON uses Google Doc's internal format directly, which you can learn more about in our [content documentation](content-documentation.md).
 
-See [Content Documentation](content-documentation.md) for more information about the structure of the
-Google Docs paste buffers.
+## 📋 Handling pastes from Google Docs
+
+This source is designed to be used to handle paste events that contain bits from a Google Doc. In the text editor of your choice, add a handler to the paste event.
+
+Get the Google Docs paste item from the paste event under the name `application/x-vnd.google-docs-document-slice-clip+wrapped`:
+
+```ts
+let gdocsPaste = evt.clipboardData.getData('application/x-vnd.google-docs-document-slice-clip+wrapped');
+```
+
+After getting the data, check if it a paste from Google Docs and use the Google Docs paste source to turn the paste into an AtJSON document:
+
+```ts
+if (gdocsPaste !== '') {
+  let data = JSON.parse(JSON.parse(gdocsPaste).data);
+  let pastedDoc = GoogleDocsPasteSource.fromSource(data);
+}
+``

--- a/packages/@atjson/source-gdocs-paste/README.md
+++ b/packages/@atjson/source-gdocs-paste/README.md
@@ -17,6 +17,6 @@ After getting the data, check if it a paste from Google Docs and use the Google 
 ```ts
 if (gdocsPaste !== '') {
   let data = JSON.parse(JSON.parse(gdocsPaste).data);
-  let pastedDoc = GoogleDocsPasteSource.fromSource(data);
+  let pastedDoc = GoogleDocsPasteSource.fromRaw(data);
 }
 ``

--- a/packages/@atjson/source-gdocs-paste/README.md
+++ b/packages/@atjson/source-gdocs-paste/README.md
@@ -1,6 +1,6 @@
 # @atjson/source-gdocs-paste
 
-The Google Docs paste source provides turns Google Docs pastes into an AtJSON document. AtJSON uses Google Doc's internal format directly, which you can learn more about in our [content documentation](content-documentation.md).
+The Google Docs paste source turns Google Docs pastes into an AtJSON document. AtJSON uses Google Doc's internal format directly, which you can learn more about in our [content documentation](content-documentation.md).
 
 ## 📋 Handling pastes from Google Docs
 

--- a/packages/@atjson/source-gdocs-paste/package.json
+++ b/packages/@atjson/source-gdocs-paste/package.json
@@ -9,12 +9,16 @@
     "build": "rm -rf dist; tsc -p . && tsc -p . --module ESNext --outDir dist/modules/ --target ES2017",
     "lint": "tslint -c ./tslint.json 'src/**/*.ts'",
     "prepublishOnly": "npm run build",
+    "start": "parcel public/index.html -d public/dist",
     "test": "../../../node_modules/.bin/jest packages/@atjson/$(basename $PWD) --config=../../../package.json"
   },
   "license": "Apache-2.0",
   "publishConfig": {
     "access": "public"
   },
+  "browserslist": [
+    "last 2 Chrome versions"
+  ],
   "dependencies": {
     "@atjson/document": "file:../document",
     "@atjson/offset-annotations": "file:../offset-annotations"

--- a/packages/@atjson/source-gdocs-paste/public/app.ts
+++ b/packages/@atjson/source-gdocs-paste/public/app.ts
@@ -5,6 +5,6 @@ document.addEventListener('paste', (evt: ClipboardEvent) => {
   let gdocsPaste = evt.clipboardData.getData('application/x-vnd.google-docs-document-slice-clip+wrapped');
   if (gdocsPaste !== '') {
     let data = JSON.parse(JSON.parse(gdocsPaste).data);
-    document.body.innerText = JSON.stringify(GoogleDocsPasteSource.fromSource(data).toJSON(), null, 2);
+    document.body.innerText = JSON.stringify(GoogleDocsPasteSource.fromRaw(data).toJSON(), null, 2);
   }
 });

--- a/packages/@atjson/source-gdocs-paste/public/app.ts
+++ b/packages/@atjson/source-gdocs-paste/public/app.ts
@@ -1,0 +1,10 @@
+import OffsetSource from '@atjson/offset-annotations';
+import GoogleDocsPasteSource from '../src';
+
+document.addEventListener('paste', (evt: ClipboardEvent) => {
+  let gdocsPaste = evt.clipboardData.getData('application/x-vnd.google-docs-document-slice-clip+wrapped');
+  if (gdocsPaste !== '') {
+    let data = JSON.parse(JSON.parse(gdocsPaste).data);
+    document.body.innerHTML = JSON.stringify(GoogleDocsPasteSource.fromSource(data).toJSON(), null, 2);
+  }
+});

--- a/packages/@atjson/source-gdocs-paste/public/app.ts
+++ b/packages/@atjson/source-gdocs-paste/public/app.ts
@@ -5,6 +5,6 @@ document.addEventListener('paste', (evt: ClipboardEvent) => {
   let gdocsPaste = evt.clipboardData.getData('application/x-vnd.google-docs-document-slice-clip+wrapped');
   if (gdocsPaste !== '') {
     let data = JSON.parse(JSON.parse(gdocsPaste).data);
-    document.body.innerHTML = JSON.stringify(GoogleDocsPasteSource.fromSource(data).toJSON(), null, 2);
+    document.body.innerText = JSON.stringify(GoogleDocsPasteSource.fromSource(data).toJSON(), null, 2);
   }
 });

--- a/packages/@atjson/source-gdocs-paste/public/index.html
+++ b/packages/@atjson/source-gdocs-paste/public/index.html
@@ -1,0 +1,8 @@
+<html>
+  <head>
+    <script src="./app.ts"></script>
+    <link rel="stylesheet" type="text/css" href="./style.scss" />
+  </head>
+  <body>
+  </body>
+</html>

--- a/packages/@atjson/source-gdocs-paste/public/style.scss
+++ b/packages/@atjson/source-gdocs-paste/public/style.scss
@@ -1,0 +1,6 @@
+body {
+  margin: 0em;
+  font-family: Menlo, Monaco, monospace;
+  font-size: 12px;
+  white-space: pre-wrap;
+}

--- a/packages/@atjson/source-gdocs-paste/src/converter.ts
+++ b/packages/@atjson/source-gdocs-paste/src/converter.ts
@@ -2,6 +2,17 @@ import OffsetSource from '@atjson/offset-annotations';
 import GDocsSource from './source';
 
 GDocsSource.defineConverterTo(OffsetSource, doc => {
+  // Remove all underlines that align with links, since
+  // Google docs automatically does this when creating a link.
+  // If necessary, underlined text can be added afterwards;
+  // using this behavior ends up with unexpected consequences
+  doc.where({ type: '-gdocs-ts_un' }).as('underline').join(
+    doc.where({ type: '-gdocs-lnks_link' }).as('link'),
+    (underline, link) => underline.isAlignedWith(link)
+  ).update(({ underline }) => {
+    doc.removeAnnotation(underline);
+  });
+
   doc.where({ type: '-gdocs-ts_bd' }).set({ type: '-offset-bold' });
   doc.where({ type: '-gdocs-ts_it' }).set({ type: '-offset-italic' });
   doc.where({ type: '-gdocs-ts_un' }).set({ type: '-offset-underline' });

--- a/packages/@atjson/source-gdocs-paste/src/link-styles.ts
+++ b/packages/@atjson/source-gdocs-paste/src/link-styles.ts
@@ -32,7 +32,12 @@ export default function extractLinkStyles(linkStyles: GDocsStyleSlice[]): Annota
         }
       };
     }
+  }
 
+  // Add any unclosed links
+  if (currentLink) {
+    currentLink.end = linkStyles.length - 1;
+    links.push(currentLink);
   }
 
   return links;

--- a/packages/@atjson/source-gdocs-paste/src/text-styles.ts
+++ b/packages/@atjson/source-gdocs-paste/src/text-styles.ts
@@ -44,8 +44,14 @@ export default function extractTextStyles(styles: GDocsStyleSlice[]): Annotation
         delete state[styleType];
       }
     }
-
   }
+
+  // Close any remaining open styles
+  Object.keys(state).forEach(key => {
+    let annotation = state[key];
+    annotation.end = styles.length - 1;
+    annotations.push(annotation);
+  });
 
   return annotations;
 }

--- a/packages/@atjson/source-gdocs-paste/test/converter-test.ts
+++ b/packages/@atjson/source-gdocs-paste/test/converter-test.ts
@@ -60,7 +60,7 @@ describe('@atjson/source-gdocs-paste', () => {
     // https://docs.google.com/document/d/18pp4dAGx5II596HHGOLUXXcc6VKLAVRBUMLm9Ge8eOE/edit?usp=sharing
     let fixturePath = path.join(__dirname, 'fixtures', 'underline.json');
     let rawJSON = JSON.parse(fs.readFileSync(fixturePath).toString());
-    let gdocs = GDocsSource.fromSource(rawJSON);
+    let gdocs = GDocsSource.fromRaw(rawJSON);
     let doc = gdocs.convertTo(OffsetSource);
 
     let links = doc.where({ type: '-offset-link' }).as('links');

--- a/packages/@atjson/source-gdocs-paste/test/converter-test.ts
+++ b/packages/@atjson/source-gdocs-paste/test/converter-test.ts
@@ -55,4 +55,19 @@ describe('@atjson/source-gdocs-paste', () => {
     expect(links.length).toEqual(1);
     expect(links.map(link => link.attributes.url)).toEqual(['https://www.google.com/']);
   });
+
+  it('removes underlined text aligned exactly with links', () => {
+    // https://docs.google.com/document/d/18pp4dAGx5II596HHGOLUXXcc6VKLAVRBUMLm9Ge8eOE/edit?usp=sharing
+    let fixturePath = path.join(__dirname, 'fixtures', 'underline.json');
+    let rawJSON = JSON.parse(fs.readFileSync(fixturePath).toString());
+    let gdocs = GDocsSource.fromSource(rawJSON);
+    let doc = gdocs.convertTo(OffsetSource);
+
+    let links = doc.where({ type: '-offset-link' }).as('links');
+    let underlines = doc.where({ type: '-offset-underline' }).as('underline');
+
+    expect(
+      links.join(underlines, (a, b) => a.isAlignedWith(b)).length
+    ).toBe(0);
+  });
 });

--- a/packages/@atjson/source-gdocs-paste/test/fixtures/partial.json
+++ b/packages/@atjson/source-gdocs-paste/test/fixtures/partial.json
@@ -1,0 +1,512 @@
+{
+  "resolved": {
+    "dsl_spacers": "This is some text with a link that’s gonna",
+    "dsl_styleslices": [
+      {
+        "stsl_type": "autogen",
+        "stsl_styles": []
+      },
+      {
+        "stsl_type": "cell",
+        "stsl_styles": []
+      },
+      {
+        "stsl_type": "column_sector",
+        "stsl_leading": {
+          "css_cols": {
+            "cv": {
+              "op": "set",
+              "opValue": []
+            }
+          },
+          "css_lb": false,
+          "css_ltr": true,
+          "css_st": "continuous"
+        },
+        "stsl_leadingType": "column_sector",
+        "stsl_trailing": {
+          "css_cols": {
+            "cv": {
+              "op": "set",
+              "opValue": []
+            }
+          },
+          "css_lb": false,
+          "css_ltr": true,
+          "css_st": "continuous"
+        },
+        "stsl_trailingType": "column_sector",
+        "stsl_styles": []
+      },
+      {
+        "stsl_type": "comment",
+        "stsl_styles": [
+          {
+            "cs_cids": {
+              "cv": {
+                "op": "set",
+                "opValue": []
+              }
+            }
+          }
+        ]
+      },
+      {
+        "stsl_type": "date_time",
+        "stsl_styles": []
+      },
+      {
+        "stsl_type": "document",
+        "stsl_leading": {
+          "ds_b": {
+            "bg_c": null
+          },
+          "ds_fi": null,
+          "ds_hi": null,
+          "ds_epfi": null,
+          "ds_ephi": null,
+          "ds_uephf": false,
+          "ds_fpfi": null,
+          "ds_fphi": null,
+          "ds_ufphf": false,
+          "ds_pnsi": 1,
+          "ds_mb": 72,
+          "ds_ml": 72,
+          "ds_mr": 72,
+          "ds_mt": 72,
+          "ds_ph": 792,
+          "ds_pw": 612,
+          "ds_rtd": "",
+          "ds_mh": 36,
+          "ds_mf": 36,
+          "ds_ulhfl": true
+        },
+        "stsl_leadingType": "document",
+        "stsl_styles": []
+      },
+      {
+        "stsl_type": "equation",
+        "stsl_styles": []
+      },
+      {
+        "stsl_type": "equation_function",
+        "stsl_styles": []
+      },
+      {
+        "stsl_type": "footnote",
+        "stsl_styles": []
+      },
+      {
+        "stsl_type": "headings",
+        "stsl_styles": []
+      },
+      {
+        "stsl_type": "horizontal_rule",
+        "stsl_styles": []
+      },
+      {
+        "stsl_type": "import_warnings",
+        "stsl_styles": [
+          {
+            "iws_iwids": {
+              "cv": {
+                "op": "set",
+                "opValue": []
+              }
+            }
+          }
+        ]
+      },
+      {
+        "stsl_type": "language",
+        "stsl_trailing": {
+          "lgs_l": "en"
+        },
+        "stsl_trailingType": "language",
+        "stsl_styles": []
+      },
+      {
+        "stsl_type": "link",
+        "stsl_styles": [
+          {
+            "lnks_link": null
+          },
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          {
+            "lnks_link": {
+              "lnk_type": 0,
+              "ulnk_url": "https://google.com"
+            }
+          }
+        ]
+      },
+      {
+        "stsl_type": "list",
+        "stsl_trailing": {
+          "ls_nest": 0,
+          "ls_id": null,
+          "ls_ts": {
+            "ts_bd": false,
+            "ts_fs": 11,
+            "ts_ff": "Arial",
+            "ts_it": false,
+            "ts_sc": false,
+            "ts_st": false,
+            "ts_tw": 400,
+            "ts_un": false,
+            "ts_va": "nor",
+            "ts_bgc2": {
+              "clr_type": 0,
+              "hclr_color": null
+            },
+            "ts_fgc2": {
+              "clr_type": 0,
+              "hclr_color": "#000000"
+            },
+            "ts_bd_i": false,
+            "ts_fs_i": false,
+            "ts_ff_i": false,
+            "ts_it_i": false,
+            "ts_sc_i": false,
+            "ts_st_i": false,
+            "ts_un_i": false,
+            "ts_va_i": false,
+            "ts_bgc2_i": false,
+            "ts_fgc2_i": false
+          }
+        },
+        "stsl_trailingType": "list",
+        "stsl_styles": []
+      },
+      {
+        "stsl_type": "named_range",
+        "stsl_styles": [
+          {
+            "nrs_ei": {
+              "cv": {
+                "op": "set",
+                "opValue": []
+              }
+            }
+          }
+        ]
+      },
+      {
+        "stsl_type": "paragraph",
+        "stsl_trailing": {
+          "ps_al": 0,
+          "ps_awao": true,
+          "ps_sd": null,
+          "ps_bbtw": null,
+          "ps_bb": null,
+          "ps_bl": null,
+          "ps_br": null,
+          "ps_bt": null,
+          "ps_hd": 0,
+          "ps_hdid": "",
+          "ps_ifl": 0,
+          "ps_il": 0,
+          "ps_ir": 0,
+          "ps_klt": false,
+          "ps_kwn": false,
+          "ps_ltr": true,
+          "ps_ls": 1.15,
+          "ps_sm": 0,
+          "ps_sa": 0,
+          "ps_sb": 0,
+          "ps_al_i": false,
+          "ps_awao_i": false,
+          "ps_sd_i": false,
+          "ps_bbtw_i": false,
+          "ps_bb_i": false,
+          "ps_bl_i": false,
+          "ps_br_i": false,
+          "ps_bt_i": false,
+          "ps_ifl_i": false,
+          "ps_il_i": false,
+          "ps_ir_i": false,
+          "ps_klt_i": false,
+          "ps_kwn_i": false,
+          "ps_ls_i": false,
+          "ps_rd": "",
+          "ps_sm_i": false,
+          "ps_sa_i": false,
+          "ps_sb_i": false,
+          "ps_shd": false,
+          "ps_ts": {
+            "cv": {
+              "op": "set",
+              "opValue": []
+            }
+          }
+        },
+        "stsl_trailingType": "paragraph",
+        "stsl_styles": []
+      },
+      {
+        "stsl_type": "row",
+        "stsl_styles": []
+      },
+      {
+        "stsl_type": "suppress_feature",
+        "stsl_styles": [
+          {
+            "sfs_sst": false
+          }
+        ]
+      },
+      {
+        "stsl_type": "tbl",
+        "stsl_styles": []
+      },
+      {
+        "stsl_type": "text",
+        "stsl_styles": [
+          {
+            "ts_bd": false,
+            "ts_fs": 11,
+            "ts_ff": "Arial",
+            "ts_it": false,
+            "ts_sc": false,
+            "ts_st": false,
+            "ts_tw": 400,
+            "ts_un": false,
+            "ts_va": "nor",
+            "ts_bgc2": {
+              "clr_type": 0,
+              "hclr_color": null
+            },
+            "ts_fgc2": {
+              "clr_type": 0,
+              "hclr_color": "#000000"
+            },
+            "ts_bd_i": false,
+            "ts_fs_i": false,
+            "ts_ff_i": false,
+            "ts_it_i": false,
+            "ts_sc_i": false,
+            "ts_st_i": false,
+            "ts_un_i": false,
+            "ts_va_i": false,
+            "ts_bgc2_i": false,
+            "ts_fgc2_i": false
+          },
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          {
+            "ts_bd": false,
+            "ts_fs": 11,
+            "ts_ff": "Arial",
+            "ts_it": false,
+            "ts_sc": false,
+            "ts_st": false,
+            "ts_tw": 400,
+            "ts_un": true,
+            "ts_va": "nor",
+            "ts_bgc2": {
+              "clr_type": 0,
+              "hclr_color": null
+            },
+            "ts_fgc2": {
+              "clr_type": 0,
+              "hclr_color": "#1155cc"
+            },
+            "ts_bd_i": false,
+            "ts_fs_i": false,
+            "ts_ff_i": false,
+            "ts_it_i": false,
+            "ts_sc_i": false,
+            "ts_st_i": false,
+            "ts_un_i": false,
+            "ts_va_i": false,
+            "ts_bgc2_i": false,
+            "ts_fgc2_i": false
+          }
+        ]
+      }
+    ],
+    "dsl_metastyleslices": [
+      {
+        "stsl_type": "composing_decoration",
+        "stsl_styles": [
+          {
+            "cd_u": false,
+            "cd_bgc": {
+              "clr_type": 0,
+              "hclr_color": null
+            }
+          }
+        ]
+      },
+      {
+        "stsl_type": "composing_region",
+        "stsl_styles": [
+          {
+            "cr_c": false
+          }
+        ]
+      },
+      {
+        "stsl_type": "draft_comment",
+        "stsl_styles": [
+          {
+            "dcs_cids": {
+              "cv": {
+                "op": "set",
+                "opValue": []
+              }
+            }
+          }
+        ]
+      },
+      {
+        "stsl_type": "ignore_word",
+        "stsl_styles": [
+          {
+            "iwos_i": false
+          }
+        ]
+      },
+      {
+        "stsl_type": "revision_diff",
+        "stsl_styles": [
+          {
+            "revdiff_dt": 0,
+            "revdiff_a": "",
+            "revdiff_aid": ""
+          }
+        ]
+      },
+      {
+        "stsl_type": "smart_todo",
+        "stsl_styles": [
+          {
+            "sts_cid": null,
+            "sts_ot": null,
+            "sts_ac": null,
+            "sts_hi": {
+              "cv": {
+                "op": "set",
+                "opValue": []
+              }
+            },
+            "sts_pa": {
+              "cv": {
+                "op": "set",
+                "opValue": []
+              }
+            },
+            "sts_dm": {
+              "cv": {
+                "op": "set",
+                "opValue": []
+              }
+            }
+          }
+        ]
+      },
+      {
+        "stsl_type": "spellcheck",
+        "stsl_styles": [
+          {
+            "sc_ow": null,
+            "sc_sl": null,
+            "sc_sugg": {
+              "cv": {
+                "op": "set",
+                "opValue": []
+              }
+            },
+            "sc_sm": {
+              "cv": {
+                "op": "set",
+                "opValue": []
+              }
+            }
+          }
+        ]
+      },
+      {
+        "stsl_type": "voice_corrections",
+        "stsl_styles": [
+          {
+            "vcs_c": {
+              "cv": {
+                "op": "set",
+                "opValue": []
+              }
+            }
+          }
+        ]
+      },
+      {
+        "stsl_type": "voice_dotted_span",
+        "stsl_styles": [
+          {
+            "vdss_p": null
+          }
+        ]
+      }
+    ],
+    "dsl_suggestedinsertions": {
+      "sgsl_sugg": [
+        []
+      ]
+    },
+    "dsl_suggesteddeletions": {
+      "sgsl_sugg": [
+        []
+      ]
+    },
+    "dsl_entitypositionmap": {},
+    "dsl_entitymap": {},
+    "dsl_entitytypemap": {},
+    "dsl_relateddocslices": {}
+  },
+  "autotext_content": {}
+}

--- a/packages/@atjson/source-gdocs-paste/test/fixtures/underline.json
+++ b/packages/@atjson/source-gdocs-paste/test/fixtures/underline.json
@@ -1,0 +1,713 @@
+{
+  "resolved": {
+    "dsl_spacers": "Hello, this is a link and this is underlined text.\n",
+    "dsl_styleslices": [
+      {
+        "stsl_type": "autogen",
+        "stsl_styles": []
+      },
+      {
+        "stsl_type": "cell",
+        "stsl_styles": []
+      },
+      {
+        "stsl_type": "column_sector",
+        "stsl_leading": {
+          "css_cols": {
+            "cv": {
+              "op": "set",
+              "opValue": []
+            }
+          },
+          "css_lb": false,
+          "css_ltr": true,
+          "css_st": "continuous"
+        },
+        "stsl_leadingType": "column_sector",
+        "stsl_trailing": {
+          "css_cols": {
+            "cv": {
+              "op": "set",
+              "opValue": []
+            }
+          },
+          "css_lb": false,
+          "css_ltr": true,
+          "css_st": "continuous"
+        },
+        "stsl_trailingType": "column_sector",
+        "stsl_styles": []
+      },
+      {
+        "stsl_type": "comment",
+        "stsl_styles": [
+          {
+            "cs_cids": {
+              "cv": {
+                "op": "set",
+                "opValue": []
+              }
+            }
+          }
+        ]
+      },
+      {
+        "stsl_type": "date_time",
+        "stsl_styles": []
+      },
+      {
+        "stsl_type": "document",
+        "stsl_leading": {
+          "ds_b": {
+            "bg_c": null
+          },
+          "ds_fi": null,
+          "ds_hi": null,
+          "ds_epfi": null,
+          "ds_ephi": null,
+          "ds_uephf": false,
+          "ds_fpfi": null,
+          "ds_fphi": null,
+          "ds_ufphf": false,
+          "ds_pnsi": 1,
+          "ds_mb": 72,
+          "ds_ml": 72,
+          "ds_mr": 72,
+          "ds_mt": 72,
+          "ds_ph": 792,
+          "ds_pw": 612,
+          "ds_rtd": "",
+          "ds_mh": 36,
+          "ds_mf": 36,
+          "ds_ulhfl": true
+        },
+        "stsl_leadingType": "document",
+        "stsl_styles": []
+      },
+      {
+        "stsl_type": "equation",
+        "stsl_styles": []
+      },
+      {
+        "stsl_type": "equation_function",
+        "stsl_styles": []
+      },
+      {
+        "stsl_type": "footnote",
+        "stsl_styles": []
+      },
+      {
+        "stsl_type": "headings",
+        "stsl_styles": []
+      },
+      {
+        "stsl_type": "horizontal_rule",
+        "stsl_styles": []
+      },
+      {
+        "stsl_type": "import_warnings",
+        "stsl_styles": [
+          {
+            "iws_iwids": {
+              "cv": {
+                "op": "set",
+                "opValue": []
+              }
+            }
+          }
+        ]
+      },
+      {
+        "stsl_type": "language",
+        "stsl_trailing": {
+          "lgs_l": "en"
+        },
+        "stsl_trailingType": "language",
+        "stsl_styles": []
+      },
+      {
+        "stsl_type": "link",
+        "stsl_styles": [
+          {
+            "lnks_link": null
+          },
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          {
+            "lnks_link": {
+              "lnk_type": 0,
+              "ulnk_url": "https://condenast.com"
+            }
+          },
+          null,
+          null,
+          null,
+          {
+            "lnks_link": null
+          }
+        ]
+      },
+      {
+        "stsl_type": "list",
+        "stsl_styles": [
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          {
+            "ls_nest": 0,
+            "ls_id": null,
+            "ls_ts": {
+              "ts_bd": false,
+              "ts_fs": 11,
+              "ts_ff": "Arial",
+              "ts_it": false,
+              "ts_sc": false,
+              "ts_st": false,
+              "ts_tw": 400,
+              "ts_un": false,
+              "ts_va": "nor",
+              "ts_bgc2": {
+                "clr_type": 0,
+                "hclr_color": null
+              },
+              "ts_fgc2": {
+                "clr_type": 0,
+                "hclr_color": "#000000"
+              },
+              "ts_bd_i": false,
+              "ts_fs_i": false,
+              "ts_ff_i": false,
+              "ts_it_i": false,
+              "ts_sc_i": false,
+              "ts_st_i": false,
+              "ts_un_i": false,
+              "ts_va_i": false,
+              "ts_bgc2_i": false,
+              "ts_fgc2_i": false
+            }
+          }
+        ]
+      },
+      {
+        "stsl_type": "named_range",
+        "stsl_styles": [
+          {
+            "nrs_ei": {
+              "cv": {
+                "op": "set",
+                "opValue": []
+              }
+            }
+          }
+        ]
+      },
+      {
+        "stsl_type": "paragraph",
+        "stsl_styles": [
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          {
+            "ps_al": 0,
+            "ps_awao": true,
+            "ps_sd": null,
+            "ps_bbtw": null,
+            "ps_bb": null,
+            "ps_bl": null,
+            "ps_br": null,
+            "ps_bt": null,
+            "ps_hd": 0,
+            "ps_hdid": "",
+            "ps_ifl": 0,
+            "ps_il": 0,
+            "ps_ir": 0,
+            "ps_klt": false,
+            "ps_kwn": false,
+            "ps_ltr": true,
+            "ps_ls": 1.15,
+            "ps_sm": 0,
+            "ps_sa": 0,
+            "ps_sb": 0,
+            "ps_al_i": false,
+            "ps_awao_i": false,
+            "ps_sd_i": false,
+            "ps_bbtw_i": false,
+            "ps_bb_i": false,
+            "ps_bl_i": false,
+            "ps_br_i": false,
+            "ps_bt_i": false,
+            "ps_ifl_i": false,
+            "ps_il_i": false,
+            "ps_ir_i": false,
+            "ps_klt_i": false,
+            "ps_kwn_i": false,
+            "ps_ls_i": false,
+            "ps_rd": "",
+            "ps_sm_i": false,
+            "ps_sa_i": false,
+            "ps_sb_i": false,
+            "ps_shd": false,
+            "ps_ts": {
+              "cv": {
+                "op": "set",
+                "opValue": []
+              }
+            }
+          }
+        ]
+      },
+      {
+        "stsl_type": "row",
+        "stsl_styles": []
+      },
+      {
+        "stsl_type": "suppress_feature",
+        "stsl_styles": [
+          {
+            "sfs_sst": false
+          }
+        ]
+      },
+      {
+        "stsl_type": "tbl",
+        "stsl_styles": []
+      },
+      {
+        "stsl_type": "text",
+        "stsl_styles": [
+          {
+            "ts_bd": false,
+            "ts_fs": 11,
+            "ts_ff": "Arial",
+            "ts_it": false,
+            "ts_sc": false,
+            "ts_st": false,
+            "ts_tw": 400,
+            "ts_un": false,
+            "ts_va": "nor",
+            "ts_bgc2": {
+              "clr_type": 0,
+              "hclr_color": null
+            },
+            "ts_fgc2": {
+              "clr_type": 0,
+              "hclr_color": "#000000"
+            },
+            "ts_bd_i": false,
+            "ts_fs_i": false,
+            "ts_ff_i": false,
+            "ts_it_i": false,
+            "ts_sc_i": false,
+            "ts_st_i": false,
+            "ts_un_i": false,
+            "ts_va_i": false,
+            "ts_bgc2_i": false,
+            "ts_fgc2_i": false
+          },
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          {
+            "ts_bd": false,
+            "ts_fs": 11,
+            "ts_ff": "Arial",
+            "ts_it": false,
+            "ts_sc": false,
+            "ts_st": false,
+            "ts_tw": 400,
+            "ts_un": true,
+            "ts_va": "nor",
+            "ts_bgc2": {
+              "clr_type": 0,
+              "hclr_color": null
+            },
+            "ts_fgc2": {
+              "clr_type": 0,
+              "hclr_color": "#1155cc"
+            },
+            "ts_bd_i": false,
+            "ts_fs_i": false,
+            "ts_ff_i": false,
+            "ts_it_i": false,
+            "ts_sc_i": false,
+            "ts_st_i": false,
+            "ts_un_i": false,
+            "ts_va_i": false,
+            "ts_bgc2_i": false,
+            "ts_fgc2_i": false
+          },
+          null,
+          null,
+          null,
+          {
+            "ts_bd": false,
+            "ts_fs": 11,
+            "ts_ff": "Arial",
+            "ts_it": false,
+            "ts_sc": false,
+            "ts_st": false,
+            "ts_tw": 400,
+            "ts_un": false,
+            "ts_va": "nor",
+            "ts_bgc2": {
+              "clr_type": 0,
+              "hclr_color": null
+            },
+            "ts_fgc2": {
+              "clr_type": 0,
+              "hclr_color": "#000000"
+            },
+            "ts_bd_i": false,
+            "ts_fs_i": false,
+            "ts_ff_i": false,
+            "ts_it_i": false,
+            "ts_sc_i": false,
+            "ts_st_i": false,
+            "ts_un_i": false,
+            "ts_va_i": false,
+            "ts_bgc2_i": false,
+            "ts_fgc2_i": false
+          },
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          {
+            "ts_bd": false,
+            "ts_fs": 11,
+            "ts_ff": "Arial",
+            "ts_it": false,
+            "ts_sc": false,
+            "ts_st": false,
+            "ts_tw": 400,
+            "ts_un": true,
+            "ts_va": "nor",
+            "ts_bgc2": {
+              "clr_type": 0,
+              "hclr_color": null
+            },
+            "ts_fgc2": {
+              "clr_type": 0,
+              "hclr_color": "#000000"
+            },
+            "ts_bd_i": false,
+            "ts_fs_i": false,
+            "ts_ff_i": false,
+            "ts_it_i": false,
+            "ts_sc_i": false,
+            "ts_st_i": false,
+            "ts_un_i": false,
+            "ts_va_i": false,
+            "ts_bgc2_i": false,
+            "ts_fgc2_i": false
+          },
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          null,
+          {
+            "ts_bd": false,
+            "ts_fs": 11,
+            "ts_ff": "Arial",
+            "ts_it": false,
+            "ts_sc": false,
+            "ts_st": false,
+            "ts_tw": 400,
+            "ts_un": false,
+            "ts_va": "nor",
+            "ts_bgc2": {
+              "clr_type": 0,
+              "hclr_color": null
+            },
+            "ts_fgc2": {
+              "clr_type": 0,
+              "hclr_color": "#000000"
+            },
+            "ts_bd_i": false,
+            "ts_fs_i": false,
+            "ts_ff_i": false,
+            "ts_it_i": false,
+            "ts_sc_i": false,
+            "ts_st_i": false,
+            "ts_un_i": false,
+            "ts_va_i": false,
+            "ts_bgc2_i": false,
+            "ts_fgc2_i": false
+          }
+        ]
+      }
+    ],
+    "dsl_metastyleslices": [
+      {
+        "stsl_type": "composing_decoration",
+        "stsl_styles": [
+          {
+            "cd_u": false,
+            "cd_bgc": {
+              "clr_type": 0,
+              "hclr_color": null
+            }
+          }
+        ]
+      },
+      {
+        "stsl_type": "composing_region",
+        "stsl_styles": [
+          {
+            "cr_c": false
+          }
+        ]
+      },
+      {
+        "stsl_type": "draft_comment",
+        "stsl_styles": [
+          {
+            "dcs_cids": {
+              "cv": {
+                "op": "set",
+                "opValue": []
+              }
+            }
+          }
+        ]
+      },
+      {
+        "stsl_type": "ignore_word",
+        "stsl_styles": [
+          {
+            "iwos_i": false
+          }
+        ]
+      },
+      {
+        "stsl_type": "revision_diff",
+        "stsl_styles": [
+          {
+            "revdiff_dt": 0,
+            "revdiff_a": "",
+            "revdiff_aid": ""
+          }
+        ]
+      },
+      {
+        "stsl_type": "smart_todo",
+        "stsl_styles": [
+          {
+            "sts_cid": null,
+            "sts_ot": null,
+            "sts_ac": null,
+            "sts_hi": {
+              "cv": {
+                "op": "set",
+                "opValue": []
+              }
+            },
+            "sts_pa": {
+              "cv": {
+                "op": "set",
+                "opValue": []
+              }
+            },
+            "sts_dm": {
+              "cv": {
+                "op": "set",
+                "opValue": []
+              }
+            }
+          }
+        ]
+      },
+      {
+        "stsl_type": "spellcheck",
+        "stsl_styles": [
+          {
+            "sc_ow": null,
+            "sc_sl": null,
+            "sc_sugg": {
+              "cv": {
+                "op": "set",
+                "opValue": []
+              }
+            },
+            "sc_sm": {
+              "cv": {
+                "op": "set",
+                "opValue": []
+              }
+            }
+          }
+        ]
+      },
+      {
+        "stsl_type": "voice_corrections",
+        "stsl_styles": [
+          {
+            "vcs_c": {
+              "cv": {
+                "op": "set",
+                "opValue": []
+              }
+            }
+          }
+        ]
+      },
+      {
+        "stsl_type": "voice_dotted_span",
+        "stsl_styles": [
+          {
+            "vdss_p": null
+          }
+        ]
+      }
+    ],
+    "dsl_suggestedinsertions": {
+      "sgsl_sugg": [
+        []
+      ]
+    },
+    "dsl_suggesteddeletions": {
+      "sgsl_sugg": [
+        []
+      ]
+    },
+    "dsl_entitypositionmap": {},
+    "dsl_entitymap": {},
+    "dsl_entitytypemap": {},
+    "dsl_relateddocslices": {}
+  },
+  "autotext_content": {}
+}

--- a/packages/@atjson/source-gdocs-paste/test/source-test.ts
+++ b/packages/@atjson/source-gdocs-paste/test/source-test.ts
@@ -227,4 +227,20 @@ describe('@atjson/source-gdocs-paste', () => {
       expect(lists.length).toEqual(1);
     });
   });
+
+  describe('partial pastes', () => {
+    let gdocsBuffer: any;
+
+    beforeAll(() => {
+      let fixturePath = path.join(__dirname, 'fixtures', 'partial.json');
+      gdocsBuffer = JSON.parse(fs.readFileSync(fixturePath).toString());
+    });
+
+    it('creates the right number of list annotations', () => {
+      let gdocs = GDocsSource.fromSource(gdocsBuffer);
+      let links = gdocs.annotations.filter(a => a.type === 'lnks_link');
+
+      expect(links.length).toEqual(1);
+    });
+  });
 });

--- a/packages/@atjson/source-gdocs-paste/test/source-test.ts
+++ b/packages/@atjson/source-gdocs-paste/test/source-test.ts
@@ -237,7 +237,7 @@ describe('@atjson/source-gdocs-paste', () => {
     });
 
     it('creates the right number of list annotations', () => {
-      let gdocs = GDocsSource.fromSource(gdocsBuffer);
+      let gdocs = GDocsSource.fromRaw(gdocsBuffer);
       let links = gdocs.annotations.filter(a => a.type === 'lnks_link');
 
       expect(links.length).toEqual(1);

--- a/packages/@atjson/source-gdocs-paste/tsconfig.json
+++ b/packages/@atjson/source-gdocs-paste/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../../tsconfig.json",
   "compilerOptions": {
+    "target": "es2017",
     "outDir": "./dist/commonjs"
   },
   "include": [


### PR DESCRIPTION
When pasting from a GDocs document, the annotations don't get closed until the character _after_ the style is done. This means that after we loop through all of the styles, we need to close any that are
currently open to retain the intended paste.