### PR TITLE
Coerce or convert to sources

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,27 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Debug Tests",
+      "program": "${workspaceRoot}/node_modules/jest/bin/jest.js",
+      "cwd": "${workspaceRoot}",
+      "args": [
+          "--i"
+      ]
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Launch Program",
+      "program": "${workspaceFolder}/packages/@atjson/document/src/index.ts",
+      "outFiles": [
+        "${workspaceFolder}/**/*.js"
+      ]
+    }
+  ]
+}

--- a/packages/@atjson/document/src/annotation.ts
+++ b/packages/@atjson/document/src/annotation.ts
@@ -37,14 +37,14 @@ export default abstract class Annotation {
   end: number;
   attributes: NonNullable<any>;
 
-  constructor(attrs: { id?: string, start: number, end: number, attributes: NonNullable<any> }) {
+  constructor(attrs: { id?: string, start: number, end: number, attributes?: NonNullable<any> }) {
     let AnnotationClass = this.constructor as AnnotationConstructor;
     this.type = AnnotationClass.type;
     this.id = attrs.id || uuid();
     this.start = attrs.start;
     this.end = attrs.end;
 
-    this.attributes = attrs.attributes;
+    this.attributes = attrs.attributes || {};
   }
 
   /**

--- a/packages/@atjson/document/src/collection.ts
+++ b/packages/@atjson/document/src/collection.ts
@@ -69,6 +69,10 @@ export class Collection {
     this.annotations = newAnnotations;
     return this;
   }
+
+  toJSON() {
+    return this.map(a => a.toJSON());
+  }
 }
 
 export interface Renaming {

--- a/packages/@atjson/document/src/collection.ts
+++ b/packages/@atjson/document/src/collection.ts
@@ -34,6 +34,21 @@ export class Collection {
     return this.annotations.map(mapper);
   }
 
+  sort(sortFunction?: (a: Annotation, b: Annotation) => number) {
+    if (sortFunction) {
+      this.annotations = this.annotations.sort(sortFunction);
+    } else {
+      this.annotations = this.annotations.sort((a, b) => {
+        if (a.start - b.start === 0) {
+          return a.end - b.end;
+        } else {
+          return a.start - b.start;
+        }
+      });
+    }
+    return this;
+  }
+
   where(filter: { [key: string]: any; } | ((annotation: Annotation) => boolean)) {
     if (filter instanceof Function) {
       return new AnnotationCollection(this.document, this.annotations.filter(filter));

--- a/packages/@atjson/document/src/index.ts
+++ b/packages/@atjson/document/src/index.ts
@@ -33,14 +33,16 @@ export {
 export default class Document {
   static contentType: string;
   static schema: AnnotationConstructor[] = [];
-  static converters: WeakMap<typeof Document, (doc: Document) => Document>;
 
   static defineConverterTo(to: typeof Document, converter: (doc: Document) => Document) {
-    if (this.converters == null) {
+    if (!this.converters.has(this)) {
       this.converters = new WeakMap();
+      this.converters.set(this, doc => doc);
     }
     this.converters.set(to, converter);
   }
+
+  private static converters: WeakMap<typeof Document, (doc: Document) => Document> = new WeakMap();
 
   content: string;
   readonly contentType: string;
@@ -219,6 +221,10 @@ export default class Document {
     let DocumentClass = this.constructor as typeof Document;
     let converters = DocumentClass.converters;
     let converter = converters && converters.get(to);
+
+    if (!(to.prototype instanceof Document)) {
+      throw new Error(`💣 ${to.toString()} is not a type of Document and can't be converted to.`);
+    }
 
     // From === To
     if (to === DocumentClass) {

--- a/packages/@atjson/document/src/index.ts
+++ b/packages/@atjson/document/src/index.ts
@@ -33,9 +33,9 @@ export {
 export default class Document {
   static contentType: string;
   static schema: AnnotationConstructor[] = [];
-  static converters: WeakMap<typeof Document, (doc: Document) => void>;
+  static converters: WeakMap<typeof Document, (doc: Document) => Document>;
 
-  static defineConverterTo(to: typeof Document, converter: (doc: Document) => void) {
+  static defineConverterTo(to: typeof Document, converter: (doc: Document) => Document) {
     if (this.converters == null) {
       this.converters = new WeakMap();
     }
@@ -228,7 +228,7 @@ export default class Document {
       let convertedDoc = this.clone();
 
       if (converter) {
-        converter(convertedDoc);
+        return new to(converter(convertedDoc).toJSON()) as InstanceType<To>;
       }
       return new to(convertedDoc.toJSON()) as InstanceType<To>;
     }

--- a/packages/@atjson/document/test/atjson-test.ts
+++ b/packages/@atjson/document/test/atjson-test.ts
@@ -110,7 +110,7 @@ describe('new Document', () => {
       expect(doc.toJSON()).toEqual({
         content: 'ello, world!\n\uFFFC',
         contentType: 'application/vnd.atjson+test',
-        schema: ['-test-a', '-test-bold', '-test-code', '-test-image', '-test-instagram', '-test-italic', '-test-locale', '-test-manual', '-test-pre'],
+        schema: ['-test-a', '-test-bold', '-test-code', '-test-image', '-test-instagram', '-test-italic', '-test-locale', '-test-manual', '-test-paragraph', '-test-pre'],
         annotations: [{
           id: '1',
           type: '-test-bold',
@@ -143,7 +143,7 @@ describe('new Document', () => {
       expect(document.toJSON()).toEqual({
         content: 'Hello, world!\n\uFFFC',
         contentType: 'application/vnd.atjson+test',
-        schema: ['-test-a', '-test-bold', '-test-code', '-test-image', '-test-instagram', '-test-italic', '-test-locale', '-test-manual', '-test-pre'],
+        schema: ['-test-a', '-test-bold', '-test-code', '-test-image', '-test-instagram', '-test-italic', '-test-locale', '-test-manual', '-test-paragraph', '-test-pre'],
         annotations: [{
           id: '1',
           type: '-test-bold',

--- a/packages/@atjson/document/test/converter-test.ts
+++ b/packages/@atjson/document/test/converter-test.ts
@@ -3,7 +3,7 @@ import { TextSource } from './text-source-test';
 
 describe('Document#convert', () => {
   test('sources without conversions are coerced', () => {
-    let textDoc = TextSource.fromSource('Hello, World!');
+    let textDoc = TextSource.fromRaw('Hello, World!');
     let testDoc = textDoc.convertTo(TestSource);
     expect(testDoc).toBeInstanceOf(TestSource);
     expect(testDoc.all().toJSON()).toEqual(textDoc.all().toJSON());

--- a/packages/@atjson/document/test/converter-test.ts
+++ b/packages/@atjson/document/test/converter-test.ts
@@ -21,6 +21,8 @@ describe('Document#convert', () => {
       expect(testDoc.toJSON()).toEqual(doc.toJSON());
       doc.where(a => a.type !== 'paragraph').remove();
       doc.where({ type: '-test-paragraph' }).set({ type: '-text-paragraph' });
+
+      return doc;
     });
 
     let textDoc = testDoc.convertTo(TextSource);

--- a/packages/@atjson/document/test/converter-test.ts
+++ b/packages/@atjson/document/test/converter-test.ts
@@ -1,0 +1,47 @@
+import TestSource, { Bold, Paragraph } from './test-source';
+import { TextSource } from './text-source-test';
+
+describe('Document#convert', () => {
+  test('sources without conversions are coerced', () => {
+    let textDoc = TextSource.fromSource('Hello, World!');
+    let testDoc = textDoc.convertTo(TestSource);
+    expect(testDoc).toBeInstanceOf(TestSource);
+    expect(testDoc.all().toJSON()).toEqual(textDoc.all().toJSON());
+  });
+
+  test('sources with conversions are called', () => {
+    let testDoc = new TestSource({
+      content: 'Hello, World!',
+      annotations: [
+        new Paragraph({ start: 0, end: 13 }),
+        new Bold({ start: 0, end: 5 })
+      ]
+    });
+    TestSource.defineConverterTo(TextSource, doc => {
+      expect(testDoc.toJSON()).toEqual(doc.toJSON());
+      doc.where(a => a.type !== 'paragraph').remove();
+      doc.where({ type: '-test-paragraph' }).set({ type: '-text-paragraph' });
+    });
+
+    let textDoc = testDoc.convertTo(TextSource);
+    expect(textDoc.all().toJSON()).toEqual([{
+      id: 'Any<id>',
+      type: '-text-paragraph',
+      start: 0,
+      end: 13,
+      attributes: {}
+    }]);
+  });
+
+  test('converting to the same type is a no-op', () => {
+    let testDoc = new TestSource({
+      content: 'Hello, World!',
+      annotations: [
+        new Paragraph({ start: 0, end: 13 }),
+        new Bold({ start: 0, end: 5 })
+      ]
+    });
+
+    expect(testDoc.convertTo(TestSource).toJSON()).toEqual(testDoc.toJSON());
+  });
+});

--- a/packages/@atjson/document/test/query-test.ts
+++ b/packages/@atjson/document/test/query-test.ts
@@ -1,6 +1,34 @@
 import TestSource, { Anchor, Code, Locale, Preformatted } from './test-source';
 
-describe('Document.where', () => {
+describe('Document#all', () => {
+  it('returns all annotations', () => {
+    let doc = new TestSource({
+      content: 'Conde Nast',
+      annotations: [{
+        id: '1',
+        type: '-test-a',
+        attributes: {
+          '-test-href': 'https://example.com'
+        },
+        start: 0,
+        end: 5
+      }, {
+        id: '2',
+        type: '-test-a',
+        attributes: {
+          '-test-href': 'https://condenast.com'
+        },
+        start: 6,
+        end: 10
+      }]
+    });
+
+    expect(doc.all().length).toEqual(2);
+    expect(doc.all().toJSON()).toEqual(doc.annotations.map((a) => a.toJSON()));
+  });
+});
+
+describe('Document#where', () => {
   it('length on collections', () => {
     let doc = new TestSource({
       content: 'Hello',

--- a/packages/@atjson/document/test/test-source.ts
+++ b/packages/@atjson/document/test/test-source.ts
@@ -28,6 +28,11 @@ export class Instagram extends ObjectAnnotation {
   static type = 'instagram';
 }
 
+export class Paragraph extends ObjectAnnotation {
+  static vendorPrefix = 'test';
+  static type = 'paragraph';
+}
+
 export class Code extends ObjectAnnotation {
   static vendorPrefix = 'test';
   static type = 'code';
@@ -83,5 +88,5 @@ export class Manual extends ObjectAnnotation {
 
 export default class TestSource extends Document {
   static contentType = 'application/vnd.atjson+test';
-  static schema = [Anchor, Bold, Code, Image, Instagram, Italic, Locale, Manual, Preformatted];
+  static schema = [Anchor, Bold, Code, Image, Instagram, Italic, Locale, Manual, Paragraph, Preformatted];
 }

--- a/packages/@atjson/document/test/text-source-test.ts
+++ b/packages/@atjson/document/test/text-source-test.ts
@@ -1,15 +1,15 @@
 import Document, { BlockAnnotation, ParseAnnotation } from '../src/index';
 
-class Paragraph extends BlockAnnotation {
+export class Paragraph extends BlockAnnotation {
   static vendorPrefix = 'text';
   static type = 'paragraph';
 }
 
-class TextSource extends Document {
+export class TextSource extends Document {
   static contentType = 'application/vnd.atjson+text';
   static schema = [Paragraph];
 
-  constructor(text: string) {
+  static fromSource(text: string) {
     let annotations = [];
     let start = 0;
     let id = 1;
@@ -40,16 +40,16 @@ class TextSource extends Document {
       });
     }
 
-    super({
+    return new this({
       content: text,
       annotations
     });
   }
 }
 
-describe('plain text source', () => {
+describe('TextSource', () => {
   test('a simple document', () => {
-    let source = new TextSource('Hello\nWorld');
+    let source = TextSource.fromSource('Hello\nWorld');
     expect(source.toJSON()).toEqual({
       content: 'Hello\nWorld',
       contentType: 'application/vnd.atjson+text',
@@ -77,7 +77,7 @@ describe('plain text source', () => {
   });
 
   test('annotations are reified as Annotation instances', () => {
-    let source = new TextSource('Hello\nWorld');
+    let source = TextSource.fromSource('Hello\nWorld');
     let [firstParagraph, parseToken, lastParagraph] = source.annotations;
 
     expect(firstParagraph).toBeInstanceOf(Paragraph);

--- a/packages/@atjson/document/test/text-source-test.ts
+++ b/packages/@atjson/document/test/text-source-test.ts
@@ -9,7 +9,7 @@ export class TextSource extends Document {
   static contentType = 'application/vnd.atjson+text';
   static schema = [Paragraph];
 
-  static fromSource(text: string) {
+  static fromRaw(text: string) {
     let annotations = [];
     let start = 0;
     let id = 1;
@@ -49,7 +49,7 @@ export class TextSource extends Document {
 
 describe('TextSource', () => {
   test('a simple document', () => {
-    let source = TextSource.fromSource('Hello\nWorld');
+    let source = TextSource.fromRaw('Hello\nWorld');
     expect(source.toJSON()).toEqual({
       content: 'Hello\nWorld',
       contentType: 'application/vnd.atjson+text',
@@ -77,7 +77,7 @@ describe('TextSource', () => {
   });
 
   test('annotations are reified as Annotation instances', () => {
-    let source = TextSource.fromSource('Hello\nWorld');
+    let source = TextSource.fromRaw('Hello\nWorld');
     let [firstParagraph, parseToken, lastParagraph] = source.annotations;
 
     expect(firstParagraph).toBeInstanceOf(Paragraph);

--- a/packages/@atjson/editor/src/index.ts
+++ b/packages/@atjson/editor/src/index.ts
@@ -10,7 +10,15 @@ export interface Range {
   start: number;
   end: number;
 }
+/*
+<offset-editor>
+  -> <text-input>
+    -> <slot></slot>
+    -> <text-selection>
+      -> <slot></slot>
+  <slot></slot>
 
+*/
 export default class OffsetEditor extends EventComponent {
 
   static template = '<text-input>' +

--- a/packages/@atjson/renderer-commonmark/test/commonmark-spec-test.ts
+++ b/packages/@atjson/renderer-commonmark/test/commonmark-spec-test.ts
@@ -29,9 +29,9 @@ Object.keys(unitTestsBySection).forEach(moduleName => {
 
       (shouldSkip ? test.skip : test)(unitTest.markdown, () => {
         let markdown = unitTest.markdown.replace(/→/g, '\t');
-        let original = CommonMarkSource.fromSource(markdown);
+        let original = CommonMarkSource.fromRaw(markdown);
         let generatedMarkdown = renderer.render(original.convertTo(OffsetSource));
-        let output = CommonMarkSource.fromSource(generatedMarkdown);
+        let output = CommonMarkSource.fromRaw(generatedMarkdown);
 
         // Assert that our internal representations (AtJSON) match
         let originalHIR = new HIR(original).toJSON();

--- a/packages/@atjson/renderer-commonmark/test/commonmark-test.ts
+++ b/packages/@atjson/renderer-commonmark/test/commonmark-test.ts
@@ -421,6 +421,6 @@ After all the lists
 
     expect(renderer.render(document)).toBe('Hello\n\nThis is my text\n\n');
     // Make sure we're not generating code in the round-trip
-    expect(markdown).toEqual(renderer.render(CommonMarkSource.fromSource(markdown).convertTo(OffsetSource)));
+    expect(markdown).toEqual(renderer.render(CommonMarkSource.fromRaw(markdown).convertTo(OffsetSource)));
   });
 });

--- a/packages/@atjson/renderer-plain-text/test/text-renderer-test.ts
+++ b/packages/@atjson/renderer-plain-text/test/text-renderer-test.ts
@@ -28,7 +28,7 @@ describe('PlainTextRenderer', () => {
   });
 
   it('strips virtual annotations', () => {
-    let doc = HTMLSource.fromSource('<p>This is some <em>fancy</em> <span class="fancy">text</span>.');
+    let doc = HTMLSource.fromRaw('<p>This is some <em>fancy</em> <span class="fancy">text</span>.');
 
     let renderer = new PlainTextRenderer();
     let text = renderer.render(doc);

--- a/packages/@atjson/source-commonmark/src/converter.ts
+++ b/packages/@atjson/source-commonmark/src/converter.ts
@@ -35,4 +35,6 @@ CommonmarkSource.defineConverterTo(OffsetSource, doc => {
   doc.where({ type: '-commonmark-ordered_list' }).set({ type: '-offset-list', attributes: { '-offset-type': 'numbered' } }).rename({ attributes: { '-commonmark-start': '-offset-startsAt', '-commonmark-tight': '-offset-tight' } });
   doc.where({ type: '-commonmark-paragraph' }).set({ type: '-offset-paragraph' });
   doc.where({ type: '-commonmark-strong' }).set({ type: '-offset-bold' });
+
+  return doc;
 });

--- a/packages/@atjson/source-commonmark/src/converter.ts
+++ b/packages/@atjson/source-commonmark/src/converter.ts
@@ -35,6 +35,4 @@ CommonmarkSource.defineConverterTo(OffsetSource, doc => {
   doc.where({ type: '-commonmark-ordered_list' }).set({ type: '-offset-list', attributes: { '-offset-type': 'numbered' } }).rename({ attributes: { '-commonmark-start': '-offset-startsAt', '-commonmark-tight': '-offset-tight' } });
   doc.where({ type: '-commonmark-paragraph' }).set({ type: '-offset-paragraph' });
   doc.where({ type: '-commonmark-strong' }).set({ type: '-offset-bold' });
-
-  return new OffsetSource(doc.toJSON());
 });

--- a/packages/@atjson/source-commonmark/src/source.ts
+++ b/packages/@atjson/source-commonmark/src/source.ts
@@ -7,7 +7,7 @@ export default class CommonMarkSource extends Document {
   static contentType = 'application/vnd.atjson+commonmark';
   static schema = [Blockquote, BulletList, CodeBlock, CodeInline, Emphasis, Fence, Hardbreak, Heading, HorizontalRule, HTMLBlock, HTMLInline, Image, Link, ListItem, OrderedList, Paragraph, Strong];
 
-  static fromSource(markdown: string) {
+  static fromRaw(markdown: string) {
     let md = this.markdownParser;
     let parser = new Parser(md.parse(markdown, { linkify: false }), this.contentHandlers);
 

--- a/packages/@atjson/source-commonmark/test/commonmark-test.ts
+++ b/packages/@atjson/source-commonmark/test/commonmark-test.ts
@@ -4,18 +4,18 @@ import { render } from './utils';
 
 describe('whitespace', () => {
   test('&nbsp; is translated to a non-breaking space', () => {
-    let doc = CommonMarkSource.fromSource('&nbsp;');
+    let doc = CommonMarkSource.fromRaw('&nbsp;');
     expect(render(doc)).toBe('\u00A0\n\n');
   });
 
   test('  \\n is converted to a hardbreak', () => {
-    let doc = CommonMarkSource.fromSource('1  \n2');
+    let doc = CommonMarkSource.fromRaw('1  \n2');
     expect(render(doc)).toBe('1\n2\n\n');
   });
 
   describe('non-breaking spaces', () => {
     test('html entities are converted to unicode characters', () => {
-      let doc = CommonMarkSource.fromSource('1\n\n&#8239;\n\n&nbsp;\n\n2');
+      let doc = CommonMarkSource.fromRaw('1\n\n&#8239;\n\n&nbsp;\n\n2');
       let hir = new HIR(doc);
       expect(hir.toJSON()).toMatchObject({
         type: 'root',
@@ -41,7 +41,7 @@ describe('whitespace', () => {
     });
 
     test('empty paragraphs are created using narrow no-break unicode characters', () => {
-      let doc = CommonMarkSource.fromSource('1\n\n\u202F\n\n\u00A0\n\n2');
+      let doc = CommonMarkSource.fromRaw('1\n\n\u202F\n\n\u00A0\n\n2');
       let hir = new HIR(doc);
       expect(hir.toJSON()).toMatchObject({
         type: 'root',
@@ -70,19 +70,19 @@ describe('whitespace', () => {
 
 describe('code blocks', () => {
   test('` `` ` is converted to an inline code block', () => {
-    let doc = CommonMarkSource.fromSource('` `` `');
+    let doc = CommonMarkSource.fromRaw('` `` `');
     expect(render(doc)).toBe(' `` \n\n');
   });
 });
 
 describe('list', () => {
   test('nested lists', () => {
-    let doc = CommonMarkSource.fromSource('- 1\n   - 2\n      - 3');
+    let doc = CommonMarkSource.fromRaw('- 1\n   - 2\n      - 3');
     expect(render(doc)).toBe('1\n2\n3\n');
   });
 
   test('tight', () => {
-    let tight = CommonMarkSource.fromSource('- 1\n   - 2\n      - 3');
+    let tight = CommonMarkSource.fromRaw('- 1\n   - 2\n      - 3');
     let list = tight.where({ type: '-commonmark-bullet_list' });
     expect(list.map(a => a.toJSON())).toMatchObject([{
       type: '-commonmark-bullet_list',
@@ -101,7 +101,7 @@ describe('list', () => {
       }
     }]);
 
-    let loose = CommonMarkSource.fromSource('1. 1\n\n   2. 2\n   3. 3');
+    let loose = CommonMarkSource.fromRaw('1. 1\n\n   2. 2\n   3. 3');
     list = loose.where({ type: '-commonmark-ordered_list' });
     expect(list.map(a => a.toJSON())).toMatchObject([{
       type: '-commonmark-ordered_list',

--- a/packages/@atjson/source-commonmark/test/extensions-test.ts
+++ b/packages/@atjson/source-commonmark/test/extensions-test.ts
@@ -1,6 +1,7 @@
 import { InlineAnnotation } from '@atjson/document';
+import OffsetSource from '@atjson/offset-annotations';
 import * as MarkdownIt from 'markdown-it';
-import CommonMarkSource from '../src';
+import CommonmarkSource from '../src';
 import { render } from './utils';
 
 class StrikeThrough extends InlineAnnotation {
@@ -8,23 +9,54 @@ class StrikeThrough extends InlineAnnotation {
   static type = 's';
 }
 
-class MarkdownItSource extends CommonMarkSource {
-  static schema = [...CommonMarkSource.schema, StrikeThrough];
+class MarkdownItSource extends CommonmarkSource {
+  static contentType = 'application.vnd.atjson+markdownit';
+  static schema = [...CommonmarkSource.schema, StrikeThrough];
   static get markdownParser() {
     return MarkdownIt();
   }
 }
 
+MarkdownItSource.defineConverterTo(OffsetSource, doc => {
+  doc.where({ type: '-commonmark-s' }).set({ type: '-offset-strikethrough' });
+
+  return doc.convertTo(CommonmarkSource).convertTo(OffsetSource);
+});
+
 describe('strikethrough', () => {
-  test('~hello~ is converted to strikethrough annotations', () => {
+  test('~~hello~~ is converted to strikethrough annotations', () => {
     let doc = MarkdownItSource.fromSource('~~hello~~');
     expect(render(doc)).toBe('hello\n\n');
-    let strikeThrough = doc.annotations.find(a => a.type === 's');
-    expect(strikeThrough).toMatchObject({
-      type: 's',
+    let strikeThrough = doc.where(a => a instanceof StrikeThrough);
+    expect(strikeThrough.toJSON()).toEqual([{
+      id: 'Any<id>',
+      type: '-commonmark-s',
       attributes: {},
       start: 1,
       end: 8
-    });
+    }]);
+  });
+
+  test('conversion to Offset uses existing conversions', () => {
+    let doc = MarkdownItSource.fromSource('~~hello~~ *world*').convertTo(OffsetSource);
+    expect(doc.where(a => a.type !== 'parse-token').sort().toJSON()).toEqual([{
+      id: 'Any<id>',
+      type: '-offset-paragraph',
+      attributes: {},
+      start: 0,
+      end: 17
+    }, {
+      id: 'Any<id>',
+      type: '-offset-strikethrough',
+      attributes: {},
+      start: 1,
+      end: 8
+    }, {
+      id: 'Any<id>',
+      type: '-offset-italic',
+      attributes: {},
+      start: 9,
+      end: 16
+    }]);
   });
 });

--- a/packages/@atjson/source-commonmark/test/extensions-test.ts
+++ b/packages/@atjson/source-commonmark/test/extensions-test.ts
@@ -25,7 +25,7 @@ MarkdownItSource.defineConverterTo(OffsetSource, doc => {
 
 describe('strikethrough', () => {
   test('~~hello~~ is converted to strikethrough annotations', () => {
-    let doc = MarkdownItSource.fromSource('~~hello~~');
+    let doc = MarkdownItSource.fromRaw('~~hello~~');
     expect(render(doc)).toBe('hello\n\n');
     let strikeThrough = doc.where(a => a instanceof StrikeThrough);
     expect(strikeThrough.toJSON()).toEqual([{
@@ -38,7 +38,7 @@ describe('strikethrough', () => {
   });
 
   test('conversion to Offset uses existing conversions', () => {
-    let doc = MarkdownItSource.fromSource('~~hello~~ *world*').convertTo(OffsetSource);
+    let doc = MarkdownItSource.fromRaw('~~hello~~ *world*').convertTo(OffsetSource);
     expect(doc.where(a => a.type !== 'parse-token').sort().toJSON()).toEqual([{
       id: 'Any<id>',
       type: '-offset-paragraph',

--- a/packages/@atjson/source-gdocs-paste/src/converter.ts
+++ b/packages/@atjson/source-gdocs-paste/src/converter.ts
@@ -23,6 +23,4 @@ GDocsSource.defineConverterTo(OffsetSource, doc => {
   doc.where({ type: '-gdocs-lnks_link' })
     .set({ type: '-offset-link' })
     .rename({ attributes: { '-gdocs-ulnk_url': '-offset-url' } });
-
-  return new OffsetSource(doc.toJSON());
 });

--- a/packages/@atjson/source-gdocs-paste/src/converter.ts
+++ b/packages/@atjson/source-gdocs-paste/src/converter.ts
@@ -23,4 +23,6 @@ GDocsSource.defineConverterTo(OffsetSource, doc => {
   doc.where({ type: '-gdocs-lnks_link' })
     .set({ type: '-offset-link' })
     .rename({ attributes: { '-gdocs-ulnk_url': '-offset-url' } });
+
+  return doc;
 });

--- a/packages/@atjson/source-gdocs-paste/src/source.ts
+++ b/packages/@atjson/source-gdocs-paste/src/source.ts
@@ -17,7 +17,7 @@ import GDocsParser, { GDocsPasteBuffer } from './gdocs-parser';
 export default class extends Document {
   static contentType = 'application/vnd.atjson+gdocs';
   static schema = [Bold, Heading, HorizontalRule, Italic, Link, List, ListItem, Strikethrough, Underline, VerticalAdjust];
-  static fromSource(pasteBuffer: GDocsPasteBuffer) {
+  static fromRaw(pasteBuffer: GDocsPasteBuffer) {
     let gDocsParser = new GDocsParser(pasteBuffer);
 
     return new this({

--- a/packages/@atjson/source-gdocs-paste/test/converter-test.ts
+++ b/packages/@atjson/source-gdocs-paste/test/converter-test.ts
@@ -27,37 +27,32 @@ describe('@atjson/source-gdocs-paste', () => {
   it('correctly converts headings', () => {
     let headings = atjson.where(a => a.type === 'heading');
     expect(headings.length).toEqual(4);
-    expect(headings.map(h => h.attributes!.level)).toEqual([1, 2, 100, 101]);
+    expect(headings.map(h => h.attributes.level)).toEqual([1, 2, 100, 101]);
   });
 
   it('correctly converts lists', () => {
-    let lists = atjson.annotations
-      .filter(a => a.type === 'list');
+    let lists = atjson.where(a => a.type === 'list');
     expect(lists.length).toEqual(2);
   });
 
   it('correctly converts numbered lists', () => {
-    let lists = atjson.annotations
-      .filter(a => a.type === 'list')
-      .filter(a => a.attributes!.type === 'numbered');
+    let lists = atjson.where(a => a.type === 'list' && a.attributes.type === 'numbered')
     expect(lists.length).toEqual(1);
   });
 
   it('correctly converts bulleted lists', () => {
-    let lists = atjson.annotations
-      .filter(a => a.type === 'list')
-      .filter(a => a.attributes.type === 'bulleted');
+    let lists = atjson.where(a => a.type === 'list' && a.attributes.type === 'bulleted');
     expect(lists.length).toEqual(1);
   });
 
   it('correctly converts list-items', () => {
-    let listItems = atjson.annotations.filter(a => a.type === 'list-item');
+    let listItems = atjson.where(a => a.type === 'list-item');
     expect(listItems.length).toEqual(4);
   });
 
   it('correctly converts links', () => {
-    let links = atjson.annotations.filter(a => a.type === 'link');
+    let links = atjson.where(a => a.type === 'link');
     expect(links.length).toEqual(1);
-    expect(links[0].attributes.url).toEqual('https://www.google.com/');
+    expect(links.map(link => link.attributes.url)).toEqual(['https://www.google.com/']);
   });
 });

--- a/packages/@atjson/source-gdocs-paste/test/converter-test.ts
+++ b/packages/@atjson/source-gdocs-paste/test/converter-test.ts
@@ -10,7 +10,7 @@ describe('@atjson/source-gdocs-paste', () => {
     // https://docs.google.com/document/d/18pp4dAGx5II596HHGOLUXXcc6VKLAVRBUMLm9Ge8eOE/edit?usp=sharing
     let fixturePath = path.join(__dirname, 'fixtures', 'complex.json');
     let rawJSON = JSON.parse(fs.readFileSync(fixturePath).toString());
-    let gdocs = GDocsSource.fromSource(rawJSON);
+    let gdocs = GDocsSource.fromRaw(rawJSON);
     atjson = gdocs.convertTo(OffsetSource);
   });
 

--- a/packages/@atjson/source-gdocs-paste/test/source-test.ts
+++ b/packages/@atjson/source-gdocs-paste/test/source-test.ts
@@ -30,7 +30,7 @@ describe('@atjson/source-gdocs-paste', () => {
 
     it('extracts bold', () => {
       let gdocs = GDocsSource.fromSource(pasteBuffer);
-      let annotations = gdocs.annotations.filter(a => a.type === 'ts_bd');
+      let annotations = gdocs.where(a => a.type === 'ts_bd');
       expect(annotations.length).toEqual(2);
 
       let [a0, a1] = annotations;
@@ -40,20 +40,20 @@ describe('@atjson/source-gdocs-paste', () => {
 
     it('extracts italic', () => {
       let gdocs = GDocsSource.fromSource(pasteBuffer);
-      let annotations = gdocs.annotations.filter(a => a.type === 'ts_it');
+      let annotations = gdocs.where(a => a.type === 'ts_it');
       expect(annotations.length).toEqual(2);
 
-      let [a0, a1] = annotations;
+      let [a0, a1] = [...annotations];
       expect(gdocs.content.substring(a0.start, a0.end)).toEqual('simple ');
       expect(gdocs.content.substring(a1.start, a1.end)).toEqual('some ');
     });
 
     it('extracts headings', () => {
       let gdocs = GDocsSource.fromSource(pasteBuffer);
-      let annotations = gdocs.annotations.filter(a => a.type === 'ps_hd').sort((a, b) => a.start - b.start);
+      let annotations = gdocs.where(a => a.type === 'ps_hd').sort();
       expect(annotations.length).toEqual(4);
 
-      let [a0, a1, a2, a3] = annotations;
+      let [a0, a1, a2, a3] = [...annotations];
 
       expect(gdocs.content.substring(a0.start, a0.end)).toEqual('Heading 1');
       expect(a0.attributes.level).toEqual(1);
@@ -71,10 +71,10 @@ describe('@atjson/source-gdocs-paste', () => {
 
     it('extracts lists', () => {
       let gdocs = GDocsSource.fromSource(pasteBuffer);
-      let annotations = gdocs.annotations.filter(a => a.type === 'list');
+      let annotations = gdocs.where(a => a.type === 'list');
       expect(annotations.length).toEqual(2);
 
-      let a0 = annotations[0];
+      let [a0] = [...annotations];
 
       expect(gdocs.content.substring(a0.start, a0.end)).toEqual('Here’s a numbered list\nAnd another item');
       expect(a0.attributes.ls_id).toEqual('kix.trdi2u6o1bvt');
@@ -82,10 +82,10 @@ describe('@atjson/source-gdocs-paste', () => {
 
     it('extracts list items', () => {
       let gdocs = GDocsSource.fromSource(pasteBuffer);
-      let annotations = gdocs.annotations.filter(a => a.type === 'list_item');
+      let annotations = gdocs.where(a => a.type === 'list_item');
       expect(annotations.length).toEqual(4);
 
-      let [a0, a1] = annotations;
+      let [a0, a1] = [...annotations];
 
       expect(gdocs.content.substring(a0.start, a0.end)).toEqual('Here’s a numbered list');
       expect(a0.attributes.ls_id).toEqual('kix.trdi2u6o1bvt');
@@ -98,10 +98,10 @@ describe('@atjson/source-gdocs-paste', () => {
 
     it('extracts links', () => {
       let gdocs = GDocsSource.fromSource(pasteBuffer);
-      let annotations = gdocs.annotations.filter(a => a.type === 'lnks_link');
+      let annotations = gdocs.where(a => a.type === 'lnks_link');
       expect(annotations.length).toEqual(1);
 
-      let link = annotations[0];
+      let [link] = [...annotations];
 
       expect(gdocs.content.substring(link.start, link.end)).toEqual(' is ');
       expect(link.attributes.ulnk_url).toEqual('https://www.google.com/');
@@ -134,7 +134,7 @@ describe('@atjson/source-gdocs-paste', () => {
 
     it('extracts bold', () => {
       let gdocs = GDocsSource.fromSource(gdocsBuffer);
-      let annotations = gdocs.annotations.filter(a => a.type === 'ts_bd');
+      let annotations = gdocs.where(a => a.type === 'ts_bd');
       expect(annotations.length).toEqual(1);
 
       let [bold] = annotations;
@@ -143,7 +143,7 @@ describe('@atjson/source-gdocs-paste', () => {
 
     it('extracts italic', () => {
       let gdocs = GDocsSource.fromSource(gdocsBuffer);
-      let annotations = gdocs.annotations.filter(a => a.type === 'ts_it');
+      let annotations = gdocs.where(a => a.type === 'ts_it');
       expect(annotations.length).toEqual(1);
 
       let [italic] = annotations;
@@ -152,7 +152,7 @@ describe('@atjson/source-gdocs-paste', () => {
 
     it('extracts underline', () => {
       let gdocs = GDocsSource.fromSource(gdocsBuffer);
-      let annotations = gdocs.annotations.filter(a => a.type === 'ts_un');
+      let annotations = gdocs.where(a => a.type === 'ts_un');
       expect(annotations.length).toEqual(1);
 
       let [underline] = annotations;
@@ -161,7 +161,7 @@ describe('@atjson/source-gdocs-paste', () => {
 
     it('extracts horizontal rules', () => {
       let gdocs = GDocsSource.fromSource(gdocsBuffer);
-      let annotations = gdocs.annotations.filter(a => a.type === 'horizontal_rule');
+      let annotations = gdocs.where(a => a.type === 'horizontal_rule');
       expect(annotations.length).toEqual(1);
 
       let [hr] = annotations;
@@ -170,7 +170,7 @@ describe('@atjson/source-gdocs-paste', () => {
 
     it('extracts strikethrough', () => {
       let gdocs = GDocsSource.fromSource(gdocsBuffer);
-      let annotations = gdocs.annotations.filter(a => a.type === 'ts_st');
+      let annotations = gdocs.where(a => a.type === 'ts_st');
       expect(annotations.length).toEqual(1);
 
       let [strikethrough] = annotations;
@@ -179,11 +179,11 @@ describe('@atjson/source-gdocs-paste', () => {
 
     it('extracts vertical adjust', () => {
       let gdocs = GDocsSource.fromSource(gdocsBuffer);
-      let annotations: VerticalAdjust[] = gdocs.annotations.filter(a => a instanceof VerticalAdjust) as VerticalAdjust[];
+      let annotations = gdocs.where(a => a instanceof VerticalAdjust);
       expect(annotations.length).toEqual(2);
 
-      let [superscript] = annotations.filter(annotation => annotation.attributes.va === 'sup');
-      let [subscript] = annotations.filter(annotation => annotation.attributes.va === 'sub');
+      let [superscript] = annotations.where(annotation => annotation.attributes.va === 'sup');
+      let [subscript] = annotations.where(annotation => annotation.attributes.va === 'sub');
       expect(gdocs.content.substring(superscript.start, superscript.end)).toEqual('TM');
       expect(gdocs.content.substring(subscript.start, subscript.end)).toEqual('2');
     });
@@ -199,23 +199,23 @@ describe('@atjson/source-gdocs-paste', () => {
 
     it('creates the right number of list annotations', () => {
       let gdocs = GDocsSource.fromSource(gdocsBuffer);
-      let lists = gdocs.annotations.filter(a => a.type === 'list');
+      let lists = gdocs.where(a => a.type === 'list');
 
       expect(lists.length).toEqual(2);
     });
 
     it('captures list-specific attributes', () => {
       let gdocs = GDocsSource.fromSource(gdocsBuffer);
-      let lists = gdocs.annotations.filter(a => a.type === 'list');
+      let lists = gdocs.where(a => a.type === 'list');
       let expectedShape = expect.objectContaining({
         ls_b_gs: expect.anything(),
         ls_b_gt: expect.anything(),
         ls_b_a: expect.anything()
       });
 
-      lists.forEach(list => {
+      for (let list of lists) {
         expect(list.attributes).toEqual(expectedShape);
-      });
+      }
     });
 
     it('distinguishes numbered from bulleted lists', () => {

--- a/packages/@atjson/source-gdocs-paste/test/source-test.ts
+++ b/packages/@atjson/source-gdocs-paste/test/source-test.ts
@@ -19,17 +19,17 @@ describe('@atjson/source-gdocs-paste', () => {
     });
 
     it('does not throw an error when instantiating with GDocsSource', () => {
-      expect(GDocsSource.fromSource(pasteBuffer)).toBeDefined();
+      expect(GDocsSource.fromRaw(pasteBuffer)).toBeDefined();
     });
 
     it('correctly sets the content', () => {
-      let gdocs = GDocsSource.fromSource(pasteBuffer);
+      let gdocs = GDocsSource.fromRaw(pasteBuffer);
       expect(gdocs.content.length).toEqual(438);
       expect(gdocs.content).toMatchSnapshot();
     });
 
     it('extracts bold', () => {
-      let gdocs = GDocsSource.fromSource(pasteBuffer);
+      let gdocs = GDocsSource.fromRaw(pasteBuffer);
       let annotations = gdocs.where(a => a.type === 'ts_bd');
       expect(annotations.length).toEqual(2);
 
@@ -39,7 +39,7 @@ describe('@atjson/source-gdocs-paste', () => {
     });
 
     it('extracts italic', () => {
-      let gdocs = GDocsSource.fromSource(pasteBuffer);
+      let gdocs = GDocsSource.fromRaw(pasteBuffer);
       let annotations = gdocs.where(a => a.type === 'ts_it');
       expect(annotations.length).toEqual(2);
 
@@ -49,7 +49,7 @@ describe('@atjson/source-gdocs-paste', () => {
     });
 
     it('extracts headings', () => {
-      let gdocs = GDocsSource.fromSource(pasteBuffer);
+      let gdocs = GDocsSource.fromRaw(pasteBuffer);
       let annotations = gdocs.where(a => a.type === 'ps_hd').sort();
       expect(annotations.length).toEqual(4);
 
@@ -70,7 +70,7 @@ describe('@atjson/source-gdocs-paste', () => {
     });
 
     it('extracts lists', () => {
-      let gdocs = GDocsSource.fromSource(pasteBuffer);
+      let gdocs = GDocsSource.fromRaw(pasteBuffer);
       let annotations = gdocs.where(a => a.type === 'list');
       expect(annotations.length).toEqual(2);
 
@@ -81,7 +81,7 @@ describe('@atjson/source-gdocs-paste', () => {
     });
 
     it('extracts list items', () => {
-      let gdocs = GDocsSource.fromSource(pasteBuffer);
+      let gdocs = GDocsSource.fromRaw(pasteBuffer);
       let annotations = gdocs.where(a => a.type === 'list_item');
       expect(annotations.length).toEqual(4);
 
@@ -97,7 +97,7 @@ describe('@atjson/source-gdocs-paste', () => {
     });
 
     it('extracts links', () => {
-      let gdocs = GDocsSource.fromSource(pasteBuffer);
+      let gdocs = GDocsSource.fromRaw(pasteBuffer);
       let annotations = gdocs.where(a => a.type === 'lnks_link');
       expect(annotations.length).toEqual(1);
 
@@ -123,17 +123,17 @@ describe('@atjson/source-gdocs-paste', () => {
     });
 
     it('does not throw an error when instantiating with GDocsSource', () => {
-      expect(GDocsSource.fromSource(gdocsBuffer)).toBeDefined();
+      expect(GDocsSource.fromRaw(gdocsBuffer)).toBeDefined();
     });
 
     it('correctly sets the content', () => {
-      let gdocs = GDocsSource.fromSource(gdocsBuffer);
+      let gdocs = GDocsSource.fromRaw(gdocsBuffer);
       expect(gdocs.content.length).toEqual(219);
       expect(gdocs.content).toMatchSnapshot();
     });
 
     it('extracts bold', () => {
-      let gdocs = GDocsSource.fromSource(gdocsBuffer);
+      let gdocs = GDocsSource.fromRaw(gdocsBuffer);
       let annotations = gdocs.where(a => a.type === 'ts_bd');
       expect(annotations.length).toEqual(1);
 
@@ -142,7 +142,7 @@ describe('@atjson/source-gdocs-paste', () => {
     });
 
     it('extracts italic', () => {
-      let gdocs = GDocsSource.fromSource(gdocsBuffer);
+      let gdocs = GDocsSource.fromRaw(gdocsBuffer);
       let annotations = gdocs.where(a => a.type === 'ts_it');
       expect(annotations.length).toEqual(1);
 
@@ -151,7 +151,7 @@ describe('@atjson/source-gdocs-paste', () => {
     });
 
     it('extracts underline', () => {
-      let gdocs = GDocsSource.fromSource(gdocsBuffer);
+      let gdocs = GDocsSource.fromRaw(gdocsBuffer);
       let annotations = gdocs.where(a => a.type === 'ts_un');
       expect(annotations.length).toEqual(1);
 
@@ -160,7 +160,7 @@ describe('@atjson/source-gdocs-paste', () => {
     });
 
     it('extracts horizontal rules', () => {
-      let gdocs = GDocsSource.fromSource(gdocsBuffer);
+      let gdocs = GDocsSource.fromRaw(gdocsBuffer);
       let annotations = gdocs.where(a => a.type === 'horizontal_rule');
       expect(annotations.length).toEqual(1);
 
@@ -169,7 +169,7 @@ describe('@atjson/source-gdocs-paste', () => {
     });
 
     it('extracts strikethrough', () => {
-      let gdocs = GDocsSource.fromSource(gdocsBuffer);
+      let gdocs = GDocsSource.fromRaw(gdocsBuffer);
       let annotations = gdocs.where(a => a.type === 'ts_st');
       expect(annotations.length).toEqual(1);
 
@@ -178,7 +178,7 @@ describe('@atjson/source-gdocs-paste', () => {
     });
 
     it('extracts vertical adjust', () => {
-      let gdocs = GDocsSource.fromSource(gdocsBuffer);
+      let gdocs = GDocsSource.fromRaw(gdocsBuffer);
       let annotations = gdocs.where(a => a instanceof VerticalAdjust);
       expect(annotations.length).toEqual(2);
 
@@ -198,14 +198,14 @@ describe('@atjson/source-gdocs-paste', () => {
     });
 
     it('creates the right number of list annotations', () => {
-      let gdocs = GDocsSource.fromSource(gdocsBuffer);
+      let gdocs = GDocsSource.fromRaw(gdocsBuffer);
       let lists = gdocs.where(a => a.type === 'list');
 
       expect(lists.length).toEqual(2);
     });
 
     it('captures list-specific attributes', () => {
-      let gdocs = GDocsSource.fromSource(gdocsBuffer);
+      let gdocs = GDocsSource.fromRaw(gdocsBuffer);
       let lists = gdocs.where(a => a.type === 'list');
       let expectedShape = expect.objectContaining({
         ls_b_gs: expect.anything(),
@@ -219,7 +219,7 @@ describe('@atjson/source-gdocs-paste', () => {
     });
 
     it('distinguishes numbered from bulleted lists', () => {
-      let gdocs = GDocsSource.fromSource(gdocsBuffer);
+      let gdocs = GDocsSource.fromRaw(gdocsBuffer);
       let lists = gdocs.annotations
         .filter(a => a.type === 'list')
         .filter(a => a.attributes.ls_b_gt === 9);

--- a/packages/@atjson/source-html/src/converter.ts
+++ b/packages/@atjson/source-html/src/converter.ts
@@ -58,4 +58,6 @@ HTMLSource.defineConverterTo(OffsetSource, doc => {
       }
     });
   });
+
+  return doc;
 });

--- a/packages/@atjson/source-html/src/converter.ts
+++ b/packages/@atjson/source-html/src/converter.ts
@@ -58,5 +58,4 @@ HTMLSource.defineConverterTo(OffsetSource, doc => {
       }
     });
   });
-  return new OffsetSource(doc.toJSON());
 });

--- a/packages/@atjson/source-html/src/source.ts
+++ b/packages/@atjson/source-html/src/source.ts
@@ -59,7 +59,7 @@ export default class HTMLSource extends Document {
     Underline,
     UnorderedList
   ];
-  static fromSource(html: string) {
+  static fromRaw(html: string) {
     let parser = new Parser(html);
     return new this({
       content: parser.content,

--- a/packages/@atjson/source-html/test/source-html-test.ts
+++ b/packages/@atjson/source-html/test/source-html-test.ts
@@ -4,7 +4,7 @@ import HTMLSource from '../src';
 
 describe('@atjson/source-html', () => {
   test('pre-code', () => {
-    let doc = HTMLSource.fromSource('<pre><code>this <b>is</b> a test</code></pre>');
+    let doc = HTMLSource.fromRaw('<pre><code>this <b>is</b> a test</code></pre>');
     let hir = new HIR(doc).toJSON();
 
     expect(hir).toMatchObject({
@@ -30,7 +30,7 @@ describe('@atjson/source-html', () => {
   });
 
   test('<p>aaa<br />\nbbb</p>', () => {
-    let doc = HTMLSource.fromSource('<p>aaa<br />\nbbb</p>');
+    let doc = HTMLSource.fromRaw('<p>aaa<br />\nbbb</p>');
     let hir = new HIR(doc).toJSON();
     expect(hir).toMatchObject({
       type: 'root',
@@ -46,7 +46,7 @@ describe('@atjson/source-html', () => {
   });
 
   test('<a href="https://example.com">example</a>', () => {
-    let doc = HTMLSource.fromSource('<a href="https://example.com">example</a>');
+    let doc = HTMLSource.fromRaw('<a href="https://example.com">example</a>');
     let hir = new HIR(doc).toJSON();
 
     expect(hir).toMatchObject({
@@ -63,7 +63,7 @@ describe('@atjson/source-html', () => {
   });
 
   test('<img src="https://example.com/test.png" /> ', () => {
-    let doc = HTMLSource.fromSource('<img src="https://example.com/test.png" /> ');
+    let doc = HTMLSource.fromRaw('<img src="https://example.com/test.png" /> ');
     let hir = new HIR(doc).toJSON();
     expect(hir).toMatchObject({
       type: 'root',
@@ -79,7 +79,7 @@ describe('@atjson/source-html', () => {
   });
 
   test('<h2></h2>\n<h1></h1>\n<h3></h3>', () => {
-    let doc = HTMLSource.fromSource('<h2></h2>\n<h1></h1>\n<h3></h3>');
+    let doc = HTMLSource.fromRaw('<h2></h2>\n<h1></h1>\n<h3></h3>');
     let hir = new HIR(doc).toJSON();
     expect(hir).toMatchObject({
       type: 'root',
@@ -101,7 +101,7 @@ describe('@atjson/source-html', () => {
   });
 
   test('<p><img src="/url" alt="Foo" title="title" /></p>', () => {
-    let doc = HTMLSource.fromSource('<p><img src="/url" alt="Foo" title="title" /></p>');
+    let doc = HTMLSource.fromRaw('<p><img src="/url" alt="Foo" title="title" /></p>');
     let hir = new HIR(doc).toJSON();
     expect(hir).toMatchObject({
       type: 'root',
@@ -123,7 +123,7 @@ describe('@atjson/source-html', () => {
   });
 
   test('<p>**<a href="**"></p>', () => {
-    let doc = HTMLSource.fromSource('<p>**<a href="**"></p>');
+    let doc = HTMLSource.fromRaw('<p>**<a href="**"></p>');
     let hir = new HIR(doc).toJSON();
     expect(hir).toMatchObject({
       type: 'root',
@@ -142,7 +142,7 @@ describe('@atjson/source-html', () => {
   });
 
   test('&lt;&gt;', () => {
-    let doc = HTMLSource.fromSource('&lt;&gt;');
+    let doc = HTMLSource.fromRaw('&lt;&gt;');
     let hir = new HIR(doc).toJSON();
     expect(hir).toMatchObject({
       type: 'root',
@@ -152,7 +152,7 @@ describe('@atjson/source-html', () => {
   });
 
   test('<a href="https://en.wiktionary.org/wiki/%E6%97%A5%E6%9C%AC%E4%BA%BA"></a>', () => {
-    let doc = HTMLSource.fromSource('<a href="https://en.wiktionary.org/wiki/%E6%97%A5%E6%9C%AC%E4%BA%BA"></a>');
+    let doc = HTMLSource.fromRaw('<a href="https://en.wiktionary.org/wiki/%E6%97%A5%E6%9C%AC%E4%BA%BA"></a>');
     let hir = new HIR(doc).toJSON();
     expect(hir).toMatchObject({
       type: 'root',
@@ -169,7 +169,7 @@ describe('@atjson/source-html', () => {
 
   describe('translator to common schema', () => {
     test('bold, strong', () => {
-      let doc = HTMLSource.fromSource('This <b>text</b> is <strong>bold</strong>');
+      let doc = HTMLSource.fromRaw('This <b>text</b> is <strong>bold</strong>');
       let hir = new HIR(doc.convertTo(OffsetSource)).toJSON();
       expect(hir).toMatchObject({
         type: 'root',
@@ -187,7 +187,7 @@ describe('@atjson/source-html', () => {
     });
 
     test('i, em', () => {
-      let doc = HTMLSource.fromSource('This <i>text</i> is <em>italic</em>');
+      let doc = HTMLSource.fromRaw('This <i>text</i> is <em>italic</em>');
       let hir = new HIR(doc.convertTo(OffsetSource)).toJSON();
       expect(hir).toMatchObject({
         type: 'root',
@@ -205,7 +205,7 @@ describe('@atjson/source-html', () => {
     });
 
     test('h1, h2, h3, h4, h5, h6', () => {
-      let doc = HTMLSource.fromSource('<h1>Title</h1><h2>Byline</h2><h3>Section</h3><h4>Normal heading</h4><h5>Small heading</h5><h6>Tiny heading</h6>');
+      let doc = HTMLSource.fromRaw('<h1>Title</h1><h2>Byline</h2><h3>Section</h3><h4>Normal heading</h4><h5>Small heading</h5><h6>Tiny heading</h6>');
       let hir = new HIR(doc.convertTo(OffsetSource)).toJSON();
       expect(hir).toMatchObject({
         type: 'root',
@@ -239,7 +239,7 @@ describe('@atjson/source-html', () => {
     });
 
     test('p, br', () => {
-      let doc = HTMLSource.fromSource('<p>This paragraph has a<br>line break</p>');
+      let doc = HTMLSource.fromRaw('<p>This paragraph has a<br>line break</p>');
       let hir = new HIR(doc.convertTo(OffsetSource)).toJSON();
       expect(hir).toMatchObject({
         type: 'root',
@@ -257,7 +257,7 @@ describe('@atjson/source-html', () => {
     });
 
     test('a', () => {
-      let doc = HTMLSource.fromSource('This <a href="https://condenast.com">is a link</a>');
+      let doc = HTMLSource.fromRaw('This <a href="https://condenast.com">is a link</a>');
       let hir = new HIR(doc.convertTo(OffsetSource)).toJSON();
       expect(hir).toMatchObject({
         type: 'root',
@@ -273,7 +273,7 @@ describe('@atjson/source-html', () => {
     });
 
     test('hr', () => {
-      let doc = HTMLSource.fromSource('Horizontal <hr> rules!');
+      let doc = HTMLSource.fromRaw('Horizontal <hr> rules!');
       let hir = new HIR(doc.convertTo(OffsetSource)).toJSON();
       expect(hir).toMatchObject({
         type: 'root',
@@ -287,7 +287,7 @@ describe('@atjson/source-html', () => {
     });
 
     test('img', () => {
-      let doc = HTMLSource.fromSource('<img src="https://pbs.twimg.com/media/DXiMcM9X4AEhR3u.jpg" alt="Miles Davis came out, blond, in gold lamé, and he plays really terrific music. High heels. 4/6/86" title="Miles Davis & Andy Warhol">');
+      let doc = HTMLSource.fromRaw('<img src="https://pbs.twimg.com/media/DXiMcM9X4AEhR3u.jpg" alt="Miles Davis came out, blond, in gold lamé, and he plays really terrific music. High heels. 4/6/86" title="Miles Davis & Andy Warhol">');
       let hir = new HIR(doc.convertTo(OffsetSource)).toJSON();
       expect(hir).toMatchObject({
         type: 'root',
@@ -311,7 +311,7 @@ describe('@atjson/source-html', () => {
     });
 
     test('blockquote', () => {
-      let doc = HTMLSource.fromSource('<blockquote>This is a quote</blockquote>');
+      let doc = HTMLSource.fromRaw('<blockquote>This is a quote</blockquote>');
       let hir = new HIR(doc.convertTo(OffsetSource)).toJSON();
       expect(hir).toMatchObject({
         type: 'root',
@@ -325,7 +325,7 @@ describe('@atjson/source-html', () => {
     });
 
     test('ul, ol, li', () => {
-      let doc = HTMLSource.fromSource('<ol starts="2"><li>Second</li><li>Third</li></ol><ul><li>First</li><li>Second</li></ul>');
+      let doc = HTMLSource.fromRaw('<ol starts="2"><li>Second</li><li>Third</li></ol><ul><li>First</li><li>Second</li></ul>');
       let hir = new HIR(doc.convertTo(OffsetSource)).toJSON();
       expect(hir).toMatchObject({
         type: 'root',

--- a/packages/@atjson/source-mobiledoc/src/converter.ts
+++ b/packages/@atjson/source-mobiledoc/src/converter.ts
@@ -33,6 +33,4 @@ MobiledocSource.defineConverterTo(OffsetSource, doc => {
   doc.where({ type: '-mobiledoc-u' }).set({ type: '-offset-underline' });
 
   doc.where({ type: '-mobiledoc-img' }).set({ type: '-offset-image' }).rename({ attributes: { '-mobiledoc-src': '-offset-url' } });
-
-  return new OffsetSource(doc.toJSON());
 });

--- a/packages/@atjson/source-mobiledoc/src/converter.ts
+++ b/packages/@atjson/source-mobiledoc/src/converter.ts
@@ -33,4 +33,6 @@ MobiledocSource.defineConverterTo(OffsetSource, doc => {
   doc.where({ type: '-mobiledoc-u' }).set({ type: '-offset-underline' });
 
   doc.where({ type: '-mobiledoc-img' }).set({ type: '-offset-image' }).rename({ attributes: { '-mobiledoc-src': '-offset-url' } });
+
+  return doc;
 });

--- a/packages/@atjson/source-mobiledoc/src/source.ts
+++ b/packages/@atjson/source-mobiledoc/src/source.ts
@@ -55,7 +55,7 @@ export default class MobiledocSource extends Document {
     Underline,
     UnorderedList
   ];
-  static fromSource(mobiledoc: Mobiledoc) {
+  static fromRaw(mobiledoc: Mobiledoc) {
     let result = new Parser(mobiledoc);
 
     return new this({

--- a/packages/@atjson/source-mobiledoc/test/source-mobiledoc-test.ts
+++ b/packages/@atjson/source-mobiledoc/test/source-mobiledoc-test.ts
@@ -7,7 +7,7 @@ describe('@atjson/source-Mobiledoc', () => {
   describe('sections', () => {
     describe.each(['p', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'blockquote', 'pull-quote', 'aside'])('%s', type => {
       test('with text', () => {
-        let doc = MobiledocSource.fromSource({
+        let doc = MobiledocSource.fromRaw({
           version: '0.3.1',
           atoms: [],
           cards: [],
@@ -30,7 +30,7 @@ describe('@atjson/source-Mobiledoc', () => {
       });
 
       test('without text', () => {
-        let doc = MobiledocSource.fromSource({
+        let doc = MobiledocSource.fromRaw({
           version: '0.3.1',
           atoms: [],
           cards: [],
@@ -56,7 +56,7 @@ describe('@atjson/source-Mobiledoc', () => {
 
   describe('markup', () => {
     test.each(['b', 'code', 'em', 'i', 's', 'strong', 'sub', 'sup', 'u'])('%s', type => {
-      let doc = MobiledocSource.fromSource({
+      let doc = MobiledocSource.fromRaw({
         version: '0.3.1',
         atoms: [],
         cards: [],
@@ -90,7 +90,7 @@ describe('@atjson/source-Mobiledoc', () => {
     });
 
     test('simple markup', () => {
-      let doc = MobiledocSource.fromSource({
+      let doc = MobiledocSource.fromRaw({
         version: '0.3.1',
         atoms: [],
         cards: [],
@@ -131,7 +131,7 @@ describe('@atjson/source-Mobiledoc', () => {
     });
 
     test('multiple markups at a single position', () => {
-      let doc = MobiledocSource.fromSource({
+      let doc = MobiledocSource.fromRaw({
         version: '0.3.1',
         atoms: [],
         cards: [],
@@ -170,7 +170,7 @@ describe('@atjson/source-Mobiledoc', () => {
     });
 
     test('overlapping markup', () => {
-      let doc = MobiledocSource.fromSource({
+      let doc = MobiledocSource.fromRaw({
         version: '0.3.1',
         atoms: [],
         cards: [],
@@ -231,7 +231,7 @@ describe('@atjson/source-Mobiledoc', () => {
       static schema = [...MobiledocSource.schema, Mention];
     }
 
-    let doc = MentionSource.fromSource({
+    let doc = MentionSource.fromRaw({
       version: '0.3.1',
       atoms: [
         ['mention', '@bob', { id: 42 }]
@@ -265,7 +265,7 @@ describe('@atjson/source-Mobiledoc', () => {
   });
 
   test('image', () => {
-    let doc = MobiledocSource.fromSource({
+    let doc = MobiledocSource.fromRaw({
       version: '0.3.1',
       atoms: [],
       cards: [],
@@ -292,7 +292,7 @@ describe('@atjson/source-Mobiledoc', () => {
 
   describe('list', () => {
     test.each(['ol', 'ul'])('%s', type => {
-      let doc = MobiledocSource.fromSource({
+      let doc = MobiledocSource.fromRaw({
         version: '0.3.1',
         atoms: [],
         cards: [],


### PR DESCRIPTION
This adds coercion to documents when converting between sources.

By adding this feature, multiple passes can be made to incrementally convert to a final source.

A use case is converting Github markdown to the Offset source. The Github markdown is an extension of the Commonmark source that AtJSON has built in. It adds a few other features. To convert from Github markdown to Offset, the following code will do the trick:

```js
class GithubMarkdownSource extends CommonmarkSource {
  static contentType = 'application/vnd.atjson+gfm';
  static schema = [...CommonmarkSource.schema, Strikethrough, TaskListItem, Table, TableCell, TableRow];

  static markdownParser() {
    return markdownIt('gfm');
  }
}

GithubMarkdownSource.defineConverterTo(OffsetSource, doc => {
  doc.where({ type: '-github-strikethrough' }).set({ type: '-offset-strikethrough' });
  // et al.

  return doc.convertTo(CommonmarkSource).convertTo(OffsetSource);
});
```