### PR TITLE
Remove more escape sequences

### DIFF
--- a/packages/@atjson/renderer-commonmark/src/index.ts
+++ b/packages/@atjson/renderer-commonmark/src/index.ts
@@ -29,7 +29,7 @@ export function* split(): Iterable<any> {
 // http://spec.commonmark.org/0.28/#backslash-escapes
 function escapePunctuation(text: string) {
   return text.replace(/([#!*+=\\\[\]\^_`{|}~])/g, '\\$1')
-             .replace(/(\d+)\./g, '$1\\.')
+             .replace(/^\s*(\d+)\.(\s+)/gm, '$1\\.$2')
              .replace(/&/g, '&amp;')
              .replace(/</g, '&lt;')
              .replace(/>/g, '&gt;')

--- a/packages/@atjson/renderer-commonmark/src/index.ts
+++ b/packages/@atjson/renderer-commonmark/src/index.ts
@@ -28,7 +28,10 @@ export function* split(): Iterable<any> {
 
 // http://spec.commonmark.org/0.28/#backslash-escapes
 function escapePunctuation(text: string) {
-  return text.replace(/([#!*+=\\\[\]\^_`{|}~])/g, '\\$1')
+  return text.replace(/([#!*+=\\\^_`{|}~])/g, '\\$1')
+             .replace(/(\[)([^\]]*$)/g, '\\$1$2')    // Escape bare opening brackets [
+             .replace(/(^[^\[]*)(\].*$)/g, '$1\\$2') // Escape bare closing brackets ]
+             .replace(/(\]\()/g, ']\\(')             // Escape parenthesis ](
              .replace(/^\s*(\d+)\.(\s+)/gm, '$1\\.$2')
              .replace(/&/g, '&amp;')
              .replace(/</g, '&lt;')

--- a/packages/@atjson/renderer-commonmark/src/index.ts
+++ b/packages/@atjson/renderer-commonmark/src/index.ts
@@ -29,10 +29,10 @@ export function* split(): Iterable<any> {
 // http://spec.commonmark.org/0.28/#backslash-escapes
 function escapePunctuation(text: string) {
   return text.replace(/([#!*+=\\\^_`{|}~])/g, '\\$1')
-             .replace(/(\[)([^\]]*$)/g, '\\$1$2')    // Escape bare opening brackets [
-             .replace(/(^[^\[]*)(\].*$)/g, '$1\\$2') // Escape bare closing brackets ]
-             .replace(/(\]\()/g, ']\\(')             // Escape parenthesis ](
-             .replace(/^\s*(\d+)\.(\s+)/gm, '$1\\.$2')
+             .replace(/(\[)([^\]]*$)/g, '\\$1$2')      // Escape bare opening brackets [
+             .replace(/(^[^\[]*)(\].*$)/g, '$1\\$2')   // Escape bare closing brackets ]
+             .replace(/(\]\()/g, ']\\(')               // Escape parenthesis ](
+             .replace(/^\s*(\d+)\.(\s+)/gm, '$1\\.$2') // Escape list items; not all numbers
              .replace(/&/g, '&amp;')
              .replace(/</g, '&lt;')
              .replace(/>/g, '&gt;')

--- a/packages/@atjson/renderer-commonmark/test/commonmark-test.ts
+++ b/packages/@atjson/renderer-commonmark/test/commonmark-test.ts
@@ -425,19 +425,38 @@ After all the lists
   });
 
   describe('escape sequences', () => {
-    test.each([
-      '5.8 million',
-      'in 2016.',
-      '2.0',
-      '$280,000.'
-    ])('%s is not escaped', text => {
-      let document = new OffsetSource({
-        content: text,
-        annotations: []
-      });
+    describe('numbers', () => {
+      test.each([
+        '5.8 million',
+        'in 2016.',
+        '2.0',
+        '$280,000.'
+      ])('%s is not escaped', text => {
+        let document = new OffsetSource({
+          content: text,
+          annotations: []
+        });
 
-      let renderer = new CommonMarkRenderer();
-      expect(renderer.render(document)).toBe(text);
+        let renderer = new CommonMarkRenderer();
+        expect(renderer.render(document)).toBe(text);
+      });
+    });
+
+    describe('sic / citations', () => {
+      test.each([
+        '“[We] are',
+        '“[Our algorithm] allows',
+        'surpass [rival software] C',
+        'for [my district] in 2016'
+      ])('%s is not escaped', text => {
+        let document = new OffsetSource({
+          content: text,
+          annotations: []
+        });
+
+        let renderer = new CommonMarkRenderer();
+        expect(renderer.render(document)).toBe(text);
+      });
     });
   });
 });

--- a/packages/@atjson/renderer-commonmark/test/commonmark-test.ts
+++ b/packages/@atjson/renderer-commonmark/test/commonmark-test.ts
@@ -423,4 +423,21 @@ After all the lists
     // Make sure we're not generating code in the round-trip
     expect(markdown).toEqual(renderer.render(CommonMarkSource.fromRaw(markdown).convertTo(OffsetSource)));
   });
+
+  describe('escape sequences', () => {
+    test.each([
+      '5.8 million',
+      'in 2016.',
+      '2.0',
+      '$280,000.'
+    ])('%s is not escaped', text => {
+      let document = new OffsetSource({
+        content: text,
+        annotations: []
+      });
+
+      let renderer = new CommonMarkRenderer();
+      expect(renderer.render(document)).toBe(text);
+    });
+  });
 });


### PR DESCRIPTION
We've had some complaints from our editors about getting unnecessary escape sequences showing up in markdown that impede their ability to copyedit text pasted from Google Docs.

This change limits occurrences of markdown escape sequences for [sic] and numbers that include periods.