### PR TITLE
Bugfix/delete extra linebreaks

### DIFF
--- a/packages/@atjson/source-gdocs-paste/src/converter.ts
+++ b/packages/@atjson/source-gdocs-paste/src/converter.ts
@@ -138,5 +138,16 @@ GDocsSource.defineConverterTo(OffsetSource, doc => {
       }
     });
 
+  // LineBreaks may have been created at a block boundary co-terminating
+  // with a paragraph, so delete those which match a paragraph end
+  doc.where(annotation => annotation instanceof LineBreak)
+  .as('lineBreak')
+  .join(
+    doc.where(annotation => annotation instanceof Paragraph).as('paragraphs'),
+    (l: Annotation, r: Annotation) => l.end === r.end)
+  .update(({lineBreak}) => {
+    doc.removeAnnotation(lineBreak);
+  });
+
   return doc;
 });

--- a/packages/@atjson/source-gdocs-paste/src/converter.ts
+++ b/packages/@atjson/source-gdocs-paste/src/converter.ts
@@ -121,12 +121,12 @@ GDocsSource.defineConverterTo(OffsetSource, doc => {
     });
 
   // LineBreaks/paragraphs may have been created for listItem separators,
-  // so delete those which exist in a list but not in any list item
+  // so delete those which exist in a list (or immediately after) but not in any list item
   doc.where((annotation: Annotation) => (annotation instanceof LineBreak) || (annotation instanceof Paragraph))
     .as('lineBreak')
     .join(
       doc.where({ type: '-offset-list' }).as('lists'),
-      (l: Annotation, r: Annotation) => l.start > r.start && l.end < r.end)
+      (l: Annotation, r: Annotation) => l.start >= r.start && l.end <= r.end + 1)
     .outerJoin(
       doc.where({type: '-offset-list-item'}).as('listItems'),
       (l: {lineBreak: LineBreak, lists: Annotation[]}, r: Annotation) => {

--- a/packages/@atjson/source-gdocs-paste/test/converter-test.ts
+++ b/packages/@atjson/source-gdocs-paste/test/converter-test.ts
@@ -94,9 +94,7 @@ describe('@atjson/source-gdocs-paste paragraphs', () => {
     [ 213, 214 ],
     [ 249, 250 ],
     [ 370, 371 ],
-    [ 486, 487 ],
-    [ 520, 521 ],
-    [ 538, 539 ]
+    [ 520, 521 ]
   ].map(([start, end]) => {
     return {
       start,

--- a/packages/@atjson/source-gdocs-paste/test/converter-test.ts
+++ b/packages/@atjson/source-gdocs-paste/test/converter-test.ts
@@ -91,7 +91,6 @@ describe('@atjson/source-gdocs-paste paragraphs', () => {
   const LINEBREAKS = [
     [ 21, 22],
     [ 70, 71 ],
-    [ 213, 214 ],
     [ 249, 250 ],
     [ 370, 371 ],
     [ 520, 521 ]
@@ -207,11 +206,11 @@ describe('@atjson/source-gdocs-paste paragraphs', () => {
     expect(linebreaksInLists.where(join => join.lists.length > 0 && join['list-items'].length === 0).toJSON()).toHaveLength(0);
     expect(linebreaksInLists.toJSON()).toMatchObject([
       {
-        linebreak: LINEBREAKS[3],
+        linebreak: LINEBREAKS[2],
         lists: [ LISTS[0] ],
         'list-items': [ LIST_ITEMS[0] ]
       }, {
-        linebreak: LINEBREAKS[4],
+        linebreak: LINEBREAKS[3],
         lists: [ LISTS[0] ],
         'list-items': [ LIST_ITEMS[1] ]
       }


### PR DESCRIPTION
Fix two small bugs, deleting extra linebreaks that occur after the last item in a list and that might occur at the end of a paragraph.