### PR TITLE
🐝: Include `source-html` in dependencies list

### DIFF
--- a/packages/@atjson/source-prism/package.json
+++ b/packages/@atjson/source-prism/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "@atjson/document": "file:../document",
     "@atjson/offset-annotations": "file:../offset-annotations",
+    "@atjson/source-html": "file:../source-html",
     "@types/sax": "^1.0.1",
     "entities": "^1.1.2",
     "sax": "^1.2.4"


### PR DESCRIPTION
Quick fix to include source-html in the dependencies list for the prism source.