### PR TITLE
Make Renderer.render a static method

### DIFF
--- a/packages/@atjson/offset-inspector/src/index.ts
+++ b/packages/@atjson/offset-inspector/src/index.ts
@@ -161,7 +161,7 @@ export default class OffsetEditorDemo extends WebComponent {
   renderMarkdown(doc: Document) {
     if (this.activeTab('commonmark-tab')) {
       let outputElement = this.shadowRoot.querySelector('.markdown');
-      let rendered = new CommonmarkRenderer().render(doc);
+      let rendered = CommonmarkRenderer.render(doc);
       if (outputElement) {
         outputElement.textContent = rendered;
       }

--- a/packages/@atjson/renderer-commonmark/src/index.ts
+++ b/packages/@atjson/renderer-commonmark/src/index.ts
@@ -168,9 +168,9 @@ export default class CommonmarkRenderer extends Renderer {
   *'image'(image: Image): Iterable<any> {
     if (image.attributes.title) {
       let title = image.attributes.title.replace(/"/g, '\\"');
-      return `![${this.render(image.attributes.description)}](${image.attributes.url} "${title}")`;
+      return `![${this.constructor.render(image.attributes.description)}](${image.attributes.url} "${title}")`;
     }
-    return `![${this.render(image.attributes.description)}](${image.attributes.url})`;
+    return `![${this.constructor.render(image.attributes.description)}](${image.attributes.url})`;
   }
 
   /**

--- a/packages/@atjson/renderer-commonmark/src/index.ts
+++ b/packages/@atjson/renderer-commonmark/src/index.ts
@@ -168,9 +168,9 @@ export default class CommonmarkRenderer extends Renderer {
   *'image'(image: Image): Iterable<any> {
     if (image.attributes.title) {
       let title = image.attributes.title.replace(/"/g, '\\"');
-      return `![${this.constructor.render(image.attributes.description)}](${image.attributes.url} "${title}")`;
+      return `![${(this.constructor as typeof CommonmarkRenderer).render(image.attributes.description)}](${image.attributes.url} "${title}")`;
     }
-    return `![${this.constructor.render(image.attributes.description)}](${image.attributes.url})`;
+    return `![${(this.constructor as typeof CommonmarkRenderer).render(image.attributes.description)}](${image.attributes.url})`;
   }
 
   /**

--- a/packages/@atjson/renderer-commonmark/test/commonmark-spec-test.ts
+++ b/packages/@atjson/renderer-commonmark/test/commonmark-spec-test.ts
@@ -25,12 +25,11 @@ Object.keys(unitTestsBySection).forEach(moduleName => {
   describe(moduleName, () => {
     unitTests.forEach(unitTest => {
       let shouldSkip = skippedTests.indexOf(unitTest.number) !== -1;
-      let renderer = new CommonMarkRenderer();
 
       (shouldSkip ? test.skip : test)(unitTest.markdown, () => {
         let markdown = unitTest.markdown.replace(/→/g, '\t');
         let original = CommonMarkSource.fromRaw(markdown);
-        let generatedMarkdown = renderer.render(original.convertTo(OffsetSource));
+        let generatedMarkdown = CommonMarkRenderer.render(original.convertTo(OffsetSource));
         let output = CommonMarkSource.fromRaw(generatedMarkdown);
 
         // Assert that our internal representations (AtJSON) match

--- a/packages/@atjson/renderer-commonmark/test/commonmark-test.ts
+++ b/packages/@atjson/renderer-commonmark/test/commonmark-test.ts
@@ -12,8 +12,7 @@ describe('commonmark', () => {
       ]
     });
 
-    let renderer = new CommonMarkRenderer();
-    expect(renderer.render(document)).toBe('Some text that is both **bold *and*** *italic* plus something after.');
+    expect(CommonMarkRenderer.render(document)).toBe('Some text that is both **bold *and*** *italic* plus something after.');
   });
 
   test('images', () => {
@@ -40,8 +39,7 @@ describe('commonmark', () => {
       }]
     });
 
-    let renderer = new CommonMarkRenderer();
-    expect(renderer.render(document)).toBe('![**CommonMark**\\!](http://commonmark.org/images/markdown-mark.png)');
+    expect(CommonMarkRenderer.render(document)).toBe('![**CommonMark**\\!](http://commonmark.org/images/markdown-mark.png)');
   });
 
   test('a plain text document with virtual paragraphs', () => {
@@ -55,8 +53,7 @@ describe('commonmark', () => {
       ]
     });
 
-    let renderer = new CommonMarkRenderer();
-    expect(renderer.render(document)).toBe(
+    expect(CommonMarkRenderer.render(document)).toBe(
                  'A paragraph with some **bold**\n\n**text** that continues into the next.\n\n');
   });
 
@@ -86,8 +83,7 @@ describe('commonmark', () => {
       ]
     });
 
-    let renderer = new CommonMarkRenderer();
-    expect(renderer.render(document)).toBe(
+    expect(CommonMarkRenderer.render(document)).toBe(
                  `I have a list:
 
 1. First item plus **bold** text
@@ -114,8 +110,7 @@ After all the lists
       }]
     });
 
-    let renderer = new CommonMarkRenderer();
-    expect(renderer.render(document)).toBe('I have a [link](https://example.com)');
+    expect(CommonMarkRenderer.render(document)).toBe('I have a [link](https://example.com)');
   });
 
   describe('blockquote', () => {
@@ -131,8 +126,7 @@ After all the lists
         }]
       });
 
-      let renderer = new CommonMarkRenderer();
-      expect(renderer.render(document)).toBe('> This is a quote\n> \n> That has some\n> lines in it.\n\n');
+      expect(CommonMarkRenderer.render(document)).toBe('> This is a quote\n> \n> That has some\n> lines in it.\n\n');
     });
 
     test('with a paragraph', () => {
@@ -159,8 +153,7 @@ After all the lists
         }]
       });
 
-      let renderer = new CommonMarkRenderer();
-      expect(renderer.render(document)).toBe('> This is a quote\n\nAnd this is not.\n\n');
+      expect(CommonMarkRenderer.render(document)).toBe('> This is a quote\n\nAnd this is not.\n\n');
     });
 
     test('with flanking whitespace', () => {
@@ -187,8 +180,7 @@ After all the lists
         }]
       });
 
-      let renderer = new CommonMarkRenderer();
-      expect(renderer.render(document)).toBe('> This is a quote\n\nAnd this is not.\n\n');
+      expect(CommonMarkRenderer.render(document)).toBe('> This is a quote\n\nAnd this is not.\n\n');
     });
 
     test('with surrounding paragraphs', () => {
@@ -233,8 +225,7 @@ After all the lists
         }]
       });
 
-      let renderer = new CommonMarkRenderer();
-      expect(renderer.render(document)).toBe('This is some text\n\n> This is a quote\n\nAnd this is not.\n\n');
+      expect(CommonMarkRenderer.render(document)).toBe('This is some text\n\n> This is a quote\n\nAnd this is not.\n\n');
     });
   });
 
@@ -248,8 +239,7 @@ After all the lists
       ]
     });
 
-    let renderer = new CommonMarkRenderer();
-    expect(renderer.render(document)).toBe('x\n\n***\ny\n\n');
+    expect(CommonMarkRenderer.render(document)).toBe('x\n\n***\ny\n\n');
   });
 
   test('headlines', () => {
@@ -266,8 +256,7 @@ After all the lists
       }]
     });
 
-    let renderer = new CommonMarkRenderer();
-    expect(renderer.render(document)).toBe('# Banner\n## Headline\n');
+    expect(CommonMarkRenderer.render(document)).toBe('# Banner\n## Headline\n');
   });
 
   test('moves spaces at annotation boundaries to the outside', () => {
@@ -280,8 +269,7 @@ After all the lists
       }]
     });
 
-    let renderer = new CommonMarkRenderer();
-    expect(renderer.render(document)).toBe('This is **bold** text and a [link](https://example.com).');
+    expect(CommonMarkRenderer.render(document)).toBe('This is **bold** text and a [link](https://example.com).');
   });
 
   test('unambiguous nesting of bold and italic', () => {
@@ -306,8 +294,7 @@ After all the lists
       }]
     });
 
-    let renderer = new CommonMarkRenderer();
-    expect(renderer.render(document)).toBe('**_bold then italic_** *__italic then bold__*');
+    expect(CommonMarkRenderer.render(document)).toBe('**_bold then italic_** *__italic then bold__*');
   });
 
   test('adjacent bold and italic annotations are given unique markdown makers', () => {
@@ -348,8 +335,7 @@ After all the lists
       }]
     });
 
-    let renderer = new CommonMarkRenderer();
-    expect(renderer.render(document)).toBe('**bold**_, then italic_\n\n_italic_**, then bold**\n\n');
+    expect(CommonMarkRenderer.render(document)).toBe('**bold**_, then italic_\n\n_italic_**, then bold**\n\n');
   });
 
   test('empty format strings are removed', () => {
@@ -362,8 +348,7 @@ After all the lists
       }]
     });
 
-    let renderer = new CommonMarkRenderer();
-    expect(renderer.render(document)).toBe('Some formatting on empty spaces');
+    expect(CommonMarkRenderer.render(document)).toBe('Some formatting on empty spaces');
   });
 
   test('non-breaking spaces don\'t receive formatting', () => {
@@ -382,8 +367,7 @@ After all the lists
       }]
     });
 
-    let renderer = new CommonMarkRenderer();
-    expect(renderer.render(document)).toBe('&nbsp;\n\n**text**\n\n\u202F');
+    expect(CommonMarkRenderer.render(document)).toBe('&nbsp;\n\n**text**\n\n\u202F');
   });
 
   test('line feed characters don\'t recieve formatting', () => {
@@ -402,8 +386,7 @@ After all the lists
       }]
     });
 
-    let renderer = new CommonMarkRenderer();
-    expect(renderer.render(document)).toBe('\u000b\n\n**text**\n\n');
+    expect(CommonMarkRenderer.render(document)).toBe('\u000b\n\n**text**\n\n');
   });
 
   test('tabs and leading / trailing spaces are stripped from output', () => {
@@ -416,12 +399,11 @@ After all the lists
       }]
     });
 
-    let renderer = new CommonMarkRenderer();
-    let markdown = renderer.render(document);
+    let markdown = CommonMarkRenderer.render(document);
 
-    expect(renderer.render(document)).toBe('Hello\n\nThis is my text\n\n');
+    expect(CommonMarkRenderer.render(document)).toBe('Hello\n\nThis is my text\n\n');
     // Make sure we're not generating code in the round-trip
-    expect(markdown).toEqual(renderer.render(CommonMarkSource.fromRaw(markdown).convertTo(OffsetSource)));
+    expect(markdown).toEqual(CommonMarkRenderer.render(CommonMarkSource.fromRaw(markdown).convertTo(OffsetSource)));
   });
 
   describe('escape sequences', () => {
@@ -437,8 +419,7 @@ After all the lists
           annotations: []
         });
 
-        let renderer = new CommonMarkRenderer();
-        expect(renderer.render(document)).toBe(text);
+        expect(CommonMarkRenderer.render(document)).toBe(text);
       });
     });
 
@@ -454,8 +435,7 @@ After all the lists
           annotations: []
         });
 
-        let renderer = new CommonMarkRenderer();
-        expect(renderer.render(document)).toBe(text);
+        expect(CommonMarkRenderer.render(document)).toBe(text);
       });
     });
   });

--- a/packages/@atjson/renderer-graphviz/src/index.ts
+++ b/packages/@atjson/renderer-graphviz/src/index.ts
@@ -57,7 +57,7 @@ export interface GraphvizOptions {
 }
 
 export default class GraphvizRenderer {
-  render(document: Document, options: GraphvizOptions = { shape: 'oval' }): string {
+  static render(document: Document, options: GraphvizOptions = { shape: 'oval' }): string {
     let edges: Array<[Node, Node]> = [];
     let nodes: Node[] = [];
     generateGraph(new HIR(document).rootNode, edges, nodes);

--- a/packages/@atjson/renderer-graphviz/test/graphviz-test.ts
+++ b/packages/@atjson/renderer-graphviz/test/graphviz-test.ts
@@ -38,8 +38,7 @@ describe('graphviz', () => {
         attributes: {}
       }]
     });
-    let renderer = new GraphvizRenderer();
-    expect(renderer.render(doc)).toBe(`digraph atjson{
+    expect(GraphvizRenderer.render(doc)).toBe(`digraph atjson{
   node [shape=oval];
   root1 [label="root\\n{}" style=filled fillcolor="#222222" fontcolor="#FFFFFF"];
   bold2 [label="bold\\n{}" style=filled fillcolor="#888888" fontcolor="#FFFFFF"];
@@ -77,8 +76,7 @@ describe('graphviz', () => {
       }]
     });
 
-    let renderer = new GraphvizRenderer();
-    let result = renderer.render(doc, { shape: 'record' });
+    let result = GraphvizRenderer.render(doc, { shape: 'record' });
     expect(result).toMatchSnapshot();
     writeFileSync(join(__dirname, '../example.dot'), result);
   });
@@ -96,8 +94,7 @@ describe('graphviz', () => {
         }]
       });
 
-      let renderer = new GraphvizRenderer();
-      expect(renderer.render(doc, { shape })).toBe(`digraph atjson{
+      expect(GraphvizRenderer.render(doc, { shape })).toBe(`digraph atjson{
   node [shape=${shape}];
   root1 [label="{root|{}}" style=filled fillcolor="#222222" fontcolor="#FFFFFF"];
   bold2 [label="{bold|{}}" style=filled fillcolor="#888888" fontcolor="#FFFFFF"];

--- a/packages/@atjson/renderer-hir/test/renderer-hir-test.ts
+++ b/packages/@atjson/renderer-hir/test/renderer-hir-test.ts
@@ -107,8 +107,7 @@ describe('@atjson/renderer-hir', () => {
       }
     }
 
-    let renderer = new ConcreteRenderer();
-    renderer.render(atjson);
+    ConcreteRenderer.render(atjson);
   });
 
   it('escapes HTML entities in text', () => {
@@ -131,7 +130,6 @@ describe('@atjson/renderer-hir', () => {
       }
     }
 
-    let renderer = new ConcreteRenderer();
-    expect(renderer.render(atjson)).toBe('This &lt;html-element with&#x3D;&quot;param&quot; and-another&#x3D;&#x27;param&#x27;&gt; should render as plain text');
+    expect(ConcreteRenderer.render(atjson)).toBe('This &lt;html-element with&#x3D;&quot;param&quot; and-another&#x3D;&#x27;param&#x27;&gt; should render as plain text');
   });
 });

--- a/packages/@atjson/renderer-plain-text/test/text-renderer-test.ts
+++ b/packages/@atjson/renderer-plain-text/test/text-renderer-test.ts
@@ -8,7 +8,6 @@ class PlainText extends Document {
 }
 describe('PlainTextRenderer', () => {
   it('returns the text from the atjson document', () => {
-    let renderer = new PlainTextRenderer();
 
     let document = new PlainText({
       content: '☎️👨🏻⛵️🐳👌🏼',
@@ -23,15 +22,14 @@ describe('PlainTextRenderer', () => {
         }
       }]
     });
-    let text = renderer.render(document);
+    let text = PlainTextRenderer.render(document);
     expect(text).toBe('☎️👨🏻⛵️🐳👌🏼');
   });
 
   it('strips virtual annotations', () => {
     let doc = HTMLSource.fromRaw('<p>This is some <em>fancy</em> <span class="fancy">text</span>.');
 
-    let renderer = new PlainTextRenderer();
-    let text = renderer.render(doc);
+    let text = PlainTextRenderer.render(doc);
     expect(text).toBe('This is some fancy text.');
   });
 });

--- a/packages/@atjson/source-commonmark/test/utils.ts
+++ b/packages/@atjson/source-commonmark/test/utils.ts
@@ -37,6 +37,5 @@ class PlainTextRenderer extends Renderer {
 }
 
 export function render(doc: Document) {
-  let renderer = new PlainTextRenderer();
-  return renderer.render(doc);
+  return PlainTextRenderer.render(doc);
 }

--- a/packages/@atjson/source-prism/public/app.js
+++ b/packages/@atjson/source-prism/public/app.js
@@ -9,11 +9,11 @@ document.addEventListener('paste', (evt) => {
   let xml = evt.clipboardData.getData('text/plain');
   if (xml !== '') {
     let doc = PRISMSource.fromRaw(xml).convertTo(OffsetSource);
-    document.body.innerText = new Renderer().render(doc) + '\n\n-----------------\n\n' + JSON.stringify(doc.toJSON(), null, 2);
+    document.body.innerText = Renderer.render(doc) + '\n\n-----------------\n\n' + JSON.stringify(doc.toJSON(), null, 2);
   }
 });
 
 document.querySelector('button').addEventListener('click', () => {
   let doc = PRISMSource.fromRaw(example.toString()).convertTo(OffsetSource);
-  document.body.innerText = new Renderer().render(doc) + '\n\n-----------------\n\n' + JSON.stringify(doc.toJSON(), null, 2);
+  document.body.innerText = Renderer.render(doc) + '\n\n-----------------\n\n' + JSON.stringify(doc.toJSON(), null, 2);
 });

--- a/packages/@atjson/source-url/test/url-test.ts
+++ b/packages/@atjson/source-url/test/url-test.ts
@@ -40,8 +40,7 @@ class EmbedRenderer extends CommonMarkRenderer {
 describe('url-source', () => {
   test('text that is not a URL is returned as plain text', () => {
     let url = URLSource.fromRaw('Hi buddy!');
-    let renderer = new EmbedRenderer();
-    expect(renderer.render(url.convertTo(OffsetSource))).toBe('Hi buddy\\!');
+    expect(EmbedRenderer.render(url.convertTo(OffsetSource))).toBe('Hi buddy\\!');
   });
 
   test.each([
@@ -51,8 +50,7 @@ describe('url-source', () => {
     'https://pinterest.com'
   ])('URLs that do not match our embed expansion are displayed as text (%s)', text => {
     let url = URLSource.fromRaw(text);
-    let renderer = new EmbedRenderer();
-    expect(renderer.render(url.convertTo(OffsetSource))).toBe(text);
+    expect(EmbedRenderer.render(url.convertTo(OffsetSource))).toBe(text);
   });
 
   describe('instagram', () => {
@@ -63,8 +61,7 @@ describe('url-source', () => {
       'https://instagr.am/p/Bnzz-g6gpwg/?taken-by=lgbt_history'
     ])('%s', text => {
       let url = URLSource.fromRaw(text);
-      let renderer = new EmbedRenderer();
-      expect(renderer.render(url.convertTo(OffsetSource))).toBe('<blockquote class="instagram-media" data-instgrm-permalink="https://www.instagram.com/p/Bnzz-g6gpwg" data-instgrm-version="12"></blockquote>');
+      expect(EmbedRenderer.render(url.convertTo(OffsetSource))).toBe('<blockquote class="instagram-media" data-instgrm-permalink="https://www.instagram.com/p/Bnzz-g6gpwg" data-instgrm-version="12"></blockquote>');
     });
   });
 
@@ -75,8 +72,7 @@ describe('url-source', () => {
       'https://m.twitter.com/jennschiffer/status/708888255828250625?ref_src=twsrc%5Etfw%7Ctwcamp%5Etweetembed&ref_url=https%3A%2F%2Ftwitter.com%2Fjennschiffer%2Fstatus%2F708888255828250625'
     ])('%s', text => {
       let url = URLSource.fromRaw(text);
-      let renderer = new EmbedRenderer();
-      expect(renderer.render(url.convertTo(OffsetSource))).toBe('<blockquote lang=\"en\" data-type=\"twitter\" data-url=\"https://twitter.com/jennschiffer/status/708888255828250625\"><p><a href=\"https://twitter.com/jennschiffer/status/708888255828250625\">https://twitter.com/jennschiffer/status/708888255828250625</a></p></blockquote>');
+      expect(EmbedRenderer.render(url.convertTo(OffsetSource))).toBe('<blockquote lang=\"en\" data-type=\"twitter\" data-url=\"https://twitter.com/jennschiffer/status/708888255828250625\"><p><a href=\"https://twitter.com/jennschiffer/status/708888255828250625\">https://twitter.com/jennschiffer/status/708888255828250625</a></p></blockquote>');
     });
   });
 
@@ -87,8 +83,7 @@ describe('url-source', () => {
       'https://youtu.be/Mh5LY4Mz15o'
     ])('%s', text => {
       let url = URLSource.fromRaw(text);
-      let renderer = new EmbedRenderer();
-      expect(renderer.render(url.convertTo(OffsetSource))).toBe('<iframe src="https://www.youtube.com/embed/Mh5LY4Mz15o" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>');
+      expect(EmbedRenderer.render(url.convertTo(OffsetSource))).toBe('<iframe src="https://www.youtube.com/embed/Mh5LY4Mz15o" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>');
     });
 
     test.each([
@@ -96,28 +91,24 @@ describe('url-source', () => {
       'https://www.youtube-nocookie.com/embed/Mh5LY4Mz15ot=165'
     ])('%s', text => {
       let url = URLSource.fromRaw(text);
-      let renderer = new EmbedRenderer();
-      expect(renderer.render(url.convertTo(OffsetSource))).toBe(`<iframe src="${text}" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>`);
+      expect(EmbedRenderer.render(url.convertTo(OffsetSource))).toBe(`<iframe src="${text}" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>`);
     });
   });
 
   describe('pinterest', () => {
     test('profile', () => {
       let url = URLSource.fromRaw('https://www.pinterest.com/alluremagazine/');
-      let renderer = new EmbedRenderer();
-      expect(renderer.render(url.convertTo(OffsetSource))).toBe('<a href="https://www.pinterest.com/alluremagazine/" data-pin-do="embedPin" data-pin-width="large">https://www.pinterest.com/alluremagazine/</a>');
+      expect(EmbedRenderer.render(url.convertTo(OffsetSource))).toBe('<a href="https://www.pinterest.com/alluremagazine/" data-pin-do="embedPin" data-pin-width="large">https://www.pinterest.com/alluremagazine/</a>');
     });
 
     test('board', () => {
       let url = URLSource.fromRaw('https://www.pinterest.com/alluremagazine/makeup-inspiration/');
-      let renderer = new EmbedRenderer();
-      expect(renderer.render(url.convertTo(OffsetSource))).toBe('<a href="https://www.pinterest.com/alluremagazine/makeup-inspiration/" data-pin-do="embedPin" data-pin-width="large">https://www.pinterest.com/alluremagazine/makeup-inspiration/</a>');
+      expect(EmbedRenderer.render(url.convertTo(OffsetSource))).toBe('<a href="https://www.pinterest.com/alluremagazine/makeup-inspiration/" data-pin-do="embedPin" data-pin-width="large">https://www.pinterest.com/alluremagazine/makeup-inspiration/</a>');
     });
 
     test('pin', () => {
       let url = URLSource.fromRaw('https://www.pinterest.com/pin/246290673356918386/');
-      let renderer = new EmbedRenderer();
-      expect(renderer.render(url.convertTo(OffsetSource))).toBe('<a href="https://www.pinterest.com/pin/246290673356918386/" data-pin-do="embedPin" data-pin-width="large">https://www.pinterest.com/pin/246290673356918386/</a>');
+      expect(EmbedRenderer.render(url.convertTo(OffsetSource))).toBe('<a href="https://www.pinterest.com/pin/246290673356918386/" data-pin-do="embedPin" data-pin-width="large">https://www.pinterest.com/pin/246290673356918386/</a>');
     });
   });
 
@@ -127,8 +118,7 @@ describe('url-source', () => {
       'https://giphy.com/embed/3o7btW6jvrZduOA3ZK/'
     ])('%s', text => {
       let url = URLSource.fromRaw(text);
-      let renderer = new EmbedRenderer();
-      expect(renderer.render(url.convertTo(OffsetSource))).toBe('<iframe src="https://giphy.com/embed/3o7btW6jvrZduOA3ZK"></iframe>');
+      expect(EmbedRenderer.render(url.convertTo(OffsetSource))).toBe('<iframe src="https://giphy.com/embed/3o7btW6jvrZduOA3ZK"></iframe>');
     });
   });
 
@@ -139,8 +129,7 @@ describe('url-source', () => {
         'https://www.facebook.com/Vogue/posts/10156453076157279'
       ])('%s', text => {
         let url = URLSource.fromRaw(text);
-        let renderer = new EmbedRenderer();
-        expect(renderer.render(url.convertTo(OffsetSource))).toBe('<div class="fb-post" data-href="https://www.facebook.com/Vogue/posts/10156453076157279" data-show-text="true"></div>');
+        expect(EmbedRenderer.render(url.convertTo(OffsetSource))).toBe('<div class="fb-post" data-href="https://www.facebook.com/Vogue/posts/10156453076157279" data-show-text="true"></div>');
       });
     });
 
@@ -149,9 +138,8 @@ describe('url-source', () => {
         'https://www.facebook.com/Vogue/videos/vb.42933792278/258591818132754/?type=2&theater',
         'https://www.facebook.com/Vogue/posts/258591818132754'
       ])('%s', text => {
-        let url = URLSource.fromRaw(text);
-        let renderer = new EmbedRenderer();
-        expect(renderer.render(url.convertTo(OffsetSource))).toBe('<div class="fb-post" data-href="https://www.facebook.com/Vogue/posts/258591818132754" data-show-text="true"></div>');
+        let url = URLSource.fromRaw(text);\
+        expect(EmbedRenderer.render(url.convertTo(OffsetSource))).toBe('<div class="fb-post" data-href="https://www.facebook.com/Vogue/posts/258591818132754" data-show-text="true"></div>');
       });
     });
   });


### PR DESCRIPTION
This updates the base hir renderer to have a static render method,
so inheriting renderers are updated to follow suit.

This also adds the `document` to the hir renderer `Context` interface,
so that we have access to the source document while rendering out
annotations, which may be necessary if that rendering depends on
text that is unrelated to the hir tree.