### PR TITLE
🐜 Fix converter to offset to remove (Sub)Titles

### DIFF
--- a/packages/@atjson/source-gdocs-paste/src/converter.ts
+++ b/packages/@atjson/source-gdocs-paste/src/converter.ts
@@ -1,6 +1,7 @@
 import { Annotation, BlockAnnotation, ParseAnnotation } from '@atjson/document';
 import OffsetSource, { LineBreak, Paragraph } from '@atjson/offset-annotations';
 import GDocsSource from './source';
+import { Heading } from './annotations';
 
 GDocsSource.defineConverterTo(OffsetSource, doc => {
   // Remove all underlines that align with links, since
@@ -22,6 +23,13 @@ GDocsSource.defineConverterTo(OffsetSource, doc => {
   doc.where({ type: '-gdocs-ts_va', attributes: { '-gdocs-va': 'sup' } }).set({ type: '-offset-superscript' }).unset('attributes.-gdocs-va');
 
   doc.where({ type: '-gdocs-horizontal_rule' }).set({ type: '-offset-horizontal-rule' });
+
+  // Remove headings with level 100, 101, as these are Titles/Subtitles
+  // in GDocs which is not yet supported, as these should be thought of
+  // as non-body annotations
+  doc.where({ type: '-gdocs-ps_hd' })
+    .where((annotation: Heading) => annotation.attributes.level >= 100)
+    .remove();
 
   doc.where({ type: '-gdocs-ps_hd' })
     .set({ type: '-offset-heading' })

--- a/packages/@atjson/source-gdocs-paste/test/converter-test.ts
+++ b/packages/@atjson/source-gdocs-paste/test/converter-test.ts
@@ -24,10 +24,10 @@ describe('@atjson/source-gdocs-paste', () => {
     expect(italics.length).toEqual(2);
   });
 
-  it('correctly converts headings', () => {
+  it('correctly converts headings, removing Titles and Subtitles', () => {
     let headings = atjson.where(a => a.type === 'heading');
-    expect(headings.length).toEqual(4);
-    expect(headings.map(h => h.attributes.level)).toEqual([1, 2, 100, 101]);
+    expect(headings.length).toEqual(2);
+    expect(headings.map(h => h.attributes.level)).toEqual([1, 2]);
   });
 
   it('correctly converts lists', () => {


### PR DESCRIPTION
Title/Subtitle GDocs annotations should be considered non-body
annotations and aren't supported in Offset (yet).