### PR TITLE
🐝 Allow annotation classes in document constructor

### DIFF
--- a/packages/@atjson/document/src/index.ts
+++ b/packages/@atjson/document/src/index.ts
@@ -51,7 +51,7 @@ export default class Document {
 
   private pendingChangeEvent: any;
 
-  constructor(options: { content: string, annotations: AnnotationJSON[] }) {
+  constructor(options: { content: string, annotations: Array<AnnotationJSON | Annotation> }) {
     let DocumentClass = this.constructor as typeof Document;
     this.contentType = DocumentClass.contentType;
     this.changeListeners = [];


### PR DESCRIPTION
Allows documents to accept either AnnotationJSON or Annotation class instances in its constructor.