### PR TITLE
🍢✨ Allow using classified names for rendering hooks (`Bold` & `bold` / `GiphyEmbed` & `giphy-embed`)

### DIFF
--- a/packages/@atjson/renderer-commonmark/src/index.ts
+++ b/packages/@atjson/renderer-commonmark/src/index.ts
@@ -138,7 +138,7 @@ export default class CommonmarkRenderer extends Renderer {
     return escapePunctuation(text);
   }
 
-  *'root'() {
+  *root() {
     let rawText = yield;
     return rawText.join('');
   }
@@ -149,7 +149,7 @@ export default class CommonmarkRenderer extends Renderer {
    * Asterisks are used here because they can split
    * words; underscores cannot split words.
    */
-  *'bold'(_bold: Bold, context: Context): Iterable<any> {
+  *Bold(_bold: Bold, context: Context): Iterable<any> {
     let [before, text, after] = yield* split(_bold, context);
     if (text.length === 0) {
       return before + after;
@@ -167,7 +167,7 @@ export default class CommonmarkRenderer extends Renderer {
    * >
    * > It can also span multiple lines.
    */
-  *'blockquote'(): Iterable<any> {
+  *Blockquote(): Iterable<any> {
     let text = yield;
     let lines: string[] = text.join('').split('\n');
     let endOfQuote = lines.length;
@@ -193,7 +193,7 @@ export default class CommonmarkRenderer extends Renderer {
    * style, using a series of `=` or `-` markers. This only works for
    * headings of level 1 or 2, so any other level will be broken.
    */
-  *'heading'(heading: Heading): Iterable<any> {
+  *Heading(heading: Heading): Iterable<any> {
     let rawText = yield;
     let text = rawText.join('');
     let level = new Array(heading.attributes.level + 1).join('#');
@@ -214,7 +214,7 @@ export default class CommonmarkRenderer extends Renderer {
    * ***
    * Into multiple sections.
    */
-  *'horizontal-rule'(): Iterable<any> {
+  *HorizontalRule(): Iterable<any> {
     return '***\n';
   }
 
@@ -222,7 +222,7 @@ export default class CommonmarkRenderer extends Renderer {
    * Images are embedded like links, but with a `!` in front.
    * ![CommonMark](http://commonmark.org/images/markdown-mark.png)
    */
-  *'image'(image: Image): Iterable<any> {
+  *Image(image: Image): Iterable<any> {
     if (image.attributes.title) {
       let title = image.attributes.title.replace(/"/g, '\\"');
       return `![${(this.constructor as typeof CommonmarkRenderer).render(image.attributes.description)}](${image.attributes.url} "${title}")`;
@@ -233,7 +233,7 @@ export default class CommonmarkRenderer extends Renderer {
   /**
    * Italic text looks like *this* in Markdown.
    */
-  *'italic'(_italic: Italic, context: Context): Iterable<any> {
+  *Italic(_italic: Italic, context: Context): Iterable<any> {
     // This adds support for strong emphasis (per Commonmark)
     // Strong emphasis includes _*two*_ emphasis markers around text.
     let state = Object.assign({}, this.state);
@@ -260,14 +260,14 @@ export default class CommonmarkRenderer extends Renderer {
    * A line break in Commonmark can be two white spaces at the end of the line  <--
    * or it can be a backslash at the end of the line\
    */
-  *'line-break'(): Iterable<any> {
+  *LineBreak(): Iterable<any> {
     return '  \n';
   }
 
   /**
    * A [link](http://commonmark.org) has the url right next to it in Markdown.
    */
-  *'link'(link: Link, context: Context): Iterable<any> {
+  *Link(link: Link, context: Context): Iterable<any> {
     let [before, text, after] = yield* split(link, context);
     let url = escapeAttribute(link.attributes.url);
     if (link.attributes.title) {
@@ -284,7 +284,7 @@ export default class CommonmarkRenderer extends Renderer {
    * function () {}
    * ```
    */
-  *'code'(code: Code, context: Context): Iterable<any> {
+  *Code(code: Code, context: Context): Iterable<any> {
     let state = Object.assign({}, this.state);
     Object.assign(this.state, { isPreformatted: true, htmlSafe: true });
 
@@ -322,7 +322,7 @@ export default class CommonmarkRenderer extends Renderer {
     }
   }
 
-  *'html'(html: HTML): Iterable<any> {
+  *Html(html: HTML): Iterable<any> {
     let state = Object.assign({}, this.state);
     Object.assign(this.state, { isPreformatted: true, htmlSafe: true });
 
@@ -340,7 +340,7 @@ export default class CommonmarkRenderer extends Renderer {
   /**
    * A list item is part of an ordered list or an unordered list.
    */
-  *'list-item'(): Iterable<any> {
+  *ListItem(): Iterable<any> {
     let digit: number = this.state.digit;
     let delimiter = this.state.delimiter;
     let marker: string = delimiter;
@@ -382,7 +382,7 @@ export default class CommonmarkRenderer extends Renderer {
    * 2. A number
    * 3. Of things with numbers preceding them
    */
-  *'list'(list: List, context: Context): Iterable<any> {
+  *List(list: List, context: Context): Iterable<any> {
     let start = 1;
 
     if (list.attributes.startsAt != null) {
@@ -433,7 +433,7 @@ export default class CommonmarkRenderer extends Renderer {
   /**
    * Paragraphs are delimited by two or more newlines in markdown.
    */
-  *'paragraph'(): Iterable<any> {
+  *Paragraph(): Iterable<any> {
     let rawText = yield;
     let text = rawText.join('');
 

--- a/packages/@atjson/renderer-hir/README.md
+++ b/packages/@atjson/renderer-hir/README.md
@@ -1,3 +1,153 @@
-# @atjson/renderer-hir
+# 🌳 @atjson/renderer-hir
 
-A brand new TypeScript library.
+This renderer is designed to render out to hierarchical formats like HTML, markdown, and the DOM.
+
+Renderers use generators to return the content around annotations so each annotation has contextual awareness of what's going on. Render functions are keyed on their annotation `type` (or the classified `type`). In addition, there are 3 special functions that can be overridden:
+
+- `*renderAnnotation`, which will be called for _every_ annotation (even unknown annotations)
+- `*root`, which is the root node of the document being rendered. Overriding this allows for output to be fixed accordingly (for example, `join`ing the `yield`ed contents when the string output is expected to be a string)
+- `text`, which will be called for all text nodes.
+
+## 🖍 Writing a Renderer
+
+Let's write a renderer for Slack! Slack has a simple message format that looks somewhat like markdown (but isn't). We'll use their documentation found [here](https://get.slack.help/hc/en-us/articles/202288908-Format-your-messages) to write this renderer.
+
+First, install the package:
+
+```bash
+npm install --save @atjson/renderer-hir
+```
+
+And import it to the top of the file:
+
+```ts
+import Renderer from '@atjson/renderer-hir';
+
+export default class SlackRenderer extends Renderer {
+}
+```
+
+We have a renderer that will return the text of the document we pass in! (yay!)
+
+Let's make the renderer return a string instead of an array of strings:
+
+```ts
+import Renderer from '@atjson/renderer-hir';
+
+export default class SlackRenderer extends Renderer {
+  *root() {
+    let text = yield;
+    return text.join('');
+  }
+}
+```
+
+Let's start writing tests to verify what we're writing works. For this example we'll be using [🃏Jest](https://jestjs.io) as our testing framework.
+
+We're going to use the `OffsetSource` as our source document and set of annotations, since it's provided with out-of-the-box support for the basic syntax that Slack supports.
+
+```ts
+import OffsetSource from '@atjson/offset-annotations';
+import SlackRenderer from '../src';
+
+describe('SlackRenderer', () => {
+  test('it returns text', () => {
+    let doc = new OffsetSource({
+      content: 'Hello!',
+      annotations: []
+    });
+
+    expect(SlackRenderer.render(doc)).toBe('Hello!');
+  });
+});
+```
+
+Let's add some test cases for this, from their docs:
+
+```ts
+import OffsetSource, { Bold, Italic, Strikethrough } from '@atjson/offset-annotations';
+import SlackRenderer from '../src';
+
+describe('SlackRenderer', () => {
+  test('it returns text', () => { ... });
+
+  test('bold', () => {
+    let doc = new OffsetSource({
+      content: 'To bold, surround your text with asterisks: your text',
+      annotations: [new Bold({ start: 44, end: 53 })]
+    });
+
+    expect(SlackRenderer.render(doc)).toBe('To bold, surround your text with asterisks: *your text*');
+  });
+
+  test('italic', () => {
+    let doc = new OffsetSource({
+      content: 'To italicize, surround your text with underscores: your text',
+      annotations: [new Italic({ start: 51, end: 60 })]
+    });
+
+    expect(SlackRenderer.render(doc)).toBe('To italicize, surround your text with underscores: _your text_');
+  });
+
+  test('strikethrough', () => {
+    let doc = new OffsetSource({
+      content: 'To strikethrough, surround your text with tildes: your text',
+      annotations: [new Italic({ start: 50, end: 59 })]
+    });
+
+    expect(SlackRenderer.render(doc)).toBe('To strikethrough, surround your text with tildes: ~your text~');
+  });
+});
+```
+
+Running tests should result in 3 failing tests.
+
+Now that we have some failing test cases, let's go back to our renderer and implement bold markup:
+
+```ts
+import Renderer from '@atjson/renderer-hir';
+
+export default class SlackRenderer extends Renderer {
+  *Bold() {
+    let text = yield;
+    return `*${text.join('')}*`;
+  }
+
+  *root() {
+    let text = yield;
+    return text.join('');
+  }
+}
+```
+
+We use `Bold` here as a convention to match the class name of the annotation. Alternatively, we can use the key `bold` to generate the markup (it's up to you how you want to write it 😉).
+
+Running tests now should result in 2 failing tests. 🎉
+
+Now that we've got the hang of the first one, let's bang out the other 2 failing tests:
+
+```ts
+import Renderer from '@atjson/renderer-hir';
+
+export default class SlackRenderer extends Renderer {
+  *Bold() {
+    let text = yield;
+    return `*${text.join('')}*`;
+  }
+
+  *Italic() {
+    let text = yield;
+    return `_${text.join('')}_`;
+  }
+
+  *Strikethrough() {
+    let text = yield;
+    return `~${text.join('')}~`;
+  }
+
+  *root() {
+    let text = yield;
+    return text.join('');
+  }
+}
+```

--- a/packages/@atjson/renderer-hir/src/index.ts
+++ b/packages/@atjson/renderer-hir/src/index.ts
@@ -34,6 +34,17 @@ function flatten(array: any[]): any[] {
   return flattenedArray;
 }
 
+// This classify is _specifically_ for our annotation types—
+// casing is ignored, and dashes are the only thing allowed.
+export function classify(type: string) {
+  return type.toLowerCase().split('-').map(word => {
+    if (word.length > 0) {
+      return word[0].toUpperCase() + word.slice(1);
+    }
+    return '';
+  }).join('');
+}
+
 export interface Context {
   parent: Annotation;
   previous: Annotation | null;
@@ -90,7 +101,7 @@ export default class Renderer {
   }
 
   *renderAnnotation(annotation: Annotation, context: Context): IterableIterator<any> {
-    let generator = (this as any)[annotation.type];
+    let generator = (this as any)[annotation.type] || (this as any)[classify(annotation.type)];
     if (generator) {
       return yield* generator.call(this, annotation, context);
     }


### PR DESCRIPTION
This adds a nicety to the HIR renderer so you can use the classified version of the `type` (it also enforces a lowercase convention that @blaine and I discussed briefly)