### PR TITLE
⏱add performance stats to renderer-commonmark

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,12 +19,12 @@ script:
   - npx lerna run lint
   - npx lerna run build
   - npx jest --no-cache --coverage --maxWorkers=4
-
-after_script:
-  - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
   - pushd packages/\@atjson/renderer-commonmark/
   - time npm run performance
   - popd
+
+after_script:
+  - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
 
 after_success:
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ script:
 after_script:
   - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
   - pushd packages/\@atjson/renderer-commonmark/
-  - npm run performance
+  - time npm run performance
   - popd
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ script:
 
 after_script:
   - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
-  - pushd ./packages/\@atjson/renderer-commonmark
+  - pushd packages/\@atjson/renderer-commonmark/
   - npm run performance
   - popd
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,9 @@ script:
 
 after_script:
   - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
+  - pushd ./packages/\@atjson/renderer-commonmark
+  - npm run performance
+  - popd
 
 after_success:
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ script:
   - npx lerna run build
   - npx jest --no-cache --coverage --maxWorkers=4
   - pushd packages/\@atjson/renderer-commonmark/
-  - time npm run performance
+  - time node ./performance/index.js
   - popd
 
 after_script:

--- a/package-lock.json
+++ b/package-lock.json
@@ -140,8 +140,16 @@
       "requires": {
         "@atjson/document": "file:packages/@atjson/document",
         "@atjson/offset-annotations": "file:packages/@atjson/offset-annotations",
+        "@atjson/source-html": "file:packages/@atjson/source-html",
         "@types/sax": "^1.0.1",
+        "entities": "^1.1.2",
         "sax": "^1.2.4"
+      },
+      "dependencies": {
+        "entities": {
+          "version": "1.1.2",
+          "bundled": true
+        }
       }
     },
     "@atjson/source-url": {
@@ -6958,7 +6966,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -6979,12 +6988,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -6999,17 +7010,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -7126,7 +7140,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -7138,6 +7153,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -7152,6 +7168,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -7159,12 +7176,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -7183,6 +7202,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -7263,7 +7283,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -7275,6 +7296,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -7360,7 +7382,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -7396,6 +7419,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -7415,6 +7439,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -7458,12 +7483,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -11236,6 +11263,12 @@
         "yallist": "^2.1.2"
       }
     },
+    "macos-release": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/macos-release/-/macos-release-2.0.0.tgz",
+      "integrity": "sha512-iCM3ZGeqIzlrH7KxYK+fphlJpCCczyHXc+HhRVbEu9uNTCrzYJjvvtefzeKTCVHd5AP/aD/fzC80JZ4ZP+dQ/A==",
+      "dev": true
+    },
     "magic-string": {
       "version": "0.22.5",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.22.5.tgz",
@@ -12298,6 +12331,16 @@
       "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
       "requires": {
         "lcid": "^1.0.0"
+      }
+    },
+    "os-name": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/os-name/-/os-name-3.0.0.tgz",
+      "integrity": "sha512-7c74tib2FsdFbQ3W+qj8Tyd1R3Z6tuVRNNxXjJcZ4NgjIEQU9N/prVMqcW29XZPXGACqaXN3jq58/6hoaoXH6g==",
+      "dev": true,
+      "requires": {
+        "macos-release": "^2.0.0",
+        "windows-release": "^3.1.0"
       }
     },
     "os-tmpdir": {
@@ -18479,6 +18522,45 @@
       "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
       "requires": {
         "string-width": "^1.0.2 || 2"
+      }
+    },
+    "windows-release": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/windows-release/-/windows-release-3.1.0.tgz",
+      "integrity": "sha512-hBb7m7acFgQPQc222uEQTmdcGLeBmQLNLFIh0rDk3CwFOBrfjefLzEfEfmpMq8Af/n/GnFf3eYf203FY1PmudA==",
+      "dev": true,
+      "requires": {
+        "execa": "^0.10.0"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "6.0.5",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+          "dev": true,
+          "requires": {
+            "nice-try": "^1.0.4",
+            "path-key": "^2.0.1",
+            "semver": "^5.5.0",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          }
+        },
+        "execa": {
+          "version": "0.10.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-0.10.0.tgz",
+          "integrity": "sha512-7XOMnz8Ynx1gGo/3hyV9loYNPWM94jG3+3T3Y8tsfSstFmETmENCMU/A/zj8Lyaj1lkgEepKepvd6240tBRvlw==",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "^6.0.0",
+            "get-stream": "^3.0.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
+          }
+        }
       }
     },
     "wordwrap": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "jest": "^23.6.0",
     "lerna": "^3.6.0",
     "markdown-it": "^8.4.1",
+    "os-name": "^3.0.0",
     "parcel-bundler": "^1.10.3",
     "react-dom": "^16.2.0",
     "shelljs": "^0.8.2",

--- a/packages/@atjson/renderer-commonmark/package.json
+++ b/packages/@atjson/renderer-commonmark/package.json
@@ -9,6 +9,7 @@
     "build": "rm -rf dist; tsc -p . && tsc -p . --module ESNext --outDir dist/modules/ --target ES2017",
     "lint": "tslint -c ./tslint.json 'src/**/*.ts'",
     "prepublishOnly": "npm run build",
+    "performance": "node ./performance/index.js > ./performance/README.md",
     "test": "../../../node_modules/.bin/jest packages/@atjson/$(basename $PWD) --config=../../../package.json"
   },
   "license": "Apache-2.0",

--- a/packages/@atjson/renderer-commonmark/performance/README.md
+++ b/packages/@atjson/renderer-commonmark/performance/README.md
@@ -6,8 +6,8 @@ This benchmark was taken on macOS High Sierra on x64 with 8 cores of Intel(R) Co
 
 | Function | Mean | Median | 95th Percentile | Standard Deviation |
 |----------|------|--------|-----------------|--------------------|
-| CommonMarkSource.fromRaw | 0.604ms | 0.491ms | 1.239ms | 0.402ms |
-| CommonMarkSource.convertTo(OffsetSource) | 0.480ms | 0.377ms | 1.009ms | 0.323ms |
-| CommonMarkRenderer.render | 0.409ms | 0.304ms | 0.935ms | 0.344ms |
-| MarkdownIt.render | 0.089ms | 0.074ms | 0.156ms | 0.112ms |
-| Round trip | 1.569ms | 1.328ms | 3.050ms | 0.871ms |
+| CommonMarkSource.fromRaw | 0.388ms | 0.338ms | 0.507ms | 0.236ms |
+| CommonMarkSource.convertTo(OffsetSource) | 0.343ms | 0.280ms | 0.725ms | 0.269ms |
+| CommonMarkRenderer.render | 0.245ms | 0.191ms | 0.568ms | 0.228ms |
+| MarkdownIt.render | 0.029ms | 0.025ms | 0.047ms | 0.031ms |
+| Round trip | 1.023ms | 0.868ms | 2.119ms | 0.546ms |

--- a/packages/@atjson/renderer-commonmark/performance/README.md
+++ b/packages/@atjson/renderer-commonmark/performance/README.md
@@ -5,8 +5,7 @@ This benchmark was taken on Linux 4.4 on x64 with 2 cores of Intel(R) Xeon(R) CP
 
 | Function | Mean | Median | 95th Percentile | Standard Deviation |
 |----------|------|--------|-----------------|--------------------|
-| CommonMarkSource.fromRaw | 0.490ms | 0.409ms | 0.714ms | 0.386ms |
-| CommonMarkSource.convertTo(OffsetSource) | 0.446ms | 0.357ms | 0.931ms | 0.386ms |
-| CommonMarkRenderer.render | 0.305ms | 0.234ms | 0.704ms | 0.305ms |
-| MarkdownIt.render | 0.039ms | 0.034ms | 0.066ms | 0.054ms |
-| Round trip | 1.301ms | 1.074ms | 2.935ms | 0.764ms |
+| CommonMarkSource.fromRaw | 0.514ms | 0.424ms | 0.685ms | 0.450ms |
+| CommonMarkSource.convertTo(OffsetSource) | 0.451ms | 0.361ms | 0.931ms | 0.406ms |
+| CommonMarkRenderer.render | 0.308ms | 0.234ms | 0.699ms | 0.351ms |
+| Round trip | 1.332ms | 1.092ms | 3.121ms | 0.826ms |

--- a/packages/@atjson/renderer-commonmark/performance/README.md
+++ b/packages/@atjson/renderer-commonmark/performance/README.md
@@ -1,13 +1,10 @@
 # ⏱ Performance
-
 The metrics below are taken from the CommonMark specification tests. These are _not_ realistic examples of what you'd find out in the world, but it is a fairly large dataset that runs the code through its paces.
-
-This benchmark was taken on macOS High Sierra on x64 with 8 cores of Intel(R) Core(TM) i7-4870HQ CPU @ 2.50GHz.
-
+This benchmark was taken on Linux 4.4 on x64 with 2 cores of Intel(R) Xeon(R) CPU @ 2.30GHz.
 | Function | Mean | Median | 95th Percentile | Standard Deviation |
 |----------|------|--------|-----------------|--------------------|
-| CommonMarkSource.fromRaw | 0.388ms | 0.338ms | 0.507ms | 0.236ms |
-| CommonMarkSource.convertTo(OffsetSource) | 0.343ms | 0.280ms | 0.725ms | 0.269ms |
-| CommonMarkRenderer.render | 0.245ms | 0.191ms | 0.568ms | 0.228ms |
-| MarkdownIt.render | 0.029ms | 0.025ms | 0.047ms | 0.031ms |
-| Round trip | 1.023ms | 0.868ms | 2.119ms | 0.546ms |
+| CommonMarkSource.fromRaw | 0.490ms | 0.409ms | 0.714ms | 0.386ms |
+| CommonMarkSource.convertTo(OffsetSource) | 0.446ms | 0.357ms | 0.931ms | 0.386ms |
+| CommonMarkRenderer.render | 0.305ms | 0.234ms | 0.704ms | 0.305ms |
+| MarkdownIt.render | 0.039ms | 0.034ms | 0.066ms | 0.054ms |
+| Round trip | 1.301ms | 1.074ms | 2.935ms | 0.764ms |

--- a/packages/@atjson/renderer-commonmark/performance/README.md
+++ b/packages/@atjson/renderer-commonmark/performance/README.md
@@ -1,6 +1,8 @@
 # ⏱ Performance
 The metrics below are taken from the CommonMark specification tests. These are _not_ realistic examples of what you'd find out in the world, but it is a fairly large dataset that runs the code through its paces.
+
 This benchmark was taken on Linux 4.4 on x64 with 2 cores of Intel(R) Xeon(R) CPU @ 2.30GHz.
+
 | Function | Mean | Median | 95th Percentile | Standard Deviation |
 |----------|------|--------|-----------------|--------------------|
 | CommonMarkSource.fromRaw | 0.490ms | 0.409ms | 0.714ms | 0.386ms |

--- a/packages/@atjson/renderer-commonmark/performance/README.md
+++ b/packages/@atjson/renderer-commonmark/performance/README.md
@@ -4,10 +4,10 @@ The metrics below are taken from the CommonMark specification tests. These are _
 
 This benchmark was taken on macOS High Sierra on x64 with 8 cores of Intel(R) Core(TM) i7-4870HQ CPU @ 2.50GHz.
 
-| Function | Median | 95th Percentile | Standard Deviation |
-|----------|--------|-----------------|--------------------|
-| CommonMarkSource.fromRaw | 0.428ms | 1.043ms | 0.356ms |
-| CommonMarkSource.convertTo(OffsetSource) | 0.327ms | 0.940ms | 0.300ms |
-| CommonMarkRenderer.render | 0.250ms | 0.851ms | 0.312ms |
-| MarkdownIt.render | 0.061ms | 0.128ms | 0.095ms |
-| Round trip | 1.115ms | 2.659ms | 0.783ms |
+| Function | Mean | Median | 95th Percentile | Standard Deviation |
+|----------|------|--------|-----------------|--------------------|
+| CommonMarkSource.fromRaw | 0.604ms | 0.491ms | 1.239ms | 0.402ms |
+| CommonMarkSource.convertTo(OffsetSource) | 0.480ms | 0.377ms | 1.009ms | 0.323ms |
+| CommonMarkRenderer.render | 0.409ms | 0.304ms | 0.935ms | 0.344ms |
+| MarkdownIt.render | 0.089ms | 0.074ms | 0.156ms | 0.112ms |
+| Round trip | 1.569ms | 1.328ms | 3.050ms | 0.871ms |

--- a/packages/@atjson/renderer-commonmark/performance/README.md
+++ b/packages/@atjson/renderer-commonmark/performance/README.md
@@ -1,0 +1,13 @@
+# ⏱ Performance
+
+The metrics below are taken from the CommonMark specification tests. These are _not_ realistic examples of what you'd find out in the world, but it is a fairly large dataset that runs the code through its paces.
+
+This benchmark was taken on macOS High Sierra on x64 with 8 cores of Intel(R) Core(TM) i7-4870HQ CPU @ 2.50GHz.
+
+| Function | Median | 95th Percentile | Standard Deviation |
+|----------|--------|-----------------|--------------------|
+| CommonMarkSource.fromRaw | 0.428ms | 1.043ms | 0.356ms |
+| CommonMarkSource.convertTo(OffsetSource) | 0.327ms | 0.940ms | 0.300ms |
+| CommonMarkRenderer.render | 0.250ms | 0.851ms | 0.312ms |
+| MarkdownIt.render | 0.061ms | 0.128ms | 0.095ms |
+| Round trip | 1.115ms | 2.659ms | 0.783ms |

--- a/packages/@atjson/renderer-commonmark/performance/index.js
+++ b/packages/@atjson/renderer-commonmark/performance/index.js
@@ -1,0 +1,104 @@
+const OffsetSource = require('@atjson/offset-annotations').default;
+const CommonMarkSource = require('@atjson/source-commonmark').default;
+const spec = require('commonmark-spec');
+const MarkdownIt = require('markdown-it');
+const { performance } = require('perf_hooks');
+const CommonMarkRenderer = require('../dist/commonjs/index').default;
+const os = require('os');
+const osName = require('os-name');
+
+const skippedTests = [
+  140, // Additional newline in HTML block
+  491  // Alt text that is never used
+];
+
+class Statistics {
+  constructor(name) {
+    this.name = name;
+    this.entries = performance.getEntriesByName(name).sort((a, b) => a.duration - b.duration);
+  }
+
+  // Not completely correct, but it's good enough for this
+  percentile(percent) {
+    let index = (this.entries.length - 1) * percent;
+    return this.entries[Math.floor(index)].duration;
+  }
+
+  get median() {
+    return this.percentile(0.5);
+  }
+
+  get average() {
+    return this.entries.reduce((totalTime, entry) => {
+      return totalTime + entry.duration;
+    }, 0) / this.entries.length;
+  }
+
+  get standardDeviation() {
+    let average = this.average;
+
+    let squaredDifferences = this.entries.map((entry) => {
+      var diff = entry.duration - average;
+      return diff * diff;
+    });
+
+    let averageOfSquaredDifferences = squaredDifferences.reduce((E, diff) => {
+      return E + diff;
+    }, 0) / squaredDifferences.length;
+
+    return Math.sqrt(averageOfSquaredDifferences);
+  }
+}
+
+function measure(name, fn) {
+  performance.mark('⏱');
+  let result = fn();
+  performance.mark('🏁');
+  performance.measure(name, '⏱', '🏁');
+  performance.clearMarks('⏱');
+  performance.clearMarks('🏁');
+  return result;
+}
+
+performance.maxEntries = spec.tests.length * 5;
+spec.tests.forEach((unitTest) => {
+  let md = MarkdownIt('commonmark');
+
+  let shouldSkip = skippedTests.indexOf(unitTest.number) !== -1;
+  if (shouldSkip) {
+    return;
+  }
+
+  performance.mark('start');
+  let markdown = unitTest.markdown.replace(/→/g, '\t');
+  let original = measure('CommonMarkSource.fromRaw', () => CommonMarkSource.fromRaw(markdown));
+  let converted = measure('CommonMarkSource.convertTo(OffsetSource)', () => original.convertTo(OffsetSource));
+  let generatedMarkdown = measure('CommonMarkRenderer.render', () => CommonMarkRenderer.render(converted));
+  performance.mark('end');
+  performance.measure('Round trip', 'start', 'end');
+  performance.clearMarks();
+
+  measure('MarkdownIt.render', () => md.render(generatedMarkdown));
+});
+
+console.log(
+  [
+    '# ⏱ Performance',
+    '',
+    `The metrics below are taken from the CommonMark specification tests. These are _not_ realistic examples of what you'd find out in the world, but it is a fairly large dataset that runs the code through its paces.`,
+    '',
+    `This benchmark was taken on ${osName(os.platform(), os.release())} on ${os.arch()} with ${os.cpus().length} cores of ${os.cpus()[0].model}.`,
+    '',
+    '| Function | Median | 95th Percentile | Standard Deviation |',
+    '|----------|--------|-----------------|--------------------|',
+    ...[
+      new Statistics('CommonMarkSource.fromRaw'),
+      new Statistics('CommonMarkSource.convertTo(OffsetSource)'),
+      new Statistics('CommonMarkRenderer.render'),
+      new Statistics('MarkdownIt.render'),
+      new Statistics('Round trip')
+    ].map(stats => {
+      return `| ${stats.name} | ${stats.median.toFixed(3)}ms | ${stats.percentile(0.95).toFixed(3)}ms | ${stats.standardDeviation.toFixed(3)}ms |`;
+    })
+  ].join('\n')
+);

--- a/packages/@atjson/renderer-commonmark/performance/index.js
+++ b/packages/@atjson/renderer-commonmark/performance/index.js
@@ -60,26 +60,28 @@ function measure(name, fn) {
   return result;
 }
 
-performance.maxEntries = spec.tests.length * 5;
-spec.tests.forEach((unitTest) => {
-  let md = MarkdownIt('commonmark');
+performance.maxEntries = spec.tests.length * 500;
+for (let i = 0; i < 100; i++) {
+  spec.tests.forEach((unitTest) => {
+    let md = MarkdownIt('commonmark');
 
-  let shouldSkip = skippedTests.indexOf(unitTest.number) !== -1;
-  if (shouldSkip) {
-    return;
-  }
+    let shouldSkip = skippedTests.indexOf(unitTest.number) !== -1;
+    if (shouldSkip) {
+      return;
+    }
 
-  performance.mark('start');
-  let markdown = unitTest.markdown.replace(/→/g, '\t');
-  let original = measure('CommonMarkSource.fromRaw', () => CommonMarkSource.fromRaw(markdown));
-  let converted = measure('CommonMarkSource.convertTo(OffsetSource)', () => original.convertTo(OffsetSource));
-  let generatedMarkdown = measure('CommonMarkRenderer.render', () => CommonMarkRenderer.render(converted));
-  performance.mark('end');
-  performance.measure('Round trip', 'start', 'end');
-  performance.clearMarks();
+    performance.mark('start');
+    let markdown = unitTest.markdown.replace(/→/g, '\t');
+    let original = measure('CommonMarkSource.fromRaw', () => CommonMarkSource.fromRaw(markdown));
+    let converted = measure('CommonMarkSource.convertTo(OffsetSource)', () => original.convertTo(OffsetSource));
+    let generatedMarkdown = measure('CommonMarkRenderer.render', () => CommonMarkRenderer.render(converted));
+    performance.mark('end');
+    performance.measure('Round trip', 'start', 'end');
+    performance.clearMarks();
 
-  measure('MarkdownIt.render', () => md.render(generatedMarkdown));
-});
+    measure('MarkdownIt.render', () => md.render(generatedMarkdown));
+  });
+}
 
 console.log(
   [

--- a/packages/@atjson/renderer-commonmark/performance/index.js
+++ b/packages/@atjson/renderer-commonmark/performance/index.js
@@ -28,17 +28,17 @@ class Statistics {
     return this.percentile(0.5);
   }
 
-  get average() {
+  get mean() {
     return this.entries.reduce((totalTime, entry) => {
       return totalTime + entry.duration;
     }, 0) / this.entries.length;
   }
 
   get standardDeviation() {
-    let average = this.average;
+    let mean = this.mean;
 
     let squaredDifferences = this.entries.map((entry) => {
-      var diff = entry.duration - average;
+      var diff = entry.duration - mean;
       return diff * diff;
     });
 
@@ -89,8 +89,8 @@ console.log(
     '',
     `This benchmark was taken on ${osName(os.platform(), os.release())} on ${os.arch()} with ${os.cpus().length} cores of ${os.cpus()[0].model}.`,
     '',
-    '| Function | Median | 95th Percentile | Standard Deviation |',
-    '|----------|--------|-----------------|--------------------|',
+    '| Function | Mean | Median | 95th Percentile | Standard Deviation |',
+    '|----------|------|--------|-----------------|--------------------|',
     ...[
       new Statistics('CommonMarkSource.fromRaw'),
       new Statistics('CommonMarkSource.convertTo(OffsetSource)'),
@@ -98,7 +98,7 @@ console.log(
       new Statistics('MarkdownIt.render'),
       new Statistics('Round trip')
     ].map(stats => {
-      return `| ${stats.name} | ${stats.median.toFixed(3)}ms | ${stats.percentile(0.95).toFixed(3)}ms | ${stats.standardDeviation.toFixed(3)}ms |`;
+      return `| ${stats.name} | ${stats.mean.toFixed(3)}ms | ${stats.median.toFixed(3)}ms | ${stats.percentile(0.95).toFixed(3)}ms | ${stats.standardDeviation.toFixed(3)}ms |`;
     })
   ].join('\n')
 );

--- a/packages/@atjson/renderer-commonmark/performance/index.js
+++ b/packages/@atjson/renderer-commonmark/performance/index.js
@@ -60,7 +60,7 @@ function measure(name, fn) {
   return result;
 }
 
-performance.maxEntries = spec.tests.length * 500;
+performance.maxEntries = spec.tests.length * 400;
 for (let i = 0; i < 100; i++) {
   spec.tests.forEach((unitTest) => {
     let md = MarkdownIt('commonmark');
@@ -78,8 +78,6 @@ for (let i = 0; i < 100; i++) {
     performance.mark('end');
     performance.measure('Round trip', 'start', 'end');
     performance.clearMarks();
-
-    measure('MarkdownIt.render', () => md.render(generatedMarkdown));
   });
 }
 
@@ -97,7 +95,6 @@ console.log(
       new Statistics('CommonMarkSource.fromRaw'),
       new Statistics('CommonMarkSource.convertTo(OffsetSource)'),
       new Statistics('CommonMarkRenderer.render'),
-      new Statistics('MarkdownIt.render'),
       new Statistics('Round trip')
     ].map(stats => {
       return `| ${stats.name} | ${stats.mean.toFixed(3)}ms | ${stats.median.toFixed(3)}ms | ${stats.percentile(0.95).toFixed(3)}ms | ${stats.standardDeviation.toFixed(3)}ms |`;


### PR DESCRIPTION
This adds a performance testing to `renderer-commonmark` so we have a baseline for round-trip conversions and alterations to markdown.

I'm also horrible at statistics, so I *hope* what I wrote is correct 😓 