### PR TITLE
Better delimiter fix

### DIFF
--- a/packages/@atjson/renderer-commonmark/src/index.ts
+++ b/packages/@atjson/renderer-commonmark/src/index.ts
@@ -13,9 +13,9 @@ function getPreviousChar(doc: Document, end: number) {
   let start = end;
 
   while (start > 0) {
-    let parseAnnotations = doc.where(a => a.end === start && a instanceof ParseAnnotation);
+    let parseAnnotations = doc.where(a => a instanceof ParseAnnotation && a.end >= start && a.start < start);
     if (parseAnnotations.length) {
-      start = parseAnnotations.annotations[0].start;
+      start = Math.min(...parseAnnotations.annotations.map(a => a.start));
     } else {
       break;
     }
@@ -36,9 +36,9 @@ function getNextChar(doc: Document, start: number) {
   let end = start;
 
   while (end < doc.content.length) {
-    let parseAnnotations = doc.where(a => a.start === end && a instanceof ParseAnnotation);
+    let parseAnnotations = doc.where(a => a instanceof ParseAnnotation && a.start <= end && a.end > end);
     if (parseAnnotations.length) {
-      end = parseAnnotations.annotations[0].end;
+      end = Math.max(...parseAnnotations.annotations.map(a => a.end));
     } else {
       break;
     }

--- a/packages/@atjson/renderer-commonmark/src/index.ts
+++ b/packages/@atjson/renderer-commonmark/src/index.ts
@@ -1,4 +1,4 @@
-import Document, { Annotation, ParseAnnotation } from '@atjson/document';
+import Document, { Annotation, ParseAnnotation, UnknownAnnotation } from '@atjson/document';
 import { Bold, Code, HTML, Heading, Image, Italic, Link, List } from '@atjson/offset-annotations';
 import Renderer, { Context } from '@atjson/renderer-hir';
 import {
@@ -22,7 +22,7 @@ function getPreviousChar(doc: Document, end: number) {
   }
 
   let wrappingAnnotations = doc
-    .where(a => !(a instanceof ParseAnnotation))
+    .where(a => !(a instanceof ParseAnnotation || a instanceof UnknownAnnotation))
     .where(a => (a.start >= start && a.start < end) || (a.end >= start && a.end <= end));
 
   if (wrappingAnnotations.length) {
@@ -45,7 +45,7 @@ function getNextChar(doc: Document, start: number) {
   }
 
   let wrappingAnnotations = doc
-    .where(a => !(a instanceof ParseAnnotation))
+    .where(a => !(a instanceof ParseAnnotation || a instanceof UnknownAnnotation))
     .where(a => (a.start >= start && a.start <= end) || (a.end > start && a.end <= end));
 
   if (wrappingAnnotations.length) {

--- a/packages/@atjson/renderer-commonmark/test/commonmark-test.ts
+++ b/packages/@atjson/renderer-commonmark/test/commonmark-test.ts
@@ -383,6 +383,23 @@ After all the lists
         expect(CommonMarkRenderer.render(document).trim()).toBe(md);
       });
 
+      // *a.*^b^ -> *a*.b if superscript annotations are unsupported
+      test('wrapping adjacent characters in an unknown annotation does not preserve boundary punctuation', () => {
+        let document = new OffsetSource({
+          content: '*a.*^b^',
+          annotations: [
+            { id: '1', type: '-atjson-parse-token', start: 0, end: 1, attributes: {} },
+            { id: '1', type: '-offset-italic', start: 0, end: 4, attributes: {} },
+            { id: '1', type: '-atjson-parse-token', start: 3, end: 4, attributes: {} },
+            { id: '1', type: '-atjson-parse-token', start: 4, end: 5, attributes: {} },
+            { id: '1', type: '-atjson-unknown', start: 4, end: 7, attributes: {} },
+            { id: '1', type: '-atjson-parse-token', start: 6, end: 7, attributes: {} },
+          ]
+        });
+
+        expect(CommonMarkRenderer.render(document)).toBe('*a*.b');
+      });
+
       // This is a weird case in that it results in asymmetric parens, but is probably the
       // most correct thing to do
       // a—*(italic)*non-italic -> a—*(italic*)non-italic

--- a/packages/@atjson/renderer-commonmark/test/commonmark-test.ts
+++ b/packages/@atjson/renderer-commonmark/test/commonmark-test.ts
@@ -374,6 +374,15 @@ After all the lists
         expect(CommonMarkRenderer.render(document)).toBe(md);
       });
 
+      // **bold:**[link](http://url.com)
+      test('wrapping adjacent characters in an annotation preserves boundary punctuation', () => {
+        let md = '**bold:**[link](http://url.com)';
+        let mdDoc = CommonMarkSource.fromRaw(md);
+        let document = mdDoc.convertTo(OffsetSource);
+
+        expect(CommonMarkRenderer.render(document).trim()).toBe(md);
+      });
+
       // This is a weird case in that it results in asymmetric parens, but is probably the
       // most correct thing to do
       // a—*(italic)*non-italic -> a—*(italic*)non-italic
@@ -450,7 +459,7 @@ After all the lists
 
       // **bold**_, then italic_ -> **bold**, *then italic*
       // _italic_**, then bold** -> _italic_, **then bold**
-      test('punctuation and whitespace are pushed out together', () => {
+      test('adjacent bold and italic preserve boundary punctuation and are rendered correctly', () => {
         let document = new OffsetSource({
           content: '\uFFFCbold\uFFFC\uFFFC, then italic\uFFFC\n\uFFFCitalic\uFFFC\uFFFC, then bold\uFFFC\n',
           annotations: [
@@ -473,7 +482,7 @@ After all the lists
           ]
         });
 
-        expect(CommonMarkRenderer.render(document)).toBe('**bold**, *then italic*\n\n_italic_, **then bold**\n\n');
+        expect(CommonMarkRenderer.render(document)).toBe('**bold**_, then italic_\n\n_italic_**, then bold**\n\n');
       });
     });
 

--- a/packages/@atjson/renderer-commonmark/test/commonmark-test.ts
+++ b/packages/@atjson/renderer-commonmark/test/commonmark-test.ts
@@ -1,6 +1,6 @@
 import OffsetSource from '@atjson/offset-annotations';
-import CommonMarkSource from '@atjson/source-commonmark';
-import CommonMarkRenderer from '../src';
+import CommonmarkSource from '@atjson/source-commonmark';
+import CommonmarkRenderer from '../src';
 
 describe('commonmark', () => {
   test('raw atjson document', () => {
@@ -12,7 +12,7 @@ describe('commonmark', () => {
       ]
     });
 
-    expect(CommonMarkRenderer.render(document)).toBe('Some text that is both **bold *and*** *italic* plus something after.');
+    expect(CommonmarkRenderer.render(document)).toBe('Some text that is both **bold *and*** *italic* plus something after.');
   });
 
   test('images', () => {
@@ -26,7 +26,7 @@ describe('commonmark', () => {
         attributes: {
           '-offset-url': 'http://commonmark.org/images/markdown-mark.png',
           '-offset-description': {
-            content: 'CommonMark!',
+            content: 'Commonmark!',
             annotations: [{
               id: '2',
               type: '-offset-bold',
@@ -39,7 +39,7 @@ describe('commonmark', () => {
       }]
     });
 
-    expect(CommonMarkRenderer.render(document)).toBe('![**CommonMark**\\!](http://commonmark.org/images/markdown-mark.png)');
+    expect(CommonmarkRenderer.render(document)).toBe('![**Commonmark**\\!](http://commonmark.org/images/markdown-mark.png)');
   });
 
   test('a plain text document with virtual paragraphs', () => {
@@ -53,7 +53,7 @@ describe('commonmark', () => {
       ]
     });
 
-    expect(CommonMarkRenderer.render(document)).toBe(
+    expect(CommonmarkRenderer.render(document)).toBe(
                  'A paragraph with some **bold**\n\n**text** that continues into the next.\n\n');
   });
 
@@ -83,7 +83,7 @@ describe('commonmark', () => {
       ]
     });
 
-    expect(CommonMarkRenderer.render(document)).toBe(
+    expect(CommonmarkRenderer.render(document)).toBe(
                  `I have a list:
 
 1. First item plus **bold** text
@@ -110,7 +110,7 @@ After all the lists
       }]
     });
 
-    expect(CommonMarkRenderer.render(document)).toBe('I have a [link](https://example.com)');
+    expect(CommonmarkRenderer.render(document)).toBe('I have a [link](https://example.com)');
   });
 
   describe('blockquote', () => {
@@ -126,7 +126,7 @@ After all the lists
         }]
       });
 
-      expect(CommonMarkRenderer.render(document)).toBe('> This is a quote\n> \n> That has some\n> lines in it.\n\n');
+      expect(CommonmarkRenderer.render(document)).toBe('> This is a quote\n> \n> That has some\n> lines in it.\n\n');
     });
 
     test('with a paragraph', () => {
@@ -153,7 +153,7 @@ After all the lists
         }]
       });
 
-      expect(CommonMarkRenderer.render(document)).toBe('> This is a quote\n\nAnd this is not.\n\n');
+      expect(CommonmarkRenderer.render(document)).toBe('> This is a quote\n\nAnd this is not.\n\n');
     });
 
     test('with flanking whitespace', () => {
@@ -180,7 +180,7 @@ After all the lists
         }]
       });
 
-      expect(CommonMarkRenderer.render(document)).toBe('> This is a quote\n\nAnd this is not.\n\n');
+      expect(CommonmarkRenderer.render(document)).toBe('> This is a quote\n\nAnd this is not.\n\n');
     });
 
     test('with surrounding paragraphs', () => {
@@ -225,7 +225,7 @@ After all the lists
         }]
       });
 
-      expect(CommonMarkRenderer.render(document)).toBe('This is some text\n\n> This is a quote\n\nAnd this is not.\n\n');
+      expect(CommonmarkRenderer.render(document)).toBe('This is some text\n\n> This is a quote\n\nAnd this is not.\n\n');
     });
   });
 
@@ -239,7 +239,7 @@ After all the lists
       ]
     });
 
-    expect(CommonMarkRenderer.render(document)).toBe('x\n\n***\ny\n\n');
+    expect(CommonmarkRenderer.render(document)).toBe('x\n\n***\ny\n\n');
   });
 
   test('headlines', () => {
@@ -256,7 +256,7 @@ After all the lists
       }]
     });
 
-    expect(CommonMarkRenderer.render(document)).toBe('# Banner\n## Headline\n');
+    expect(CommonmarkRenderer.render(document)).toBe('# Banner\n## Headline\n');
   });
 
   test('moves spaces at annotation boundaries to the outside', () => {
@@ -269,7 +269,7 @@ After all the lists
       }]
     });
 
-    expect(CommonMarkRenderer.render(document)).toBe('This is **bold** text and a [link](https://example.com).');
+    expect(CommonmarkRenderer.render(document)).toBe('This is **bold** text and a [link](https://example.com).');
   });
 
   test('unambiguous nesting of bold and italic', () => {
@@ -294,7 +294,7 @@ After all the lists
       }]
     });
 
-    expect(CommonMarkRenderer.render(document)).toBe('**_bold then italic_** *__italic then bold__*');
+    expect(CommonmarkRenderer.render(document)).toBe('**_bold then italic_** *__italic then bold__*');
   });
 
   test('adjacent bold and italic annotations are given unique markdown makers', () => {
@@ -335,7 +335,7 @@ After all the lists
       }]
     });
 
-    expect(CommonMarkRenderer.render(document)).toBe('**bold**_then italic_\n\n_italic_**then bold**\n\n');
+    expect(CommonmarkRenderer.render(document)).toBe('**bold**_then italic_\n\n_italic_**then bold**\n\n');
   });
 
   describe('boundary punctuation', () => {
@@ -350,7 +350,7 @@ After all the lists
           }]
         });
 
-        expect(CommonMarkRenderer.render(document)).toBe('a—*italic*—non-italic');
+        expect(CommonmarkRenderer.render(document)).toBe('a—*italic*—non-italic');
       });
 
       // [link.](https://some-url.com)a
@@ -362,25 +362,25 @@ After all the lists
           }]
         });
 
-        expect(CommonMarkRenderer.render(document)).toBe('[link.](https://some-url.com)a');
+        expect(CommonmarkRenderer.render(document)).toBe('[link.](https://some-url.com)a');
       });
 
       // *[menu.as](https://menu.as/)*\n\n\n\n__Missoni Partners with Donghia__\n\n
       test('delimiters wrapping links are not parsed as punctuation at paragraph boundaries', () => {
         let md = '*[menu.as](https://menu.as/)*\n\n**Missoni Partners with Donghia**\n\n';
-        let mdDoc = CommonMarkSource.fromRaw(md);
+        let mdDoc = CommonmarkSource.fromRaw(md);
         let document = mdDoc.convertTo(OffsetSource);
 
-        expect(CommonMarkRenderer.render(document)).toBe(md);
+        expect(CommonmarkRenderer.render(document)).toBe(md);
       });
 
       // **bold:**[link](http://url.com)
       test('wrapping adjacent characters in an annotation preserves boundary punctuation', () => {
         let md = '**bold:**[link](http://url.com)';
-        let mdDoc = CommonMarkSource.fromRaw(md);
+        let mdDoc = CommonmarkSource.fromRaw(md);
         let document = mdDoc.convertTo(OffsetSource);
 
-        expect(CommonMarkRenderer.render(document).trim()).toBe(md);
+        expect(CommonmarkRenderer.render(document).trim()).toBe(md);
       });
 
       // *a.*^b^ -> *a*.b if superscript annotations are unsupported
@@ -397,7 +397,7 @@ After all the lists
           ]
         });
 
-        expect(CommonMarkRenderer.render(document)).toBe('*a*.b');
+        expect(CommonmarkRenderer.render(document)).toBe('*a*.b');
       });
 
       // This is a weird case in that it results in asymmetric parens, but is probably the
@@ -411,7 +411,7 @@ After all the lists
           }]
         });
 
-        expect(CommonMarkRenderer.render(document)).toBe('a—*(italic*)non-italic');
+        expect(CommonmarkRenderer.render(document)).toBe('a—*(italic*)non-italic');
       });
 
       // *italic]*non-italic -> *italic*\]non-italic
@@ -423,7 +423,7 @@ After all the lists
           }]
         });
 
-        expect(CommonMarkRenderer.render(document)).toBe('*italic*\\]non-italic');
+        expect(CommonmarkRenderer.render(document)).toBe('*italic*\\]non-italic');
       });
 
       // *italic\]*non-italic -> *italic\\*\]non-italic
@@ -435,7 +435,7 @@ After all the lists
           }]
         });
 
-        expect(CommonMarkRenderer.render(document)).toBe('*italic\\\\*\\]non-italic');
+        expect(CommonmarkRenderer.render(document)).toBe('*italic\\\\*\\]non-italic');
       });
 
       // *italic..*non-italic -> *italic.*.non-italic
@@ -447,7 +447,7 @@ After all the lists
           }]
         });
 
-        expect(CommonMarkRenderer.render(document)).toBe('*italic.*.non-italic');
+        expect(CommonmarkRenderer.render(document)).toBe('*italic.*.non-italic');
       });
 
       // *italic&*non-italic -> *italic*&amp;non-italic
@@ -459,7 +459,7 @@ After all the lists
           }]
         });
 
-        expect(CommonMarkRenderer.render(document)).toBe('*italic*&amp;non-italic');
+        expect(CommonmarkRenderer.render(document)).toBe('*italic*&amp;non-italic');
       });
 
       // a*&}italic&]*non-italic -> a&amp;*\}italic&amp;*\]non-italic
@@ -471,7 +471,7 @@ After all the lists
           }]
         });
 
-        expect(CommonMarkRenderer.render(document)).toBe('a&amp;*\\}italic&amp;*\\]non-italic');
+        expect(CommonmarkRenderer.render(document)).toBe('a&amp;*\\}italic&amp;*\\]non-italic');
       });
 
       // **bold**_, then italic_ -> **bold**, *then italic*
@@ -499,7 +499,7 @@ After all the lists
           ]
         });
 
-        expect(CommonMarkRenderer.render(document)).toBe('**bold**_, then italic_\n\n_italic_**, then bold**\n\n');
+        expect(CommonmarkRenderer.render(document)).toBe('**bold**_, then italic_\n\n_italic_**, then bold**\n\n');
       });
     });
 
@@ -512,7 +512,7 @@ After all the lists
           }]
         });
 
-        expect(CommonMarkRenderer.render(document)).toBe(' *—italic—* non-italic');
+        expect(CommonmarkRenderer.render(document)).toBe(' *—italic—* non-italic');
       });
 
       // `  *—italic— * non-italic` -> `  *-italic-*  non-italic`
@@ -524,7 +524,7 @@ After all the lists
           }]
         });
 
-        expect(CommonMarkRenderer.render(document)).toBe('  *—italic—*  non-italic');
+        expect(CommonmarkRenderer.render(document)).toBe('  *—italic—*  non-italic');
       });
     });
 
@@ -539,7 +539,7 @@ After all the lists
           }]
         });
 
-        expect(CommonMarkRenderer.render(document)).toBe('*—italic*—a—**bold—**');
+        expect(CommonmarkRenderer.render(document)).toBe('*—italic*—a—**bold—**');
       });
 
       // `* —italic— *` -> ` *—italic—* `
@@ -551,7 +551,7 @@ After all the lists
           }]
         });
 
-        expect(CommonMarkRenderer.render(document)).toBe(' *—italic—* ');
+        expect(CommonmarkRenderer.render(document)).toBe(' *—italic—* ');
       });
     });
   });
@@ -566,7 +566,7 @@ After all the lists
       }]
     });
 
-    expect(CommonMarkRenderer.render(document)).toBe('Some formatting on empty spaces');
+    expect(CommonmarkRenderer.render(document)).toBe('Some formatting on empty spaces');
   });
 
   test('non-breaking spaces don\'t receive formatting', () => {
@@ -585,7 +585,7 @@ After all the lists
       }]
     });
 
-    expect(CommonMarkRenderer.render(document)).toBe('&nbsp;\n\n**text**\n\n\u202F');
+    expect(CommonmarkRenderer.render(document)).toBe('&nbsp;\n\n**text**\n\n\u202F');
   });
 
   test('line feed characters don\'t recieve formatting', () => {
@@ -604,7 +604,7 @@ After all the lists
       }]
     });
 
-    expect(CommonMarkRenderer.render(document)).toBe('\u000b\n\n**text**\n\n');
+    expect(CommonmarkRenderer.render(document)).toBe('\u000b\n\n**text**\n\n');
   });
 
   test('tabs and leading / trailing spaces are stripped from output', () => {
@@ -617,11 +617,11 @@ After all the lists
       }]
     });
 
-    let markdown = CommonMarkRenderer.render(document);
+    let markdown = CommonmarkRenderer.render(document);
 
-    expect(CommonMarkRenderer.render(document)).toBe('Hello\n\nThis is my text\n\n');
+    expect(CommonmarkRenderer.render(document)).toBe('Hello\n\nThis is my text\n\n');
     // Make sure we're not generating code in the round-trip
-    expect(markdown).toEqual(CommonMarkRenderer.render(CommonMarkSource.fromRaw(markdown).convertTo(OffsetSource)));
+    expect(markdown).toEqual(CommonmarkRenderer.render(CommonmarkSource.fromRaw(markdown).convertTo(OffsetSource)));
   });
 
   describe('escape sequences', () => {
@@ -637,7 +637,7 @@ After all the lists
           annotations: []
         });
 
-        expect(CommonMarkRenderer.render(document)).toBe(text);
+        expect(CommonmarkRenderer.render(document)).toBe(text);
       });
     });
 
@@ -653,7 +653,7 @@ After all the lists
           annotations: []
         });
 
-        expect(CommonMarkRenderer.render(document)).toBe(text);
+        expect(CommonmarkRenderer.render(document)).toBe(text);
       });
     });
   });

--- a/packages/@atjson/source-commonmark/src/parser.ts
+++ b/packages/@atjson/source-commonmark/src/parser.ts
@@ -170,17 +170,7 @@ export default class Parser {
 
     let closingToken = yield;
 
-    // For paragraphs, apply the parse annotation over a newline
-    // character rather than an object replacement character.
-    // This is because properly rendering delimiter runs requires
-    // checking adjacent characters which will skip ORCs but not
-    // newlines. This may be necessary for any annotation which
-    // renders whitespace/newlines at its edges
-    if (name === 'paragraph') {
-      this.content += '\n';
-    } else {
-      this.content += '\uFFFC';
-    }
+    this.content += '\uFFFC';
 
     let end = this.content.length;
     let attributes = Object.assign(getAttributes(open), attrs || {});


### PR DESCRIPTION
🐝 Better fix for delimiter runs  …
Instead of looking for & skipping over ORCs when looking for adjacent
characters, skip over ParseAnnotations.

When checking the adjacent character, we can preserve boundary
punctuation if a non-parse annotation begins or ends in the region
between the boundary punctuation and the adjacent character, as that
annotation will insert either a new line or other punctuation character
between them

🐝 Revert previous change in favor of better fix