### PR TITLE
🐝 Preserve space before sentence-terminating number

### DIFF
--- a/packages/@atjson/renderer-commonmark/src/index.ts
+++ b/packages/@atjson/renderer-commonmark/src/index.ts
@@ -131,7 +131,7 @@ function escapePunctuation(text: string) {
                     .replace(/(\[)([^\]]*$)/g, '\\$1$2')          // Escape bare opening brackets [
                     .replace(/(^[^\[]*)(\].*$)/g, '$1\\$2')       // Escape bare closing brackets ]
                     .replace(/(\]\()/g, ']\\(')                   // Escape parenthesis ](
-                    .replace(/^\s*(\d+)\.(\s+)/gm, '$1\\.$2')     // Escape list items; not all numbers
+                    .replace(/^(\s*\d+)\.(\s+)/gm, '$1\\.$2')     // Escape list items; not all numbers
                     .replace(/(^[\s]*)-/g, '$1\\-')               // `  - list item`
                     .replace(/(\r\n|\r|\n)([\s]*)-/g, '$1$2\\-'); // `- list item\n - list item`
   return escapeEntities(escaped);

--- a/packages/@atjson/renderer-commonmark/test/commonmark-test.ts
+++ b/packages/@atjson/renderer-commonmark/test/commonmark-test.ts
@@ -96,6 +96,19 @@ After all the lists
 `);
   });
 
+  test('avoid parsing sentence ending in italic + number as a list.', () => {
+    let document = new OffsetSource({
+      content: 'Sentence ending in *italic* 1. New sentence',
+      annotations: [
+        { type: '-offset-italic', start: 19, end: 27, attributes: {} },
+        { type: '-atjson-parse-token', start: 19, end: 20, attributes: {} },
+        { type: '-atjson-parse-token', start: 26, end: 27, attributes: {} }
+      ]
+    });
+
+    expect(CommonmarkRenderer.render(document)).toBe('Sentence ending in *italic* 1\\. New sentence');
+  });
+
   test('links', () => {
     let document = new OffsetSource({
       content: 'I have a link',

--- a/packages/@atjson/renderer-commonmark/test/commonmark-test.ts
+++ b/packages/@atjson/renderer-commonmark/test/commonmark-test.ts
@@ -96,7 +96,7 @@ After all the lists
 `);
   });
 
-  test('avoid parsing sentence ending in italic + number as a list.', () => {
+  test('preserve space between sentence-terminating italic + number.', () => {
     let document = new OffsetSource({
       content: 'Sentence ending in *italic* 1. New sentence',
       annotations: [


### PR DESCRIPTION
When escaping text that looks like a markdown ordered list, we want to
preserve leading whitespace. This fixes a bug where a sentence ending
with an italic and then a number would have the space between them
removed, as the end of the sentence is rendered as text but looks like
ordered list markdown:
`Ending with *italic* 1. ` -> `Ending with *italic*1\.`
We still have to escape the terminal period, but now it will render as
`Ending with *italic* 1. ` -> `Ending with *italic* 1\.` with the space
preserved.