### PR TITLE
🐛 Reify unknown annotations when passing them into `createAnnotation`

### DIFF
--- a/packages/@atjson/document/src/index.ts
+++ b/packages/@atjson/document/src/index.ts
@@ -298,7 +298,17 @@ export default class Document {
     let DocumentClass = this.constructor as typeof Document;
     let schema = [...DocumentClass.schema, ParseAnnotation];
 
-    if (annotation instanceof Annotation) {
+    if (annotation instanceof UnknownAnnotation) {
+      let KnownAnnotation = schema.find(AnnotationClass => {
+        return annotation.attributes.type === `-${AnnotationClass.vendorPrefix}-${AnnotationClass.type}`;
+      });
+
+      if (KnownAnnotation) {
+        return KnownAnnotation.hydrate(annotation.toJSON());
+      }
+      return annotation;
+
+    } else if (annotation instanceof Annotation) {
       let AnnotationClass = annotation.constructor as AnnotationConstructor;
       if (schema.indexOf(AnnotationClass) === -1) {
         let json = annotation.toJSON();

--- a/packages/@atjson/document/test/atjson-test.ts
+++ b/packages/@atjson/document/test/atjson-test.ts
@@ -1,3 +1,4 @@
+import { UnknownAnnotation } from '../src';
 import TestSource, { Bold, CaptionSource, Image, Italic } from './test-source';
 
 describe('new Document', () => {
@@ -17,6 +18,48 @@ describe('new Document', () => {
         attributes: {}
       })]
     })).toBeDefined();
+  });
+
+  test('instantiating with Annotations', () => {
+    let doc = new TestSource({
+      content: 'Hello World.',
+      annotations: [new Bold({
+        start: 0,
+        end: 2
+      })]
+    });
+
+    expect(doc.where(a => a instanceof Bold).length).toBe(1);
+  });
+
+  test('instantiating with UnknownAnnotations', () => {
+    let doc = new TestSource({
+      content: 'Hello World.',
+      annotations: [new UnknownAnnotation({
+        start: 0,
+        end: 2,
+        attributes: {
+          type: '-test-bold',
+          attributes: {}
+        }
+      })]
+    });
+
+    expect(doc.where(a => a instanceof Bold).length).toBe(1);
+  });
+
+  test('instantiating with JSON', () => {
+    let doc = new TestSource({
+      content: 'Hello World.',
+      annotations: [{
+        type: '-test-bold',
+        start: 0,
+        end: 2,
+        attributes: {}
+      }]
+    });
+
+    expect(doc.where(a => a instanceof Bold).length).toBe(1);
   });
 
   test('clone', () => {


### PR DESCRIPTION
I found this bug upstream in our Condé extensions to AtJSON; this should fix bugs that popped up there.