### PR TITLE
🐝 fix slice so it only includes overlapping annotations from the parent document

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17130,23 +17130,11 @@
       "integrity": "sha1-bcJDPnjti+qOiHo6zeLzF4W9Yic=",
       "dev": true
     },
-    "typedoc-plugin-monorepo": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/typedoc-plugin-monorepo/-/typedoc-plugin-monorepo-0.1.0.tgz",
-      "integrity": "sha512-hx42ck+9dJCoZO0jLCmEE3R6lydYaaYIKL+g6LT5Ev+B8CdAESsML2jiGR+TFu1rUuEujjArtCHjNLj2YqnKnQ==",
-      "dev": true,
-      "requires": {
-        "highlight.js": "^9.12.0",
-        "marked": "^0.3.19"
-      },
-      "dependencies": {
-        "marked": {
-          "version": "0.3.19",
-          "resolved": "http://registry.npmjs.org/marked/-/marked-0.3.19.tgz",
-          "integrity": "sha512-ea2eGWOqNxPcXv8dyERdSr/6FmzvWwzjMxpfGB/sbMccXoct+xY+YukPD+QTUZwyvK7BZwcr4m21WBOW41pAkg==",
-          "dev": true
-        }
-      }
+    "typedoc-plugin-lerna-packages": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/typedoc-plugin-lerna-packages/-/typedoc-plugin-lerna-packages-0.1.5.tgz",
+      "integrity": "sha512-tJ3v9hfCC6ET5heU/Yr6k2JMfQYSDU3ZubrfWou4HluD+yC/j4/rgnPsYBhDEVYBti2Ww9ZeQYzGIXsuR1zl7Q==",
+      "dev": true
     },
     "typescript": {
       "version": "3.1.3",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "ts-loader": "^4.0.0",
     "tslint": "^5.11.0",
     "typedoc": "^0.14.2",
-    "typedoc-plugin-monorepo": "^0.1.0",
+    "typedoc-plugin-lerna-packages": "^0.1.5",
     "typescript": "^3.1.1",
     "uuid": "^3.3.2"
   },

--- a/packages/@atjson/document/src/index.ts
+++ b/packages/@atjson/document/src/index.ts
@@ -210,7 +210,16 @@ export default class Document {
    * Slices return part of a document from the parent document.
    */
   slice(start: number, end: number): Document {
-    let doc = this.clone();
+    let DocumentClass = this.constructor as typeof Document;
+    let slicedAnnotations = this.where(a => {
+      return (a.start >= start && a.start < end) ||
+             (a.end > start && a.end <= end);
+    });
+
+    let doc = new DocumentClass({
+      content: this.content,
+      annotations: slicedAnnotations.map(annotation => annotation.clone())
+    });
     doc.deleteText(0, start);
     doc.deleteText(end, doc.content.length);
 

--- a/packages/@atjson/document/src/index.ts
+++ b/packages/@atjson/document/src/index.ts
@@ -212,16 +212,16 @@ export default class Document {
   slice(start: number, end: number): Document {
     let DocumentClass = this.constructor as typeof Document;
     let slicedAnnotations = this.where(a => {
-      return (a.start >= start && a.start < end) ||
-             (a.end > start && a.end <= end);
+      return Math.max(a.start, start) < end &&
+             Math.min(a.end, end) > start;
     });
 
     let doc = new DocumentClass({
       content: this.content,
       annotations: slicedAnnotations.map(annotation => annotation.clone())
     });
-    doc.deleteText(0, start);
     doc.deleteText(end, doc.content.length);
+    doc.deleteText(0, start);
 
     return doc;
   }

--- a/packages/@atjson/document/src/index.ts
+++ b/packages/@atjson/document/src/index.ts
@@ -212,8 +212,7 @@ export default class Document {
   slice(start: number, end: number): Document {
     let DocumentClass = this.constructor as typeof Document;
     let slicedAnnotations = this.where(a => {
-      return Math.max(a.start, start) < end &&
-             Math.min(a.end, end) > start;
+      return a.start <= start && a.end >= start;
     });
 
     let doc = new DocumentClass({

--- a/packages/@atjson/document/test/atjson-test.ts
+++ b/packages/@atjson/document/test/atjson-test.ts
@@ -225,6 +225,35 @@ describe('new Document', () => {
       }]
     });
 
+    test('slice matching boundary', () => {
+      let doc = document.slice(0, 5);
+
+      expect(doc.toJSON()).toEqual({
+        content: 'Hello',
+        contentType: 'application/vnd.atjson+test',
+        schema: ['-test-a', '-test-bold', '-test-code', '-test-image', '-test-instagram', '-test-italic', '-test-locale', '-test-manual', '-test-paragraph', '-test-pre'],
+        annotations: [{
+          id: '1',
+          type: '-test-bold',
+          start: 0,
+          end: 5,
+          attributes: {}
+        }, {
+          id: '2',
+          type: '-test-italic',
+          start: 0,
+          end: 5,
+          attributes: {}
+        }, {
+          id: '3',
+          type: '-test-underline',
+          start: 0,
+          end: 5,
+          attributes: {}
+        }]
+      });
+    });
+
     test('source documents are unaltered', () => {
       let doc = document.slice(7, 12);
 

--- a/packages/@atjson/document/test/atjson-test.ts
+++ b/packages/@atjson/document/test/atjson-test.ts
@@ -226,38 +226,24 @@ describe('new Document', () => {
     });
 
     test('source documents are unaltered', () => {
-      let doc = document.slice(1, 15);
+      let doc = document.slice(7, 14);
 
       expect(doc.toJSON()).toEqual({
-        content: 'ello, world!\n\uFFFC',
+        content: 'world!\n\uFFFC',
         contentType: 'application/vnd.atjson+test',
         schema: ['-test-a', '-test-bold', '-test-code', '-test-image', '-test-instagram', '-test-italic', '-test-locale', '-test-manual', '-test-paragraph', '-test-pre'],
         annotations: [{
-          id: '1',
-          type: '-test-bold',
-          start: 0,
-          end: 4,
-          attributes: {}
-        }, {
           id: '2',
           type: '-test-italic',
           start: 0,
-          end: 12,
+          end: 6,
           attributes: {}
         }, {
           id: '3',
           type: '-test-underline',
           start: 0,
-          end: 12,
+          end: 6,
           attributes: {}
-        }, {
-          id: '4',
-          type: '-test-instagram',
-          start: 13,
-          end: 14,
-          attributes: {
-            '-test-uri': 'https://www.instagram.com/p/BeW0pqZDUuK/'
-          }
         }]
       });
 

--- a/packages/@atjson/document/test/atjson-test.ts
+++ b/packages/@atjson/document/test/atjson-test.ts
@@ -226,23 +226,23 @@ describe('new Document', () => {
     });
 
     test('source documents are unaltered', () => {
-      let doc = document.slice(7, 14);
+      let doc = document.slice(7, 12);
 
       expect(doc.toJSON()).toEqual({
-        content: 'world!\n\uFFFC',
+        content: 'world',
         contentType: 'application/vnd.atjson+test',
         schema: ['-test-a', '-test-bold', '-test-code', '-test-image', '-test-instagram', '-test-italic', '-test-locale', '-test-manual', '-test-paragraph', '-test-pre'],
         annotations: [{
           id: '2',
           type: '-test-italic',
           start: 0,
-          end: 6,
+          end: 5,
           attributes: {}
         }, {
           id: '3',
           type: '-test-underline',
           start: 0,
-          end: 6,
+          end: 5,
           attributes: {}
         }]
       });

--- a/packages/@atjson/offset-core-components/src/mixins/component.ts
+++ b/packages/@atjson/offset-core-components/src/mixins/component.ts
@@ -115,14 +115,14 @@ export default class WebComponent extends HTMLElement {
           return method.call(this, evt);
         }
       };
-      element.addEventListener(eventName, this.eventHandlers[definition]);
+      element!.addEventListener(eventName, this.eventHandlers[definition]);
     });
   }
 
   disconnectedCallback() {
     Object.keys(this.eventHandlers).forEach(definition => {
       let { eventName, element } = getEventNameAndElement(this, definition);
-      element.removeEventListener(eventName, this.eventHandlers[definition]);
+      element!.removeEventListener(eventName, this.eventHandlers[definition]);
     });
     this.eventHandlers = {};
   }

--- a/packages/@atjson/offset-inspector/src/document-inspector/annotations-inspector.ts
+++ b/packages/@atjson/offset-inspector/src/document-inspector/annotations-inspector.ts
@@ -67,7 +67,7 @@ export default class AnnotationsInspector extends WebComponent {
         setTimeout(() => { delete this._updateCallback; }, 0);
       };
       window.requestIdleCallback(this._updateCallback);
-    };
+    });
   }
 }
 

--- a/packages/@atjson/source-url/test/url-test.ts
+++ b/packages/@atjson/source-url/test/url-test.ts
@@ -138,7 +138,7 @@ describe('url-source', () => {
         'https://www.facebook.com/Vogue/videos/vb.42933792278/258591818132754/?type=2&theater',
         'https://www.facebook.com/Vogue/posts/258591818132754'
       ])('%s', text => {
-        let url = URLSource.fromRaw(text);\
+        let url = URLSource.fromRaw(text);
         expect(EmbedRenderer.render(url.convertTo(OffsetSource))).toBe('<div class="fb-post" data-href="https://www.facebook.com/Vogue/posts/258591818132754" data-show-text="true"></div>');
       });
     });

--- a/typedoc.js
+++ b/typedoc.js
@@ -21,6 +21,5 @@ module.exports = {
   "mode": "modules",
   "name": "@atjson",
   "tsconfig": "./tsconfig.json",
-  "external-modulemap": ".*packages\/(@atjson\/[^\/]+)\/.*",
   "readme": "./README.md"
 };


### PR DESCRIPTION
`slice` was previously returning 0 length annotations in the results, which caused issues when rendering out. It makes sense to not include them in the sliced document.