### PR TITLE
Fix TSLint errors and improve type inference

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,34 @@
         "@atjson/renderer-commonmark": "file:packages/@atjson/renderer-commonmark",
         "@atjson/renderer-webcomponent": "file:packages/@atjson/renderer-webcomponent",
         "@types/dom-inputevent": "^1.0.1",
-        "node-sass": "^4.9.0"
+        "node-sass": "^4.11.0"
+      },
+      "dependencies": {
+        "node-sass": {
+          "version": "4.11.0",
+          "bundled": true,
+          "requires": {
+            "async-foreach": "^0.1.3",
+            "chalk": "^1.1.1",
+            "cross-spawn": "^3.0.0",
+            "gaze": "^1.0.0",
+            "get-stdin": "^4.0.1",
+            "glob": "^7.0.3",
+            "in-publish": "^2.0.0",
+            "lodash.assign": "^4.2.0",
+            "lodash.clonedeep": "^4.3.2",
+            "lodash.mergewith": "^4.6.0",
+            "meow": "^3.7.0",
+            "mkdirp": "^0.5.1",
+            "nan": "^2.10.0",
+            "node-gyp": "^3.8.0",
+            "npmlog": "^4.0.0",
+            "request": "^2.88.0",
+            "sass-graph": "^2.2.4",
+            "stdout-stream": "^1.4.0",
+            "true-case-path": "^1.0.2"
+          }
+        }
       }
     },
     "@atjson/hir": {
@@ -46,7 +73,34 @@
       "version": "file:packages/@atjson/offset-core-components",
       "requires": {
         "@atjson/document": "file:packages/@atjson/document",
-        "node-sass": "^4.9.0"
+        "node-sass": "^4.11.0"
+      },
+      "dependencies": {
+        "node-sass": {
+          "version": "4.11.0",
+          "bundled": true,
+          "requires": {
+            "async-foreach": "^0.1.3",
+            "chalk": "^1.1.1",
+            "cross-spawn": "^3.0.0",
+            "gaze": "^1.0.0",
+            "get-stdin": "^4.0.1",
+            "glob": "^7.0.3",
+            "in-publish": "^2.0.0",
+            "lodash.assign": "^4.2.0",
+            "lodash.clonedeep": "^4.3.2",
+            "lodash.mergewith": "^4.6.0",
+            "meow": "^3.7.0",
+            "mkdirp": "^0.5.1",
+            "nan": "^2.10.0",
+            "node-gyp": "^3.8.0",
+            "npmlog": "^4.0.0",
+            "request": "^2.88.0",
+            "sass-graph": "^2.2.4",
+            "stdout-stream": "^1.4.0",
+            "true-case-path": "^1.0.2"
+          }
+        }
       }
     },
     "@atjson/offset-inspector": {
@@ -9526,12 +9580,12 @@
       "dev": true
     },
     "handlebars": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.0.tgz",
-      "integrity": "sha512-l2jRuU1NAWK6AW5qqcTATWQJvNPEwkM7NEKSiv/gqOsoSQbVoWyqVEY5GS+XPQ88zLNmqASRpzfdm8d79hJS+w==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.2.tgz",
+      "integrity": "sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==",
       "dev": true,
       "requires": {
-        "async": "^2.5.0",
+        "neo-async": "^2.6.0",
         "optimist": "^0.6.1",
         "source-map": "^0.6.1",
         "uglify-js": "^3.1.4"
@@ -12810,6 +12864,12 @@
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
+    "neo-async": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.0.tgz",
+      "integrity": "sha512-MFh0d/Wa7vkKO3Y3LlacqAEeHK0mckVqzDieUKTT+KGxi+zIpeVsFxymkIiRpbpDziHc290Xr9A1O4Om7otoRA==",
+      "dev": true
+    },
     "nice-try": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
@@ -12934,32 +12994,6 @@
       "dev": true,
       "requires": {
         "semver": "^5.3.0"
-      }
-    },
-    "node-sass": {
-      "version": "4.9.4",
-      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.9.4.tgz",
-      "integrity": "sha512-MXyurANsUoE4/6KmfMkwGcBzAnJQ5xJBGW7Ei6ea8KnUKuzHr/SguVBIi3uaUAHtZCPUYkvlJ3Ef5T5VAwVpaA==",
-      "requires": {
-        "async-foreach": "^0.1.3",
-        "chalk": "^1.1.1",
-        "cross-spawn": "^3.0.0",
-        "gaze": "^1.0.0",
-        "get-stdin": "^4.0.1",
-        "glob": "^7.0.3",
-        "in-publish": "^2.0.0",
-        "lodash.assign": "^4.2.0",
-        "lodash.clonedeep": "^4.3.2",
-        "lodash.mergewith": "^4.6.0",
-        "meow": "^3.7.0",
-        "mkdirp": "^0.5.1",
-        "nan": "^2.10.0",
-        "node-gyp": "^3.8.0",
-        "npmlog": "^4.0.0",
-        "request": "^2.88.0",
-        "sass-graph": "^2.2.4",
-        "stdout-stream": "^1.4.0",
-        "true-case-path": "^1.0.2"
       }
     },
     "nopt": {
@@ -17536,9 +17570,9 @@
       "dev": true
     },
     "tslint": {
-      "version": "5.11.0",
-      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.11.0.tgz",
-      "integrity": "sha1-mPMMAurjzecAYgHkwzywi0hYHu0=",
+      "version": "5.15.0",
+      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.15.0.tgz",
+      "integrity": "sha512-6bIEujKR21/3nyeoX2uBnE8s+tMXCQXhqMmaIPJpHmXJoBJPTLcI7/VHRtUwMhnLVdwLqqY3zmd8Dxqa5CVdJA==",
       "dev": true,
       "requires": {
         "babel-code-frame": "^6.22.0",
@@ -17547,12 +17581,13 @@
         "commander": "^2.12.1",
         "diff": "^3.2.0",
         "glob": "^7.1.1",
-        "js-yaml": "^3.7.0",
+        "js-yaml": "^3.13.0",
         "minimatch": "^3.0.4",
+        "mkdirp": "^0.5.1",
         "resolve": "^1.3.2",
         "semver": "^5.3.0",
         "tslib": "^1.8.0",
-        "tsutils": "^2.27.2"
+        "tsutils": "^2.29.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -17565,9 +17600,9 @@
           }
         },
         "chalk": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
             "ansi-styles": "^3.2.1",
@@ -17576,12 +17611,12 @@
           }
         },
         "resolve": {
-          "version": "1.8.1",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
-          "integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
+          "version": "1.10.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.0.tgz",
+          "integrity": "sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==",
           "dev": true,
           "requires": {
-            "path-parse": "^1.0.5"
+            "path-parse": "^1.0.6"
           }
         },
         "supports-color": {
@@ -17684,9 +17719,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.1.3.tgz",
-      "integrity": "sha512-+81MUSyX+BaSo+u2RbozuQk/UWx6hfG0a5gHu4ANEM4sU96XbuIyAB+rWBW1u70c6a5QuZfuYICn3s2UjuHUpA==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.4.3.tgz",
+      "integrity": "sha512-FFgHdPt4T/duxx6Ndf7hwgMZZjZpB+U0nMNGVCYPq0rEzWKjEDobm4J6yb3CS7naZ0yURFqdw9Gwc7UOh/P9oQ==",
       "dev": true
     },
     "uc.micro": {
@@ -17695,20 +17730,20 @@
       "integrity": "sha512-JoLI4g5zv5qNyT09f4YAvEZIIV1oOjqnewYg5D38dkQljIzpPT296dbIGvKro3digYI1bkb7W6EP1y4uDlmzLg=="
     },
     "uglify-js": {
-      "version": "3.4.10",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.10.tgz",
-      "integrity": "sha512-Y2VsbPVs0FIshJztycsO2SfPk7/KAF/T72qzv9u5EpQ4kB2hQoHlhNQTsNyy6ul7lQtqJN/AoWeS23OzEiEFxw==",
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.5.4.tgz",
+      "integrity": "sha512-GpKo28q/7Bm5BcX9vOu4S46FwisbPbAmkkqPnGIpKvKTM96I85N6XHQV+k4I6FA2wxgLhcsSyHoNhzucwCflvA==",
       "dev": true,
       "optional": true,
       "requires": {
-        "commander": "~2.19.0",
+        "commander": "~2.20.0",
         "source-map": "~0.6.1"
       },
       "dependencies": {
         "commander": {
-          "version": "2.19.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
-          "integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==",
+          "version": "2.20.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
+          "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
           "dev": true,
           "optional": true
         },

--- a/package.json
+++ b/package.json
@@ -20,10 +20,10 @@
     "shelljs": "^0.8.2",
     "ts-jest": "^24.0.2",
     "ts-loader": "^4.0.0",
-    "tslint": "^5.11.0",
+    "tslint": "^5.15.0",
     "typedoc": "^0.14.2",
     "typedoc-plugin-lerna-packages": "^0.1.5",
-    "typescript": "^3.1.1",
+    "typescript": "^3.4.3",
     "uuid": "^3.3.2"
   },
   "dependencies": {
@@ -50,6 +50,7 @@
   "scripts": {
     "build": "lerna run build",
     "docs": "typedoc",
+    "lint": "lerna run lint",
     "publish": "lerna publish",
     "test": "./node_modules/jest/bin/jest.js"
   },

--- a/packages/@atjson/editor/package.json
+++ b/packages/@atjson/editor/package.json
@@ -26,6 +26,6 @@
     "@atjson/renderer-commonmark": "file:../renderer-commonmark",
     "@atjson/renderer-webcomponent": "file:../renderer-webcomponent",
     "@types/dom-inputevent": "^1.0.1",
-    "node-sass": "^4.9.0"
+    "node-sass": "^4.11.0"
   }
 }

--- a/packages/@atjson/offset-core-components/package.json
+++ b/packages/@atjson/offset-core-components/package.json
@@ -20,6 +20,6 @@
   ],
   "dependencies": {
     "@atjson/document": "file:../document",
-    "node-sass": "^4.9.0"
+    "node-sass": "^4.11.0"
   }
 }

--- a/packages/@atjson/renderer-commonmark/src/index.ts
+++ b/packages/@atjson/renderer-commonmark/src/index.ts
@@ -2,11 +2,11 @@ import Document, { Annotation, ParseAnnotation, UnknownAnnotation } from '@atjso
 import { Bold, Code, HTML, Heading, Image, Italic, Link, List } from '@atjson/offset-annotations';
 import Renderer, { Context } from '@atjson/renderer-hir';
 import {
-  BEGINNING_WHITESPACE_PUNCTUATION,
-  ENDING_WHITESPACE_PUNCTUATION,
-  WHITESPACE_PUNCTUATION,
   BEGINNING_WHITESPACE,
-  ENDING_WHITESPACE
+  BEGINNING_WHITESPACE_PUNCTUATION,
+  ENDING_WHITESPACE,
+  ENDING_WHITESPACE_PUNCTUATION,
+  WHITESPACE_PUNCTUATION
 } from './lib/punctuation';
 export * from './lib/punctuation';
 

--- a/packages/@atjson/renderer-commonmark/src/index.ts
+++ b/packages/@atjson/renderer-commonmark/src/index.ts
@@ -180,8 +180,8 @@ export default class CommonmarkRenderer extends Renderer {
 
   state: any;
 
-  constructor() {
-    super();
+  constructor(document: Document) {
+    super(document);
     this.state = {};
   }
 

--- a/packages/@atjson/renderer-commonmark/src/lib/punctuation.ts
+++ b/packages/@atjson/renderer-commonmark/src/lib/punctuation.ts
@@ -9,7 +9,7 @@
  * ES9 provides out-of-the-box support for these unicode categories
  * via Unicode Property Escapes: https://github.com/tc39/proposal-regexp-unicode-property-escapes
  * and once that is more widely supported this file can be removed.
- *  */
+ */
 
 export const ASCII_PUNCTUATION = /[!-\/:-@\[-`{-~]/;
 

--- a/packages/@atjson/renderer-hir/src/index.ts
+++ b/packages/@atjson/renderer-hir/src/index.ts
@@ -118,12 +118,15 @@ function compile(renderer: Renderer, node: HIRNode, context: Partial<Context>): 
 
 export default class Renderer {
 
-  static render(document: Document, ...args: any[]) {
-    // @ts-ignore
-    let renderer = new this(...args);
+  static render<T extends typeof Renderer>(this: T, ...params: ConstructorParameters<T>) {
+    let document = params[0];
+    let renderer = new this(document, ...params.slice(1));
 
     return compile(renderer, new HIR(document).rootNode, { document });
   }
+
+  // tslint:disable-next-line:no-empty
+  constructor(_document: Document, ..._args: any[]) {}
 
   *renderAnnotation(annotation: Annotation, context: Context): IterableIterator<any> {
     let generator = (this as any)[annotation.type] || (this as any)[classify(annotation.type)];

--- a/packages/@atjson/renderer-react/src/index.ts
+++ b/packages/@atjson/renderer-react/src/index.ts
@@ -2,22 +2,19 @@ import Document, { Annotation } from '@atjson/document';
 import Renderer, { classify } from '@atjson/renderer-hir';
 import * as React from 'react';
 
-export interface ComponentLookup {
-  [key: string]: React.StatelessComponent<any> | React.ComponentClass<any>;
-}
-
-// @ts-ignore
 export default class ReactRenderer extends Renderer {
 
-  static render(document: Document, components: ComponentLookup) {
-    // @ts-ignore
-    return super.render(document, components);
-  }
+  private componentLookup: {
+    [key: string]: React.StatelessComponent<any> | React.ComponentClass<any>;
+  };
 
-  private componentLookup: ComponentLookup;
-
-  constructor(componentLookup: ComponentLookup) {
-    super();
+  constructor(
+    document: Document,
+    componentLookup: {
+      [key: string]: React.StatelessComponent<any> | React.ComponentClass<any>;
+    }
+  ) {
+    super(document);
     this.componentLookup = componentLookup;
   }
 

--- a/packages/@atjson/source-gdocs-paste/src/converter.ts
+++ b/packages/@atjson/source-gdocs-paste/src/converter.ts
@@ -1,7 +1,7 @@
 import { Annotation, BlockAnnotation, ParseAnnotation } from '@atjson/document';
 import OffsetSource, { LineBreak, Paragraph } from '@atjson/offset-annotations';
-import GDocsSource from './source';
 import { Heading } from './annotations';
+import GDocsSource from './source';
 
 GDocsSource.defineConverterTo(OffsetSource, doc => {
   // Remove all underlines that align with links, since

--- a/packages/@atjson/source-mobiledoc/src/parser.ts
+++ b/packages/@atjson/source-mobiledoc/src/parser.ts
@@ -32,18 +32,18 @@ function prefix(attributes: any): any {
 export default class Parser {
   content: string;
   annotations: AnnotationJSON[];
-  Mobiledoc: Mobiledoc;
+  mobiledoc: Mobiledoc;
 
   private inProgressAnnotations: Array<Partial<AnnotationJSON>>;
 
-  constructor(Mobiledoc: Mobiledoc) {
+  constructor(mobiledoc: Mobiledoc) {
     this.annotations = [];
     this.inProgressAnnotations = [];
-    this.Mobiledoc = Mobiledoc;
+    this.mobiledoc = mobiledoc;
     let content = '';
     let start = 0;
 
-    Mobiledoc.sections.forEach(section => {
+    mobiledoc.sections.forEach(section => {
       let identifier = section[0];
       let partial = '';
       if (identifier === 1) {
@@ -63,7 +63,7 @@ export default class Parser {
 
   processCard(section: CardSection, start: number) {
     let [, cardIndex] = section;
-    let card = this.Mobiledoc.cards[cardIndex];
+    let card = this.mobiledoc.cards[cardIndex];
     this.annotations.push({
       type: `-mobiledoc-${card[0]}-card`,
       start,
@@ -96,7 +96,7 @@ export default class Parser {
       if (identifier === 0) {
         partial = this.processMarkup(tags, closed, textOrAtomIndex as string, offset);
       } else if (identifier === 1) {
-        partial = this.processAtom(this.Mobiledoc.atoms[textOrAtomIndex as number], offset);
+        partial = this.processAtom(this.mobiledoc.atoms[textOrAtomIndex as number], offset);
       }
       sectionText += partial;
       offset += partial.length;
@@ -126,7 +126,7 @@ export default class Parser {
         if (identifier === 0) {
           partial = this.processMarkup(tags, closed, textOrAtomIndex as string, offset);
         } else if (identifier === 1) {
-          partial = this.processAtom(this.Mobiledoc.atoms[textOrAtomIndex as number], offset);
+          partial = this.processAtom(this.mobiledoc.atoms[textOrAtomIndex as number], offset);
         }
         item += partial;
         offset += partial.length;
@@ -155,7 +155,7 @@ export default class Parser {
     let end = start + text.length;
 
     while (markupIndexes.length) {
-      let markup = this.Mobiledoc.markups[markupIndexes.shift()!];
+      let markup = this.mobiledoc.markups[markupIndexes.shift()!];
       let attributes: any = {};
       if (markup[1]) {
         let attributeList = markup[1];

--- a/packages/@atjson/source-prism/src/source.ts
+++ b/packages/@atjson/source-prism/src/source.ts
@@ -1,4 +1,4 @@
-import Document, { Annotation, AnnotationJSON, ParseAnnotation, AdjacentBoundaryBehaviour } from '@atjson/document';
+import Document, { AdjacentBoundaryBehaviour, Annotation, AnnotationJSON, ParseAnnotation } from '@atjson/document';
 import HTMLSource from '@atjson/source-html';
 import * as entities from 'entities';
 import * as sax from 'sax';
@@ -82,7 +82,7 @@ export default class PRISMSource extends Document {
 
     let partialAnnotations: Array<Partial<AnnotationJSON>> = [];
 
-    parser.onopentag = (node) => {
+    parser.onopentag = node => {
       let vendorPrefix = getVendorPrefix(node.name);
       let type = getType(node.name);
       if (node.isSelfClosing) {
@@ -114,7 +114,7 @@ export default class PRISMSource extends Document {
       }
     };
 
-    parser.onclosetag = (tagName) => {
+    parser.onclosetag = tagName => {
       let annotation = partialAnnotations.pop()!;
 
       // The annotation was short closed and got a duplicate close tag action
@@ -149,7 +149,7 @@ export default class PRISMSource extends Document {
       .forEach(({ start, end, matches }) => {
         let entity = entities.decodeXML(matches[0]);
         prism.insertText(start, entity, AdjacentBoundaryBehaviour.preserve);
-        prism.deleteText(start + entity.length, end + entity.length)
+        prism.deleteText(start + entity.length, end + entity.length);
       });
 
     return prism;

--- a/packages/@atjson/source-url/src/converter.ts
+++ b/packages/@atjson/source-url/src/converter.ts
@@ -47,7 +47,7 @@ URLSource.defineConverterTo(OffsetSource, doc => {
       /.*\.twitter\.com$/.test(url.attributes.host)
     ) && /\/[^\/]+\/status\/[^\/]+/.test(url.attributes.pathname);
   }).update((url: URLAnnotation) => {
-    let [username,, tweetId] = without<string>(url.attributes.pathname.split('/'), '');
+    let [username, , tweetId] = without<string>(url.attributes.pathname.split('/'), '');
     doc.replaceAnnotation(url, new TwitterEmbed({
       id: url.id,
       start: url.start,


### PR DESCRIPTION
This PR does a few things:

- 📦 Updates packages for TSLint / TypeScript
- 💆‍♂️ Fixes errors reported by TSLint
- 💻 Makes type inference better with `Renderer.render` to infer the params from the renderer constructor.