### PR TITLE
feat: add sandbox to iframe-embed attributes

### DIFF
--- a/packages/@atjson/offset-annotations/src/annotations/iframe-embed.ts
+++ b/packages/@atjson/offset-annotations/src/annotations/iframe-embed.ts
@@ -21,6 +21,7 @@ export default class IframeEmbed extends ObjectAnnotation {
     width?: string;
     height?: string;
     caption?: CaptionSource;
+    sandbox?: string;
   };
 
   get url() {


### PR DESCRIPTION
This adds the `sandbox` property to the `iframe-embed`. This attribute is intended to map directly to the optional `Iframe` [sandbox attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#attr-sandbox).

-----

🗒 I read the [CONTRIBUTING](https://github.com/CondeNast-Copilot/atjson/blob/latest/CONTRIBUTING.md) docs and have done my best to follow along. I couldn't figure out the whole conventional commit _emoji_, so I tried to at least follow the typical pattern. I can amend the message as desired.

This attribute does not appear to have corresponding tests and I'm not sure how to best contribute in that regard.